### PR TITLE
ModelDefinition (<model>) did not define the name

### DIFF
--- a/smdx/smdx.xsd
+++ b/smdx/smdx.xsd
@@ -35,6 +35,7 @@ This document may be used, copied, and furnished to others, without restrictions
     </xs:sequence>
     <xs:attribute name="id" type="xs:integer" />
     <xs:attribute name="len" type="xs:integer" />
+    <xs:attribute name="name" type="xs:string" />
   </xs:complexType>
 
   <xs:complexType name="BlockDefinition">

--- a/smdx/smdx_00002.xml
+++ b/smdx/smdx_00002.xml
@@ -11,7 +11,7 @@
         <symbol id="FULL">3</symbol>
         <symbol id="FAULT">4</symbol>
       </point>
-      <point id="StVnd" offset="4" type="enum16" />
+      <point id="StVnd" offset="4" type="enum16" /> <!-- this is an enum? It has no symbols -->
       <point id="Evt" offset="5" type="bitfield32" mandatory="true" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="INPUT_OVER_VOLTAGE">1</symbol>

--- a/smdx/smdx_00004.xml
+++ b/smdx/smdx_00004.xml
@@ -3,7 +3,7 @@
   <model id="4" len="61">
     <block len="60">
       <point id="RqSeq" offset="0" type="uint16" access="r" mandatory="true"/>
-      <point id="Sts" offset="1" type="uint16" access="r" mandatory="true">
+      <point id="Sts" offset="1" type="enum16" access="r" mandatory="true"> <!-- or bitfld16 -->
         <symbol id="SUCCESS">0</symbol>
         <symbol id="DS">1</symbol>
         <symbol id="ACL">2</symbol>

--- a/smdx/smdx_00016.xml
+++ b/smdx/smdx_00016.xml
@@ -22,7 +22,7 @@
         <symbol id="FULL_DUPLEX">1</symbol>
         <symbol id="FORCE_10MB">2</symbol>
         <symbol id="FORCE_100MB">3</symbol>
-        <symbol id="FORCE_1GB">3</symbol>
+        <symbol id="FORCE_1GB">4</symbol>
       </point>
       <point id="Pad" offset="51" type="pad" />
     </block>

--- a/smdx/smdx_00601.xml
+++ b/smdx/smdx_00601.xml
@@ -33,7 +33,7 @@
     <block len="22" type="repeating" name="tracker">
       <point id="Id" offset="0" type="string" len="8"  mandatory="false" />
       <point id="ElTrgt" offset="8" type="int32" units="Degrees" sf="Dgr_SF" mandatory="false" />
-      <point id="AzTrgt" offset="10" type="int32" units="Degrees" sf="SF" mandatory="false" />
+      <point id="AzTrgt" offset="10" type="int32" units="Degrees" sf="Dgr_SF" mandatory="false" />
       <point id="ElPos" offset="12" type="int32" units="Degrees" sf="Dgr_SF" mandatory="false" />
       <point id="AzPos" offset="14" type="int32" units="Degrees" sf="Dgr_SF" mandatory="false" />
       <point id="ElCtl" offset="16" type="int32" units="Degrees" sf="Dgr_SF" access="rw" mandatory="false" />


### PR DESCRIPTION
The ModelDefinition was lacking a name attribute that was used in all specifications I checked. Since this is the only place where the name is defined as far as I could see I decided to propose this correction

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/sunspec/models/3)
<!-- Reviewable:end -->
