### PR TITLE
Now all xml validates with xmllint

### DIFF
--- a/smdx/smdx.xsd
+++ b/smdx/smdx.xsd
@@ -35,6 +35,8 @@ This document may be used, copied, and furnished to others, without restrictions
     </xs:sequence>
     <xs:attribute name="id" type="xs:integer" />
     <xs:attribute name="len" type="xs:integer" />
+    <xs:attribute name="name" type="xs:string" />
+    <xs:attribute name="status" type="xs:string" />
   </xs:complexType>
 
   <xs:complexType name="BlockDefinition">
@@ -43,6 +45,7 @@ This document may be used, copied, and furnished to others, without restrictions
     </xs:sequence>
     <xs:attribute name="len" type="xs:integer" />
     <xs:attribute name="type" type="BlockTypeDefinition" default="fixed" />
+    <xs:attribute name="name" type="xs:string" />
   </xs:complexType>
 
   <xs:complexType name="PointDefinition">

--- a/smdx/smdx_00004.xml
+++ b/smdx/smdx_00004.xml
@@ -91,12 +91,12 @@
       <symbol id="NONE">
         <label>NONE</label>
         <description>No Alarms</description>
-        <note></note>
+        <notes></notes>
       </symbol>
       <symbol id="ALM">
         <label>ALARM</label>
         <description>Security Alarm</description>
-        <note>Tampered</note>
+        <notes>Tampered</notes>
       </symbol>
     </point>
     <point id="Ts">
@@ -129,7 +129,7 @@
         <notes></notes>
       </symbol>
     </point>
-    <point id="Sts" offset="0" type="enum16" access="w" mandatory="true">
+    <point id="Sts">
       <label>Status</label>
       <description>Status of last read operation</description>
       <notes></notes>

--- a/smdx/smdx_00005.xml
+++ b/smdx/smdx_00005.xml
@@ -95,7 +95,7 @@
       <point id="N" offset="87" type="uint16" access="rw" mandatory="true" />
     </block>
     <block type="repeating" len="1">
-      <point id="DS" offset="0" type="uint16" access="rw" andatory="true" />
+      <point id="DS" offset="0" type="uint16" access="rw" mandatory="true" />
     </block>
   </model>
   <strings id="5" locale="en">

--- a/smdx/smdx_00006.xml
+++ b/smdx/smdx_00006.xml
@@ -97,7 +97,7 @@
       <point id="N" offset="89" type="uint16" access="rw" mandatory="true" />
     </block>
     <block type="repeating" len="1">
-      <point id="DS" offset="0" type="uint16" access="rw" andatory="true" />
+      <point id="DS" offset="0" type="uint16" access="rw" mandatory="true" />
     </block>
   </model>
   <strings id="6" locale="en">

--- a/smdx/smdx_00007.xml
+++ b/smdx/smdx_00007.xml
@@ -26,7 +26,7 @@
       <point id="N" offset="9" type="uint16" access="rw" mandatory="true" />
     </block>
     <block type="repeating" len="1">
-      <point id="DS" offset="0" type="uint16" access="rw" andatory="true" />
+      <point id="DS" offset="0" type="uint16" access="rw" mandatory="true" />
     </block>
   </model>
   <strings id="7" locale="en">
@@ -55,7 +55,7 @@
         <notes></notes>
       </symbol>
     </point>
-    <point id="Sts" offset="0" type="enum16" access="w" mandatory="true">
+    <point id="Sts">
       <label>Status</label>
       <description>Status of last write operation</description>
       <notes></notes>
@@ -122,12 +122,12 @@
       <symbol id="NONE">
         <label>NONE</label>
         <description>No Alarms</description>
-        <note></note>
+        <notes></notes>
       </symbol>
       <symbol id="ALM">
         <label>ALARM</label>
         <description>Security Alarm</description>
-        <note>Tampered</note>
+        <notes>Tampered</notes>
       </symbol>
     </point>
     <point id="N">

--- a/smdx/smdx_00160.xml
+++ b/smdx/smdx_00160.xml
@@ -38,7 +38,7 @@
     <block type="repeating" len="20" name="module">
       <point id="ID" offset="0" type="uint16" />
       <point id="IDStr" offset="1" type="string" len="8" />
-      <point id="DCA" offset="9" type="uint16" sf="DCA_SF" units="A"/>
+      <point id="DCA" offset="9" type="int16" sf="DCA_SF" units="A"/>
       <point id="DCV" offset="10" type="uint16" sf="DCV_SF" units="V"/>
       <point id="DCW" offset="11" type="uint16" sf="DCW_SF" units="W"/>
       <point id="DCWH" offset="12" type="acc32" sf="DCWH_SF" units="Wh"/>

--- a/smdx/smdx_00601.xml
+++ b/smdx/smdx_00601.xml
@@ -82,14 +82,14 @@
       <symbol id="ObsEl"><label>ObsEl</label><description>Tracker ELEVATION motor is obstructed</description></symbol>
       <symbol id="ObsAz"><label>ObsAz</label><description>Tracker AZIMUTH motor is obstructed</description></symbol>
     </point>
-    <point id="GlblAlm"><label>Alarm</label><description>Global tracker alarm conditions</description><note>Combined tracker alarm conditions.  See individual trackers for alarms</note>
+    <point id="GlblAlm"><label>Alarm</label><description>Global tracker alarm conditions</description><notes>Combined tracker alarm conditions.  See individual trackers for alarms</notes>
       <symbol id="SetPoint"><label>SetPoint</label><description>One or more trackers are NOT at SetPoint</description></symbol>
       <symbol id="ObsEl"><label>ObsEl</label><description>One or more trackers ELEVATION motor is obstructed</description></symbol>
       <symbol id="ObsAz"><label>ObsAz</label><description>One or more trackers AZIMUTH motor is obstructed</description></symbol>
     </point>
     <point id="GlblElCtl"><label>Manual Elevation</label><description>Global manual override target position of elevation in degreees from horizontal.  Unimplemented for single axis azimuth tracker type</description></point>
     <point id="GlblAzCtl"><label>Manual Azimuth</label><description>Global manual override target position of azimuth in degrees from true north towards east.  Unimplemented for single axis azimuth tracker type</description></point>
-    <point id="GlblCtl"><label>Mode</label><description>Global Control register operates on all trackers. Normal operation is automatic.  Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete.</description><note>The global controls all trackers</note>
+    <point id="GlblCtl"><label>Mode</label><description>Global Control register operates on all trackers. Normal operation is automatic.  Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete.</description><notes>The global controls all trackers</notes>
       <symbol id="Automatic"><label>Auto</label><description>Follow programmed path</description></symbol>
       <symbol id="Manual"><label>Manual</label><description>Go to a fixed position</description></symbol>
       <symbol id="Calibrate"><label>Calibrate</label><description>Execute test mode</description></symbol>


### PR DESCRIPTION
FIX: added missing block name & status into XSD
FIX: typos fixed in models 4, 5, 6, 7, 601 (andatory, note ->notes)
FIX: removed point attributes, which are missing in XSD
FIX: model 160, current can be also negative if e.g. Fronius uses MPPT for a battery