### PR TITLE
Fixes for model 303 has a length that doesn't follow convention

### DIFF
--- a/smdx/smdx_00303.xml
+++ b/smdx/smdx_00303.xml
@@ -1,7 +1,7 @@
 <sunSpecModels v="1">
 
   <!-- 303: Back of Module Temperature Model -->
-  <model id="303" len="2" name="bom_temp">
+  <model id="303" len="1" name="bom_temp">
     <block type="repeating" len="1" name="temp">
       <point id="TmpBOM" offset="0" type="int16" units="C" sf="-1"  mandatory="true"/>
     </block>

--- a/smdx/smdx_00402.xml
+++ b/smdx/smdx_00402.xml
@@ -1,6 +1,6 @@
 <sunSpecModels v="1">
   <!-- 402: (SUPERSEDED by 404) String Combiner (Advanced) -->
-  <model id="402" len="33" name="string_combiner">
+  <model id="402" len="34" name="string_combiner">
     <block len="20">
       <point id="DCA_SF" offset="0" type="sunssf" mandatory="true" />
       <point id="DCAhr_SF" offset="1" type="sunssf" />

--- a/smdx/smdx_00807.xml
+++ b/smdx/smdx_00807.xml
@@ -1,7 +1,7 @@
 <sunSpecModels v="1">
 
   <!-- 807: Flow Battery String Model -->
-  <model id="807" len="36" name="flow_battery_string">
+  <model id="807" len="58" name="flow_battery_string">
     <block len="34">
       <point id="Idx" offset="0" type="uint16" mandatory="true" />
       <point id="NMod" offset="1" type="uint16" mandatory="true" />

--- a/smdx/smdx_63002.xml
+++ b/smdx/smdx_63002.xml
@@ -1,6 +1,6 @@
 <sunSpecModels v="1">
   <!-- 1: common -->
-  <model id="63002" len="8">
+  <model id="63002" len="4">
     <block type="repeating" len="4">
       <point id="sunssf_1"      offset="0"    type="sunssf" />
       <point id="int16_1"       offset="1"    type="int16"   sf="sunssf_1"  access="rw"/>


### PR DESCRIPTION
model 303 has a length that doesn't follow convention

Issue: https://github.com/sunspec/models/issues/14

Updated length values for models 303, 402, 807, 63002.  Those model's length did not follow convention.  Other models listed in the issue had been already been updated. 