### PR TITLE
Fixes model issues for models 705-713

### DIFF
--- a/json/model_705.json
+++ b/json/model_705.json
@@ -4,7 +4,7 @@
         "groups": [
             {
                 "comments": [
-                    "Stored Curve Sets - Number of curve sets contained in NCrv"
+                    "Stored Curve Sets - Number of curve sets contained in NCrv - The first set is read-only and indicates the current settings."
                 ],
                 "count": "NCrv",
                 "desc": "Stored curve sets.",
@@ -205,7 +205,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Is Volt-Var control active.",
+                "desc": "Volt-Var control enable.",
                 "label": "Module Enable",
                 "mandatory": "M",
                 "name": "Ena",
@@ -235,13 +235,13 @@
                 "symbols": [
                     {
                         "desc": "No curve is currenly active.",
-                        "label": "No active curve",
+                        "label": "No Active Curve",
                         "name": "INACTIVE",
                         "value": 0
                     },
                     {
                         "desc": "Active curve in effect.",
-                        "label": "Active curve enabled",
+                        "label": "Active Curve Enabled",
                         "name": "ACTIVE",
                         "value": 1
                     }
@@ -250,16 +250,16 @@
             },
             {
                 "access": "RW",
-                "desc": "Set active curve. 0 = No active curve",
-                "label": "Set active curve request",
+                "desc": "Index of  curve points to adopt. First curve index is 1.",
+                "label": "Adopt Curve Request",
                 "mandatory": "M",
                 "name": "AdptCrvReq",
                 "type": "uint16"
             },
             {
                 "access": "R",
-                "desc": "Result of last set active curve operation.",
-                "label": "Set active curve result",
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
                 "mandatory": "M",
                 "name": "AdptCrvRslt",
                 "symbols": [
@@ -305,16 +305,16 @@
             },
             {
                 "access": "RW",
-                "desc": "Reversion time in seconds.  0 = No reversion time",
-                "label": "Reversion timeout",
+                "desc": "Reversion time in seconds.  0 = No reversion time.",
+                "label": "Reversion Timeout",
                 "mandatory": "O",
                 "name": "RvrtTms",
                 "type": "uint32"
             },
             {
                 "access": "R",
-                "desc": "Reversion time remaining in seconds",
-                "label": "Reversion time left",
+                "desc": "Reversion time remaining in seconds.",
+                "label": "Reversion Time Remaining",
                 "mandatory": "O",
                 "name": "RvrtRem",
                 "type": "uint32"
@@ -322,7 +322,7 @@
             {
                 "access": "RW",
                 "desc": "Default curve after reversion timeout.",
-                "label": "Reversion curve",
+                "label": "Reversion Curve",
                 "mandatory": "O",
                 "name": "RvrtCrv",
                 "type": "uint16"

--- a/json/model_706.json
+++ b/json/model_706.json
@@ -1,16 +1,13 @@
 {
     "group": {
-        "comments": [],
         "desc": "DER Volt-Watt model.",
-        "detail": null,
         "groups": [
             {
                 "comments": [
-                    "Stored curve sets - Number of curve sets contained in NCrv"
+                    "Stored curve sets - Number of curve sets contained in NCrv - The first set is read-only and indicates the current settings."
                 ],
                 "count": "NCrv",
                 "desc": "Stored curve sets.",
-                "detail": null,
                 "groups": [
                     {
                         "comments": [
@@ -18,301 +15,268 @@
                         ],
                         "count": "NPt",
                         "desc": "Stored curve points.",
-                        "detail": null,
-                        "groups": [],
-                        "id": "Pt",
                         "label": "Stored Curve Points",
+                        "name": "Pt",
                         "points": [
                             {
-                                "access": "rw",
-                                "comments": [],
+                                "access": "RW",
                                 "desc": "Curve voltage point as percentage.",
-                                "detail": null,
-                                "id": "V",
                                 "label": "Voltage Point",
-                                "mandatory": "true",
+                                "mandatory": "M",
+                                "name": "V",
                                 "sf": "V_SF",
-                                "symbols": [],
                                 "type": "uint16",
                                 "units": "VRefPct"
                             },
                             {
-                                "access": "rw",
-                                "comments": [],
+                                "access": "RW",
                                 "desc": "Curve time point in seconds.",
-                                "detail": null,
-                                "id": "W",
                                 "label": "Dependent Reference",
-                                "mandatory": "true",
+                                "mandatory": "M",
+                                "name": "W",
                                 "sf": "DeptRef_SF",
-                                "symbols": [],
                                 "type": "int16",
                                 "units": "DeptRef"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     }
                 ],
-                "id": "Crv",
                 "label": "Stored Curves",
+                "name": "Crv",
                 "points": [
                     {
-                        "access": "rw",
-                        "comments": [],
+                        "access": "RW",
                         "desc": "Number of active points.",
-                        "detail": null,
-                        "id": "ActPt",
                         "label": "Active Points",
-                        "mandatory": "true",
-                        "sf": null,
-                        "symbols": [],
-                        "type": "uint16",
-                        "units": null
+                        "mandatory": "M",
+                        "name": "ActPt",
+                        "type": "uint16"
                     },
                     {
-                        "access": "rw",
-                        "comments": [],
+                        "access": "RW",
                         "desc": "Curve dependent reference.",
-                        "detail": null,
-                        "id": "DeptRef",
                         "label": "Dependent Reference",
-                        "mandatory": "true",
-                        "sf": null,
+                        "mandatory": "M",
+                        "name": "DeptRef",
                         "symbols": [
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "W_MAX_PCT",
-                                "label": null,
+                                "name": "W_MAX_PCT",
                                 "value": 1
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "W_AVAL_PCT",
-                                "label": null,
+                                "name": "W_AVAL_PCT",
                                 "value": 2
                             }
                         ],
-                        "type": "enum16",
-                        "units": null
+                        "type": "enum16"
                     },
                     {
-                        "access": "rw",
-                        "comments": [],
+                        "access": "RW",
                         "desc": "Open loop response time.",
-                        "detail": null,
-                        "id": "RspTms",
                         "label": "Open Loop Response Time",
-                        "mandatory": "false",
-                        "sf": null,
-                        "symbols": [],
-                        "type": "uint16",
-                        "units": null
+                        "mandatory": "O",
+                        "name": "RspTms",
+                        "type": "uint16"
                     },
                     {
-                        "access": "rw",
-                        "comments": [],
+                        "access": "RW",
                         "desc": "Curve read-write access.",
-                        "detail": null,
-                        "id": "ReadOnly",
                         "label": "Curve Access",
-                        "mandatory": "false",
-                        "sf": null,
+                        "mandatory": "O",
+                        "name": "ReadOnly",
                         "symbols": [
                             {
-                                "comments": [],
                                 "desc": "Curve has read-write access.",
-                                "detail": null,
-                                "id": "RW",
                                 "label": "Read-Write Access",
+                                "name": "RW",
                                 "value": 0
                             },
                             {
-                                "comments": [],
                                 "desc": "Curve has read-only access.",
-                                "detail": null,
-                                "id": "R",
                                 "label": "Read-Only Access",
+                                "name": "R",
                                 "value": 1
                             }
                         ],
-                        "type": "enum16",
-                        "units": null
+                        "type": "enum16"
                     }
-                ]
+                ],
+                "type": "group"
             }
         ],
-        "id": "DERVoltWatt",
         "label": "DERVolt-Watt",
+        "name": "DERVoltWatt",
         "points": [
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER Volt-Watt model id.",
-                "detail": null,
-                "id": "ID",
                 "label": "Model ID",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
+                "mandatory": "M",
+                "name": "ID",
+                "static": "S",
                 "type": "uint16",
-                "units": null,
                 "value": 706
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER Volt-Watt model length.",
-                "detail": null,
-                "id": "L",
                 "label": "Model Length",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "L",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "Is Volt-Watt control active.",
+                "access": "RW",
+                "desc": "Volt-Watt control enable.",
                 "detail": " ",
-                "id": "Ena",
                 "label": "Module Enable",
-                "mandatory": "true",
-                "sf": null,
+                "mandatory": "M",
+                "name": "Ena",
                 "symbols": [
                     {
-                        "comments": [],
-                        "desc": "Enabled flag (Disabled = 0, Enabled = 1).",
-                        "detail": null,
-                        "id": "ENABLED",
-                        "label": "Enabled Flag",
-                        "value": 0
-                    }
-                ],
-                "type": "bitfield16",
-                "units": null
-            },
-            {
-                "access": "rw",
-                "comments": [],
-                "desc": "Index of  curve points to adopt. First curve index is 1.",
-                "detail": " ",
-                "id": "AdoptCrv",
-                "label": "Adopt Curve",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
-            },
-            {
-                "access": "r",
-                "comments": [],
-                "desc": "Result of last adopt curve operation.",
-                "detail": null,
-                "id": "AdoptCrvRslt",
-                "label": "Adopt Curve Result",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [
-                    {
-                        "comments": [],
-                        "desc": "Curve update in progress.",
-                        "detail": null,
-                        "id": "IN_PROGRESS",
-                        "label": "Update In Progress",
+                        "desc": "Function is enabled.",
+                        "detail": "Function is enabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
                         "value": 0
                     },
                     {
-                        "comments": [],
+                        "desc": "Function is disabled.",
+                        "detail": "Function is disabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "R",
+                "desc": "Current active  curve state.",
+                "label": "Active Curve State",
+                "mandatory": "M",
+                "name": "CrvSt",
+                "symbols": [
+                    {
+                        "desc": "No curve is currenly active.",
+                        "label": "No Active Curve",
+                        "name": "INACTIVE",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Active curve in effect.",
+                        "label": "Active Curve Enabled",
+                        "name": "ACTIVE",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Index of  curve points to adopt. First curve index is 1.",
+                "detail": " ",
+                "label": "Adopt Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "type": "uint16"
+            },
+            {
+                "access": "R",
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
                         "desc": "Curve update completed successfully.",
-                        "detail": null,
-                        "id": "COMPLETED",
                         "label": "Update Complete",
+                        "name": "COMPLETED",
                         "value": 1
                     },
                     {
-                        "comments": [],
                         "desc": "Curve update failed.",
-                        "detail": null,
-                        "id": "FAILED",
                         "label": "Update Failed",
+                        "name": "FAILED",
                         "value": 2
                     }
                 ],
-                "type": "enum16",
-                "units": null
+                "type": "enum16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of curve points supported.",
                 "detail": " ",
-                "id": "NPt",
                 "label": "Number of Points",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NPt",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of stored curves supported.",
-                "detail": null,
-                "id": "NCrv",
                 "label": "Stored Curve Count",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NCrv",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
-                "desc": "Pad field for alignment.",
-                "detail": null,
-                "id": "Pad",
-                "label": "Allignment Pad",
-                "mandatory": "false",
-                "sf": null,
-                "symbols": [],
-                "type": "pad",
-                "units": null
+                "access": "RW",
+                "desc": "Reversion time in seconds.  0 = No reversion time.",
+                "detail": "Reversion time in seconds.  0 = No reversion time",
+                "label": "Reversion Timeout",
+                "mandatory": "O",
+                "name": "RvrtTms",
+                "type": "uint32"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
+                "desc": "Reversion time remaining in seconds.",
+                "detail": "Reversion time remaining in seconds",
+                "label": "Reversion Time Remaining",
+                "mandatory": "O",
+                "name": "RvrtRem",
+                "type": "uint32"
+            },
+            {
+                "access": "RW",
+                "desc": "Default curve after reversion timeout.",
+                "detail": "Default curve after reversion timeout.",
+                "label": "Reversion Curve",
+                "mandatory": "O",
+                "name": "RvrtCrv",
+                "type": "uint16"
+            },
+            {
+                "access": "R",
                 "desc": "Scale factor for curve voltage points.",
-                "detail": null,
-                "id": "V_SF",
                 "label": "Voltage Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "V_SF",
+                "static": "S",
+                "type": "sunssf"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Scale factor for curve watt points.",
-                "detail": null,
-                "id": "DeptRef_SF",
                 "label": "Watt  Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "DeptRef_SF",
+                "static": "S",
+                "type": "sunssf"
             }
-        ]
+        ],
+        "type": "group"
     },
     "id": 706
 }

--- a/json/model_707.json
+++ b/json/model_707.json
@@ -1,364 +1,295 @@
 {
     "group": {
-        "comments": [],
         "desc": "DER Low voltage trip model.",
-        "detail": null,
         "groups": [
             {
                 "comments": [
-                    "Stored curve sets - Number of curve sets contained in NCrv"
+                    "Stored curve sets - Number of curve sets contained in NCrv - The first set is read-only and indicates the current settings."
                 ],
                 "count": "NCrv",
                 "desc": "Stored curve sets.",
-                "detail": null,
                 "groups": [
                     {
                         "comments": [
                             "Stored curve set containing a Must Trip, May Trip, and Momentary Cessation Curve - Number of curve points contained in NPt"
                         ],
                         "desc": "Stored must trip curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "Must trip curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "Must Trip Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve voltage point as percentage.",
-                                        "detail": null,
-                                        "id": "V",
                                         "label": "Voltage Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "V",
                                         "sf": "V_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "VRefPct"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MustTrip",
                         "label": "Must Trip Curve",
+                        "name": "MustTrip",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in must trip curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     },
                     {
-                        "comments": [],
                         "desc": "Stored may trip curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "May trip curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "May Trip Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve voltage point as percentage.",
-                                        "detail": null,
-                                        "id": "V",
                                         "label": "Voltage Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "V",
                                         "sf": "V_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "VRefPct"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MayTrip",
                         "label": "May Trip Curve",
+                        "name": "MayTrip",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in may trip curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     },
                     {
-                        "comments": [],
                         "desc": "Stored momentary cessation curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "Monetary cessation curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "Mom Cessation Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve voltage point as percentage.",
-                                        "detail": null,
-                                        "id": "V",
                                         "label": "Voltage Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "V",
                                         "sf": "V_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "VRefPct"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MomCess",
                         "label": "Momentary Cessation Curve",
+                        "name": "MomCess",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in the momentary cessation curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     }
                 ],
-                "id": "Crv",
                 "label": "Stored Curves",
-                "points": []
+                "name": "Crv",
+                "type": "group"
             }
         ],
-        "id": "DERTripLV",
         "label": "DER Trip LV",
+        "name": "DERTripLV",
         "points": [
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER low voltage trip model id.",
-                "detail": null,
-                "id": "ID",
                 "label": "DER Trip LV Model ID",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
+                "mandatory": "M",
+                "name": "ID",
+                "static": "S",
                 "type": "uint16",
-                "units": null,
                 "value": 707
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER low volatage trip model length.",
-                "detail": null,
-                "id": "L",
                 "label": "DER Trip LV Model Length",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "L",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "Is DER low voltage trip  control active.",
+                "access": "RW",
+                "desc": "DER low voltage trip  control enable.",
                 "detail": " ",
-                "id": "ModEna",
                 "label": "DER Trip LV Module Enable",
-                "mandatory": "true",
-                "sf": null,
+                "mandatory": "M",
+                "name": "Ena",
                 "symbols": [
                     {
-                        "comments": [],
-                        "desc": "Enabled flag (Disabled = 0, Enabled = 1).",
-                        "detail": null,
-                        "id": "ENABLED",
-                        "label": "Enabled Flag",
-                        "value": 0
-                    }
-                ],
-                "type": "bitfield16",
-                "units": null
-            },
-            {
-                "access": "rw",
-                "comments": [],
-                "desc": "Index of  curve points to adopt. First curve index is 1.",
-                "detail": " ",
-                "id": "AdoptCrv",
-                "label": "Adopt Curve",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
-            },
-            {
-                "access": "r",
-                "comments": [],
-                "desc": "Result of last adopt curve operation.",
-                "detail": null,
-                "id": "AdoptCrvRslt",
-                "label": "Adopt Curve Result",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [
-                    {
-                        "comments": [],
-                        "desc": "Curve update in progress.",
-                        "detail": null,
-                        "id": "IN_PROGRESS",
-                        "label": "Update In Progress",
+                        "desc": "Function is enabled.",
+                        "detail": "Function is enabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
                         "value": 0
                     },
                     {
-                        "comments": [],
+                        "desc": "Function is disabled.",
+                        "detail": "Function is disabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "R",
+                "desc": "Current active  curve state.",
+                "label": "Active Curve State",
+                "mandatory": "M",
+                "name": "CrvSt",
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Index of  curve points to adopt. First curve index is 1.",
+                "detail": " ",
+                "label": "Adopt Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "type": "uint16"
+            },
+            {
+                "access": "R",
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
                         "desc": "Curve update completed successfully.",
-                        "detail": null,
-                        "id": "COMPLETED",
                         "label": "Update Complete",
+                        "name": "COMPLETED",
                         "value": 1
                     },
                     {
-                        "comments": [],
                         "desc": "Curve update failed.",
-                        "detail": null,
-                        "id": "FAILED",
                         "label": "Update Failed",
+                        "name": "FAILED",
                         "value": 2
                     }
                 ],
-                "type": "enum16",
-                "units": null
+                "type": "enum16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of curve points supported.",
                 "detail": " ",
-                "id": "NPt",
                 "label": "Number of Points",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NPt",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of stored curves supported.",
-                "detail": null,
-                "id": "NCrv",
                 "label": "Stored Curve Count",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NCrv",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Scale factor for curve voltage points.",
-                "detail": null,
-                "id": "V_SF",
                 "label": "Voltage Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "V_SF",
+                "static": "S",
+                "type": "sunssf"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Scale factor for curve time points.",
-                "detail": null,
-                "id": "Tms_SF",
                 "label": "Time Point Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "Tms_SF",
+                "static": "S",
+                "type": "sunssf"
             }
-        ]
+        ],
+        "type": "group"
     },
     "id": 707
 }

--- a/json/model_708.json
+++ b/json/model_708.json
@@ -1,364 +1,295 @@
 {
     "group": {
-        "comments": [],
         "desc": "DER high voltage trip model.",
-        "detail": null,
         "groups": [
             {
                 "comments": [
-                    "Stored curve sets - Number of curve sets contained in NCrv"
+                    "Stored curve sets - Number of curve sets contained in NCrv - The first set is read-only and indicates the current settings."
                 ],
                 "count": "NCrv",
                 "desc": "Stored curve sets.",
-                "detail": null,
                 "groups": [
                     {
                         "comments": [
                             "Stored curve set containing a Must Trip, May Trip, and Momentary Cessation Curve - Number of curve points contained in NPt"
                         ],
                         "desc": "Stored must trip curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "Must trip curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "Must Trip Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve voltage point as percentage.",
-                                        "detail": null,
-                                        "id": "V",
                                         "label": "Voltage Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "V",
                                         "sf": "V_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "VRefPct"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MustTrip",
                         "label": "Must Trip Curve",
+                        "name": "MustTrip",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in must trip curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     },
                     {
-                        "comments": [],
                         "desc": "Stored may trip curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "May trip curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "May Trip Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve voltage point as percentage.",
-                                        "detail": null,
-                                        "id": "V",
                                         "label": "Voltage Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "V",
                                         "sf": "V_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "VRefPct"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MayTrip",
                         "label": "May Trip Curve",
+                        "name": "MayTrip",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in may trip curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     },
                     {
-                        "comments": [],
                         "desc": "Stored momentary cessation curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "Monetary cessation curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "Mom Cessation Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve voltage point as percentage.",
-                                        "detail": null,
-                                        "id": "V",
                                         "label": "Voltage Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "V",
                                         "sf": "V_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "VRefPct"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MomCess",
                         "label": "Momentary Cessation Curve",
+                        "name": "MomCess",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in the momentary cessation curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     }
                 ],
-                "id": "Crv",
                 "label": "Stored Curves",
-                "points": []
+                "name": "Crv",
+                "type": "group"
             }
         ],
-        "id": "DERTripHV",
         "label": "DER Trip HV",
+        "name": "DERTripHV",
         "points": [
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER high voltage trip  model id.",
-                "detail": null,
-                "id": "ID",
                 "label": "DER Trip HV Model ID",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
+                "mandatory": "M",
+                "name": "ID",
+                "static": "S",
                 "type": "uint16",
-                "units": null,
                 "value": 708
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER high voltage trip model length.",
-                "detail": null,
-                "id": "L",
                 "label": "DER Trip HV Model Length",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "L",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "Is DER high voltage trip control active.",
+                "access": "RW",
+                "desc": "DER high voltage trip control enable.",
                 "detail": " ",
-                "id": "ModEna",
                 "label": "DER Trip HV Module Enable",
-                "mandatory": "true",
-                "sf": null,
+                "mandatory": "M",
+                "name": "Ena",
                 "symbols": [
                     {
-                        "comments": [],
-                        "desc": "Enabled flag (Disabled = 0, Enabled = 1).",
-                        "detail": null,
-                        "id": "ENABLED",
-                        "label": "Enabled Flag",
-                        "value": 0
-                    }
-                ],
-                "type": "bitfield16",
-                "units": null
-            },
-            {
-                "access": "rw",
-                "comments": [],
-                "desc": "Index of  curve points to adopt. First curve index is 1.",
-                "detail": " ",
-                "id": "AdoptCrv",
-                "label": "Adopt Curve",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
-            },
-            {
-                "access": "r",
-                "comments": [],
-                "desc": "Result of last adopt curve operation.",
-                "detail": null,
-                "id": "AdoptCrvRslt",
-                "label": "Adopt Curve Result",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [
-                    {
-                        "comments": [],
-                        "desc": "Curve update in progress.",
-                        "detail": null,
-                        "id": "IN_PROGRESS",
-                        "label": "Update In Progress",
+                        "desc": "Function is enabled.",
+                        "detail": "Function is enabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
                         "value": 0
                     },
                     {
-                        "comments": [],
+                        "desc": "Function is disabled.",
+                        "detail": "Function is disabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "R",
+                "desc": "Current active  curve state.",
+                "label": "Active Curve State",
+                "mandatory": "M",
+                "name": "CrvSt",
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Index of  curve points to adopt. First curve index is 1.",
+                "detail": " ",
+                "label": "Adopt Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "type": "uint16"
+            },
+            {
+                "access": "R",
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
                         "desc": "Curve update completed successfully.",
-                        "detail": null,
-                        "id": "COMPLETED",
                         "label": "Update Complete",
+                        "name": "COMPLETED",
                         "value": 1
                     },
                     {
-                        "comments": [],
                         "desc": "Curve update failed.",
-                        "detail": null,
-                        "id": "FAILED",
                         "label": "Update Failed",
+                        "name": "FAILED",
                         "value": 2
                     }
                 ],
-                "type": "enum16",
-                "units": null
+                "type": "enum16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of curve points supported.",
                 "detail": " ",
-                "id": "NPt",
                 "label": "Number of Points",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NPt",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of stored curves supported.",
-                "detail": null,
-                "id": "NCrv",
                 "label": "Stored Curve Count",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NCrv",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Scale factor for curve voltage points.",
-                "detail": null,
-                "id": "V_SF",
                 "label": "Voltage Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "V_SF",
+                "static": "S",
+                "type": "sunssf"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Scale factor for curve time points.",
-                "detail": null,
-                "id": "Tms_SF",
                 "label": "Time Point Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "Tms_SF",
+                "static": "S",
+                "type": "sunssf"
             }
-        ]
+        ],
+        "type": "group"
     },
     "id": 708
 }

--- a/json/model_709.json
+++ b/json/model_709.json
@@ -1,364 +1,295 @@
 {
     "group": {
-        "comments": [],
         "desc": "DER low frequency trip model.",
-        "detail": null,
         "groups": [
             {
                 "comments": [
-                    "Stored curve sets - Number of curve sets contained in NCrv"
+                    "Stored curve sets - Number of curve sets contained in NCrv - The first set is read-only and indicates the current settings."
                 ],
                 "count": "NCrv",
                 "desc": "Stored curve sets.",
-                "detail": null,
                 "groups": [
                     {
                         "comments": [
                             "Stored curve set containing a Must Trip, May Trip, and Momentary Cessation Curve - Number of curve points contained in NPt"
                         ],
                         "desc": "Stored must trip curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "Must trip curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "Must Trip Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve frequency point.",
-                                        "detail": null,
-                                        "id": "Freq",
                                         "label": "Frequency Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Freq",
                                         "sf": "Freq_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Hz"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MustTrip",
                         "label": "Must Trip Curve",
+                        "name": "MustTrip",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in must trip curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     },
                     {
-                        "comments": [],
                         "desc": "Stored may trip curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "May trip curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "May Trip Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve frequency point.",
-                                        "detail": null,
-                                        "id": "Freq",
                                         "label": "Frequency Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Freq",
                                         "sf": "Freq_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Hz"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MayTrip",
                         "label": "May Trip Curve",
+                        "name": "MayTrip",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in may trip curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     },
                     {
-                        "comments": [],
                         "desc": "Stored momentary cessation curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "Monetary cessation curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "Mom Cessation Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve frequency point.",
-                                        "detail": null,
-                                        "id": "Freq",
                                         "label": "Frequency Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Freq",
                                         "sf": "Freq_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Hz"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MomCess",
                         "label": "Momentary Cessation Curve",
+                        "name": "MomCess",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in the momentary cessation curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     }
                 ],
-                "id": "Crv",
                 "label": "Stored Curves",
-                "points": []
+                "name": "Crv",
+                "type": "group"
             }
         ],
-        "id": "DERTripLF",
         "label": "DER Trip LF",
+        "name": "DERTripLF",
         "points": [
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER low frequency trip model id.",
-                "detail": null,
-                "id": "ID",
                 "label": "DER Trip LF Model ID",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
+                "mandatory": "M",
+                "name": "ID",
+                "static": "S",
                 "type": "uint16",
-                "units": null,
                 "value": 709
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER low frequency trip model length.",
-                "detail": null,
-                "id": "L",
                 "label": "DER Trip LF Model Length",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "L",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "Is DER low frequency trip control active.",
+                "access": "RW",
+                "desc": "DER low frequency trip control enable.",
                 "detail": " ",
-                "id": "ModEna",
                 "label": "DER Trip LF Module Enable",
-                "mandatory": "true",
-                "sf": null,
+                "mandatory": "M",
+                "name": "Ena",
                 "symbols": [
                     {
-                        "comments": [],
-                        "desc": "Enabled flag (Disabled = 0, Enabled = 1).",
-                        "detail": null,
-                        "id": "ENABLED",
-                        "label": "Enabled Flag",
-                        "value": 0
-                    }
-                ],
-                "type": "bitfield16",
-                "units": null
-            },
-            {
-                "access": "rw",
-                "comments": [],
-                "desc": "Index of  curve points to adopt. First curve index is 1.",
-                "detail": " ",
-                "id": "AdoptCrv",
-                "label": "Adopt Curve",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
-            },
-            {
-                "access": "r",
-                "comments": [],
-                "desc": "Result of last adopt curve operation.",
-                "detail": null,
-                "id": "AdoptCrvRslt",
-                "label": "Adopt Curve Result",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [
-                    {
-                        "comments": [],
-                        "desc": "Curve update in progress.",
-                        "detail": null,
-                        "id": "IN_PROGRESS",
-                        "label": "Update In Progress",
+                        "desc": "Function is enabled.",
+                        "detail": "Function is enabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
                         "value": 0
                     },
                     {
-                        "comments": [],
+                        "desc": "Function is disabled.",
+                        "detail": "Function is disabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "R",
+                "desc": "Current active  curve state.",
+                "label": "Active Curve State",
+                "mandatory": "M",
+                "name": "CrvSt",
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Index of  curve points to adopt. First curve index is 1.",
+                "detail": " ",
+                "label": "Adopt Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "type": "uint16"
+            },
+            {
+                "access": "R",
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
                         "desc": "Curve update completed successfully.",
-                        "detail": null,
-                        "id": "COMPLETED",
                         "label": "Update Complete",
+                        "name": "COMPLETED",
                         "value": 1
                     },
                     {
-                        "comments": [],
                         "desc": "Curve update failed.",
-                        "detail": null,
-                        "id": "FAILED",
                         "label": "Update Failed",
+                        "name": "FAILED",
                         "value": 2
                     }
                 ],
-                "type": "enum16",
-                "units": null
+                "type": "enum16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of curve points supported.",
                 "detail": " ",
-                "id": "NPt",
                 "label": "Number of Points",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NPt",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of stored curves supported.",
-                "detail": null,
-                "id": "NCrv",
                 "label": "Stored Curve Count",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NCrv",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Scale factor for curve frequency points.",
-                "detail": null,
-                "id": "Freq_SF",
                 "label": "Frequency Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "Freq_SF",
+                "static": "S",
+                "type": "sunssf"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Scale factor for curve time points.",
-                "detail": null,
-                "id": "Tms_SF",
                 "label": "Time Point Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "Tms_SF",
+                "static": "S",
+                "type": "sunssf"
             }
-        ]
+        ],
+        "type": "group"
     },
     "id": 709
 }

--- a/json/model_710.json
+++ b/json/model_710.json
@@ -1,364 +1,295 @@
 {
     "group": {
-        "comments": [],
         "desc": "DER high frequency trip model.",
-        "detail": null,
         "groups": [
             {
                 "comments": [
-                    "Stored curve sets - Number of curve sets contained in NCrv"
+                    "Stored curve sets - Number of curve sets contained in NCrv - The first set is read-only and indicates the current settings."
                 ],
                 "count": "NCrv",
                 "desc": "Stored curve sets.",
-                "detail": null,
                 "groups": [
                     {
                         "comments": [
                             "Stored curve set containing a Must Trip, May Trip, and Momentary Cessation Curve - Number of curve points contained in NPt"
                         ],
                         "desc": "Stored must trip curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "Must trip curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "Must Trip Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve frequency point.",
-                                        "detail": null,
-                                        "id": "Freq",
                                         "label": "Frequency Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Freq",
                                         "sf": "Freq_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Hz"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MustTrip",
                         "label": "Must Trip Curve",
+                        "name": "MustTrip",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in must trip curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     },
                     {
-                        "comments": [],
                         "desc": "Stored may trip curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "May trip curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "May Trip Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve frequency point.",
-                                        "detail": null,
-                                        "id": "Freq",
                                         "label": "Frequency Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Freq",
                                         "sf": "Freq_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Hz"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MayTrip",
                         "label": "May Trip Curve",
+                        "name": "MayTrip",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in may trip curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     },
                     {
-                        "comments": [],
                         "desc": "Stored momentary cessation curve.",
-                        "detail": null,
                         "groups": [
                             {
-                                "comments": [],
                                 "count": "NPt",
                                 "desc": "Monetary cessation curve points.",
-                                "detail": null,
-                                "groups": [],
-                                "id": "Pt",
                                 "label": "Mom Cessation Curve Points",
+                                "name": "Pt",
                                 "points": [
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve frequency point.",
-                                        "detail": null,
-                                        "id": "Freq",
                                         "label": "Frequency Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Freq",
                                         "sf": "Freq_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Hz"
                                     },
                                     {
-                                        "access": "r",
-                                        "comments": [],
+                                        "access": "R",
                                         "desc": "Curve time point in seconds.",
-                                        "detail": null,
-                                        "id": "Tms",
                                         "label": "Time Point",
-                                        "mandatory": "true",
+                                        "mandatory": "M",
+                                        "name": "Tms",
                                         "sf": "Tms_SF",
-                                        "symbols": [],
                                         "type": "uint16",
                                         "units": "Secs"
                                     }
-                                ]
+                                ],
+                                "type": "group"
                             }
                         ],
-                        "id": "MomCess",
                         "label": "Momentary Cessation Curve",
+                        "name": "MomCess",
                         "points": [
                             {
-                                "access": "r",
-                                "comments": [],
+                                "access": "R",
                                 "desc": "Number of active points in the momentary cessation curve.",
-                                "detail": null,
-                                "id": "ActPt",
                                 "label": "Number of Active Points",
-                                "mandatory": "false",
-                                "sf": null,
-                                "symbols": [],
-                                "type": "uint16",
-                                "units": null
+                                "mandatory": "O",
+                                "name": "ActPt",
+                                "type": "uint16"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     }
                 ],
-                "id": "Crv",
                 "label": "Stored Curves",
-                "points": []
+                "name": "Crv",
+                "type": "group"
             }
         ],
-        "id": "DERTripHF",
         "label": "DER Trip HF",
+        "name": "DERTripHF",
         "points": [
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER high frequency trip model id.",
-                "detail": null,
-                "id": "ID",
                 "label": "DER Trip HFModel ID",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
+                "mandatory": "M",
+                "name": "ID",
+                "static": "S",
                 "type": "uint16",
-                "units": null,
                 "value": 710
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER high frequency trip model length.",
-                "detail": null,
-                "id": "L",
                 "label": "DER Trip HFModel Length",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "L",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "Is DER high frequency trip control active.",
+                "access": "RW",
+                "desc": "DER high frequency trip control enable.",
                 "detail": " ",
-                "id": "ModEna",
                 "label": "DER Trip HFModule Enable",
-                "mandatory": "true",
-                "sf": null,
+                "mandatory": "M",
+                "name": "Ena",
                 "symbols": [
                     {
-                        "comments": [],
-                        "desc": "Enabled flag (Disabled = 0, Enabled = 1).",
-                        "detail": null,
-                        "id": "ENABLED",
-                        "label": "Enabled Flag",
-                        "value": 0
-                    }
-                ],
-                "type": "bitfield16",
-                "units": null
-            },
-            {
-                "access": "rw",
-                "comments": [],
-                "desc": "Index of  curve points to adopt. First curve index is 1.",
-                "detail": " ",
-                "id": "AdoptCrv",
-                "label": "Adopt Curve",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
-            },
-            {
-                "access": "r",
-                "comments": [],
-                "desc": "Result of last adopt curve operation.",
-                "detail": null,
-                "id": "AdoptCrvRslt",
-                "label": "Adopt Curve Result",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [
-                    {
-                        "comments": [],
-                        "desc": "Curve update in progress.",
-                        "detail": null,
-                        "id": "IN_PROGRESS",
-                        "label": "Update In Progress",
+                        "desc": "Function is enabled.",
+                        "detail": "Function is enabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
                         "value": 0
                     },
                     {
-                        "comments": [],
+                        "desc": "Function is disabled.",
+                        "detail": "Function is disabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
+            },
+            {
+                "access": "R",
+                "desc": "Current active  curve state.",
+                "label": "Active Curve State",
+                "mandatory": "M",
+                "name": "CrvSt",
+                "type": "enum16"
+            },
+            {
+                "access": "RW",
+                "desc": "Index of  curve points to adopt. First curve index is 1.",
+                "detail": " ",
+                "label": "Adopt Curve Request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "type": "uint16"
+            },
+            {
+                "access": "R",
+                "desc": "Result of last adopt curve operation.",
+                "label": "Adopt Curve Result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
                         "desc": "Curve update completed successfully.",
-                        "detail": null,
-                        "id": "COMPLETED",
                         "label": "Update Complete",
+                        "name": "COMPLETED",
                         "value": 1
                     },
                     {
-                        "comments": [],
                         "desc": "Curve update failed.",
-                        "detail": null,
-                        "id": "FAILED",
                         "label": "Update Failed",
+                        "name": "FAILED",
                         "value": 2
                     }
                 ],
-                "type": "enum16",
-                "units": null
+                "type": "enum16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of curve points supported.",
                 "detail": " ",
-                "id": "NPt",
                 "label": "Number of Points",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NPt",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of stored curves supported.",
-                "detail": null,
-                "id": "NCrv",
                 "label": "Stored Curve Count",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NCrv",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Scale factor for curve frequency points.",
-                "detail": null,
-                "id": "Freq_SF",
                 "label": "Frequency Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "Freq_SF",
+                "static": "S",
+                "type": "sunssf"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Scale factor for curve time points.",
-                "detail": null,
-                "id": "Tms_SF",
                 "label": "Time Point Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "Tms_SF",
+                "static": "S",
+                "type": "sunssf"
             }
-        ]
+        ],
+        "type": "group"
     },
     "id": 710
 }

--- a/json/model_711.json
+++ b/json/model_711.json
@@ -1,174 +1,235 @@
 {
     "group": {
-        "comments": [],
         "desc": "DER Frequency Droop model.",
-        "detail": null,
-        "groups": [],
-        "id": "DERFreqDroop",
+        "groups": [
+            {
+                "comments": [
+                    "Stored control sets - Number of control sets contained in NCtl - The first set is read-only and indicates the current settings."
+                ],
+                "count": "NCtl",
+                "desc": "Stored curve sets.",
+                "label": "Stored Curves",
+                "name": "Ctl",
+                "points": [
+                    {
+                        "access": "RW",
+                        "desc": "The deadband value for over-frequency conditions in Hz.",
+                        "label": "Over-frequency Deadband",
+                        "mandatory": "M",
+                        "name": "DbOf",
+                        "sf": "Db_SF",
+                        "type": "uint16",
+                        "units": "Hz"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "The deadband value for under-frequency conditions in Hz.",
+                        "label": "Under-frequency Deadband",
+                        "mandatory": "M",
+                        "name": "DbUf",
+                        "sf": "Db_SF",
+                        "type": "uint16",
+                        "units": "Hz"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Frequency droop per-unit frequency change for over-frequency conditions corresponding to 1 per-unit power output change.",
+                        "label": "Over-frequency Change Ratio",
+                        "mandatory": "M",
+                        "name": "KOf",
+                        "sf": "K_SF",
+                        "type": "uint16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "Frequency droop per-unit frequency change for under-frequency conditions corresponding to 1 per-unit power output change.",
+                        "label": "Under-frequency Change Ratio",
+                        "mandatory": "M",
+                        "name": "KUf",
+                        "sf": "K_SF",
+                        "type": "uint16"
+                    },
+                    {
+                        "access": "RW",
+                        "desc": "The open-loop response time in seconds.",
+                        "label": "Open-Loop Response Time",
+                        "mandatory": "M",
+                        "name": "RspTms",
+                        "sf": "RspTms_SF",
+                        "type": "uint16",
+                        "units": "Secs"
+                    }
+                ],
+                "type": "group"
+            }
+        ],
         "label": "DER Frequency Droop",
+        "name": "DERFreqDroop",
         "points": [
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER Frequency Droop model id.",
-                "detail": null,
-                "id": "ID",
                 "label": "DER Frequency Droop ID",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
+                "mandatory": "M",
+                "name": "ID",
+                "static": "S",
                 "type": "uint16",
-                "units": null,
                 "value": 711
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER Frequency Droop  model length.",
-                "detail": null,
-                "id": "L",
                 "label": "DER Frequency Droop Length",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "L",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "Is DER Frequency-Watt (Frequency-Droop) control active.",
-                "detail": null,
-                "id": "ModEna",
-                "label": null,
-                "mandatory": "true",
-                "sf": null,
+                "access": "RW",
+                "desc": "DER Frequency-Watt (Frequency-Droop) control enable.",
+                "mandatory": "M",
+                "name": "Ena",
                 "symbols": [
                     {
-                        "comments": [],
-                        "desc": null,
-                        "detail": null,
-                        "id": "DISABLED",
-                        "label": null,
+                        "desc": "Function is enabled.",
+                        "detail": "Function is enabled.",
+                        "label": "Disabled",
+                        "name": "DISABLED",
                         "value": 0
                     },
                     {
-                        "comments": [],
-                        "desc": null,
-                        "detail": null,
-                        "id": "ENABLED",
-                        "label": null,
+                        "desc": "Function is disabled.",
+                        "detail": "Function is disabled.",
+                        "label": "Enabled",
+                        "name": "ENABLED",
                         "value": 1
                     }
                 ],
-                "type": "enum16",
-                "units": null
+                "type": "enum16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "The deadband value for over-frequency conditions in Hz.",
-                "detail": null,
-                "id": "DbOf",
-                "label": "Over-frequency Deadband",
-                "mandatory": "true",
-                "sf": "Db_SF",
-                "symbols": [],
-                "type": "uint16",
-                "units": "Hz"
+                "access": "R",
+                "desc": "Current active  curve state.",
+                "detail": " ",
+                "label": "Active Curve State",
+                "mandatory": "M",
+                "name": "CrvSt",
+                "symbols": [
+                    {
+                        "desc": "No curve is currenly active.",
+                        "label": "No active curve",
+                        "name": "INACTIVE",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Active curve in effect.",
+                        "label": "Active curve enabled",
+                        "name": "ACTIVE",
+                        "value": 1
+                    }
+                ],
+                "type": "enum16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "The deadband value for under-frequency conditions in Hz.",
-                "detail": null,
-                "id": "DbUf",
-                "label": "Under-frequency Deadband",
-                "mandatory": "true",
-                "sf": "Db_SF",
-                "symbols": [],
-                "type": "uint16",
-                "units": "Hz"
+                "access": "RW",
+                "desc": "Set active curve. 0 = No active curve",
+                "label": "Set active curve request",
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "type": "uint16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "Frequency droop per-unit frequency change for over-frequency conditions corresponding to 1 per-unit power output change.",
-                "detail": null,
-                "id": "KOf",
-                "label": "Over-frequency Change Ratio",
-                "mandatory": "true",
-                "sf": "K_SF",
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "access": "R",
+                "desc": "Result of last set active curve operation.",
+                "label": "Set active curve result",
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
+                "symbols": [
+                    {
+                        "desc": "Curve update in progress.",
+                        "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
+                        "value": 0
+                    },
+                    {
+                        "desc": "Curve update completed successfully.",
+                        "detail": "The duration from a step change in control signal input until the output changes by 90% of its final change, before any overshoot.",
+                        "label": "Update Complete",
+                        "name": "COMPLETED",
+                        "value": 1
+                    },
+                    {
+                        "desc": "Curve update failed.",
+                        "label": "Update Failed",
+                        "name": "FAILED",
+                        "value": 2
+                    }
+                ],
+                "type": "enum16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "Frequency droop per-unit frequency change for under-frequency conditions corresponding to 1 per-unit power output change.",
-                "detail": null,
-                "id": "KUf",
-                "label": "Under-frequency Change Ratio",
-                "mandatory": "true",
-                "sf": "K_SF",
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "access": "R",
+                "desc": "Number of stored curves supported.",
+                "label": "Stored Curve Count",
+                "mandatory": "M",
+                "name": "NCtl",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "The open-loop response time in seconds.",
-                "detail": "The duration from a step change in control signal input until the output changes by 90% of its final change, before any overshoot.",
-                "id": "RspTms",
-                "label": "Open-Loop Response Time",
-                "mandatory": "true",
-                "sf": "RspTms_SF",
-                "symbols": [],
-                "type": "uint16",
-                "units": "Secs"
+                "access": "RW",
+                "desc": "Reversion time in seconds.  0 = No reversion time",
+                "label": "Reversion timeout",
+                "mandatory": "O",
+                "name": "RvrtTms",
+                "type": "uint32"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
+                "desc": "Reversion time remaining in seconds",
+                "label": "Reversion time left",
+                "mandatory": "O",
+                "name": "RvrtRem",
+                "type": "uint32"
+            },
+            {
+                "access": "RW",
+                "desc": "Default curve after reversion timeout.",
+                "label": "Reversion curve",
+                "mandatory": "O",
+                "name": "RvrtCrv",
+                "type": "uint16"
+            },
+            {
+                "access": "R",
                 "desc": "Deadband scale factor.",
-                "detail": null,
-                "id": "Db_SF",
                 "label": "Deadband Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "Db_SF",
+                "static": "S",
+                "type": "sunssf"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Frequency change scale factor.",
-                "detail": null,
-                "id": "K_SF",
                 "label": "Frequency Change Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "K_SF",
+                "static": "S",
+                "type": "sunssf"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Open loop response time scale factor.",
-                "detail": null,
-                "id": "RspTms_SF",
                 "label": "Open-Loop Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "RspTms_SF",
+                "static": "S",
+                "type": "sunssf"
             }
-        ]
+        ],
+        "type": "group"
     },
     "id": 711
 }

--- a/json/model_712.json
+++ b/json/model_712.json
@@ -1,16 +1,13 @@
 {
     "group": {
-        "comments": [],
         "desc": "DER Watt-Var mod.",
-        "detail": null,
         "groups": [
             {
                 "comments": [
-                    "Stored curve sets - Number of curve sets contained in NCrv"
+                    "Stored curve sets - Number of curve sets contained in NCrv - The first set is read-only and indicates the current settings."
                 ],
                 "count": "NCrv",
                 "desc": "Stored curve sets.",
-                "detail": null,
                 "groups": [
                     {
                         "comments": [
@@ -18,377 +15,269 @@
                         ],
                         "count": "NPt",
                         "desc": "Stored curve points.",
-                        "detail": null,
-                        "groups": [],
-                        "id": "Pt",
                         "label": "Stored Curve Points",
+                        "name": "Pt",
                         "points": [
                             {
-                                "access": "rw",
-                                "comments": [],
+                                "access": "RW",
                                 "desc": "Curve active power point as percentage.",
-                                "detail": null,
-                                "id": "W",
                                 "label": "Active Power Point",
-                                "mandatory": "true",
-                                "sf": null,
-                                "symbols": [],
+                                "mandatory": "M",
+                                "name": "W",
                                 "type": "uint16",
                                 "units": "VRefPct"
                             },
                             {
-                                "access": "rw",
-                                "comments": [],
+                                "access": "RW",
                                 "desc": "Curve reactive power point as set in DeptRef point.",
-                                "detail": null,
-                                "id": "Var",
                                 "label": "Reactive Power Point",
-                                "mandatory": "true",
+                                "mandatory": "M",
+                                "name": "Var",
                                 "sf": "DeptRef_SF",
-                                "symbols": [],
                                 "type": "int16",
                                 "units": "VarPct"
                             }
-                        ]
+                        ],
+                        "type": "group"
                     }
                 ],
-                "id": "Crv",
                 "label": "Stored Curves",
+                "name": "Crv",
                 "points": [
                     {
-                        "access": "rw",
-                        "comments": [],
+                        "access": "RW",
                         "desc": "Number of active points.",
-                        "detail": null,
-                        "id": "ActPt",
                         "label": "Active Points",
-                        "mandatory": "true",
-                        "sf": null,
-                        "symbols": [],
-                        "type": "uint16",
-                        "units": null
+                        "mandatory": "M",
+                        "name": "ActPt",
+                        "type": "uint16"
                     },
                     {
-                        "access": "rw",
-                        "comments": [],
+                        "access": "RW",
                         "desc": "Curve dependent reference.",
-                        "detail": null,
-                        "id": "DeptRef",
                         "label": "Dependent Reference",
-                        "mandatory": "true",
-                        "sf": null,
+                        "mandatory": "M",
+                        "name": "DeptRef",
                         "symbols": [
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "W_MAX_PCT",
                                 "label": "Percent Max Watts",
+                                "name": "W_MAX_PCT",
                                 "value": 1
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "VAR_MAX_PCT",
                                 "label": "Percent Max Vars",
+                                "name": "VAR_MAX_PCT",
                                 "value": 2
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "VAR_AVAL_PCT",
                                 "label": "Percent Available Vars",
+                                "name": "VAR_AVAL_PCT",
                                 "value": 3
                             }
                         ],
-                        "type": "enum16",
-                        "units": null
+                        "type": "enum16"
                     },
                     {
-                        "access": "r",
-                        "comments": [],
-                        "desc": null,
-                        "detail": null,
-                        "id": "Pri",
-                        "label": null,
-                        "mandatory": "false",
-                        "sf": null,
+                        "access": "R",
+                        "mandatory": "O",
+                        "name": "Pri",
                         "symbols": [
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "ACTIVE",
-                                "label": null,
+                                "name": "ACTIVE",
                                 "value": 1
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "REACTIVE",
-                                "label": null,
+                                "name": "REACTIVE",
                                 "value": 2
                             }
                         ],
-                        "type": "enum16",
-                        "units": null
+                        "type": "enum16"
                     },
                     {
-                        "access": "rw",
-                        "comments": [],
+                        "access": "RW",
                         "desc": "Curve read-write access.",
-                        "detail": null,
-                        "id": "ReadOnly",
                         "label": "Curve Access",
-                        "mandatory": "false",
-                        "sf": null,
+                        "mandatory": "O",
+                        "name": "ReadOnly",
                         "symbols": [
                             {
-                                "comments": [],
                                 "desc": "Curve has read-write access.",
-                                "detail": null,
-                                "id": "RW",
                                 "label": "Read-Write Access",
+                                "name": "RW",
                                 "value": 0
                             },
                             {
-                                "comments": [],
                                 "desc": "Curve has read-only access.",
-                                "detail": null,
-                                "id": "R",
                                 "label": "Read-Only Access",
+                                "name": "R",
                                 "value": 1
                             }
                         ],
-                        "type": "enum16",
-                        "units": null
+                        "type": "enum16"
                     }
-                ]
+                ],
+                "type": "group"
             }
         ],
-        "id": "DERWattVar",
         "label": "DER Watt-Var",
+        "name": "DERWattVar",
         "points": [
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER Watt-Var model id.",
-                "detail": null,
-                "id": "ID",
                 "label": "Model ID",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
+                "mandatory": "M",
+                "name": "ID",
+                "static": "S",
                 "type": "uint16",
-                "units": null,
                 "value": 712
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER Watt-Var model length.",
-                "detail": null,
-                "id": "L",
                 "label": "Model Length",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "L",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "rw",
-                "comments": [],
-                "desc": "Is Watt-Var control active.",
-                "detail": null,
-                "id": "Ena",
+                "access": "RW",
+                "desc": "Watt-Var control enable.",
                 "label": "Module Enable",
-                "mandatory": "true",
-                "sf": null,
+                "mandatory": "M",
+                "name": "Ena",
                 "symbols": [
                     {
-                        "comments": [],
                         "desc": "Function is enabled.",
-                        "detail": null,
-                        "id": "DISABLED",
+                        "detail": "Function is enabled.",
                         "label": "Disabled",
+                        "name": "DISABLED",
                         "value": 0
                     },
                     {
-                        "comments": [],
                         "desc": "Function is disabled.",
-                        "detail": null,
-                        "id": "ENABLED",
+                        "detail": "Function is disabled.",
                         "label": "Enabled",
+                        "name": "ENABLED",
                         "value": 1
                     }
                 ],
-                "type": "enum16",
-                "units": null
+                "type": "enum16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Current active  curve state.",
                 "detail": " ",
-                "id": "CrvSt",
                 "label": "Active Curve State",
-                "mandatory": "true",
-                "sf": null,
+                "mandatory": "M",
+                "name": "CrvSt",
                 "symbols": [
                     {
-                        "comments": [],
                         "desc": "No curve is currenly active.",
-                        "detail": null,
-                        "id": "INACTIVE",
                         "label": "No active curve",
+                        "name": "INACTIVE",
                         "value": 0
                     },
                     {
-                        "comments": [],
                         "desc": "Active curve in effect.",
-                        "detail": null,
-                        "id": "ACTIVE",
                         "label": "Active curve enabled",
+                        "name": "ACTIVE",
                         "value": 1
                     }
                 ],
-                "type": "enum16",
-                "units": null
+                "type": "enum16"
             },
             {
-                "access": "rw",
-                "comments": [],
+                "access": "RW",
                 "desc": "Set active curve. 0 = No active curve",
-                "detail": null,
-                "id": "AdptCrvReq",
                 "label": "Set active curve request",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "AdptCrvReq",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Result of last set active curve operation.",
-                "detail": null,
-                "id": "AdptCrvRslt",
                 "label": "Set active curve result",
-                "mandatory": "true",
-                "sf": null,
+                "mandatory": "M",
+                "name": "AdptCrvRslt",
                 "symbols": [
                     {
-                        "comments": [],
                         "desc": "Curve update in progress.",
-                        "detail": null,
-                        "id": "IN_PROGRESS",
                         "label": "Update In Progress",
+                        "name": "IN_PROGRESS",
                         "value": 0
                     },
                     {
-                        "comments": [],
                         "desc": "Curve update completed successfully.",
-                        "detail": null,
-                        "id": "COMPLETED",
                         "label": "Update Complete",
+                        "name": "COMPLETED",
                         "value": 1
                     },
                     {
-                        "comments": [],
                         "desc": "Curve update failed.",
-                        "detail": null,
-                        "id": "FAILED",
                         "label": "Update Failed",
+                        "name": "FAILED",
                         "value": 2
                     }
                 ],
-                "type": "enum16",
-                "units": null
+                "type": "enum16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of curve points supported.",
                 "detail": " ",
-                "id": "NPt",
                 "label": "Number of Points",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NPt",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of stored curves supported.",
-                "detail": null,
-                "id": "NCrv",
                 "label": "Stored Curve Count",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "NCrv",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "rw",
-                "comments": [],
+                "access": "RW",
                 "desc": "Reversion time in seconds.  0 = No reversion time",
-                "detail": null,
-                "id": "RvrtTms",
                 "label": "Reversion timeout",
-                "mandatory": "false",
-                "sf": null,
-                "symbols": [],
-                "type": "uint32",
-                "units": null
+                "mandatory": "O",
+                "name": "RvrtTms",
+                "type": "uint32"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Reversion time remaining in seconds",
-                "detail": null,
-                "id": "RvrtRem",
                 "label": "Reversion time left",
-                "mandatory": "false",
-                "sf": null,
-                "symbols": [],
-                "type": "uint32",
-                "units": null
+                "mandatory": "O",
+                "name": "RvrtRem",
+                "type": "uint32"
             },
             {
-                "access": "rw",
-                "comments": [],
+                "access": "RW",
                 "desc": "Default curve after reversion timeout.",
-                "detail": null,
-                "id": "RvrtCrv",
                 "label": "Reversion curve",
-                "mandatory": "false",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "O",
+                "name": "RvrtCrv",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Scale factor for curve var points.",
-                "detail": null,
-                "id": "DeptRef_SF",
                 "label": "Var  Scale Factor",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "M",
+                "name": "DeptRef_SF",
+                "static": "S",
+                "type": "sunssf"
             }
-        ]
+        ],
+        "type": "group"
     },
     "id": 712
 }

--- a/json/model_713.json
+++ b/json/model_713.json
@@ -1,505 +1,337 @@
 {
     "group": {
-        "comments": [],
         "desc": "DER DC measurement.",
-        "detail": null,
         "groups": [
             {
                 "comments": [
                     "DC Port"
                 ],
                 "count": "NPrt",
-                "desc": null,
-                "detail": null,
-                "groups": [],
-                "id": "Prt",
-                "label": null,
+                "name": "Prt",
                 "points": [
                     {
-                        "access": "r",
-                        "comments": [],
+                        "access": "R",
                         "desc": "Port type.",
-                        "detail": null,
-                        "id": "PrtTyp",
                         "label": "Port Type",
-                        "mandatory": "false",
-                        "sf": null,
+                        "mandatory": "O",
+                        "name": "PrtTyp",
                         "symbols": [
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "PV",
                                 "label": "Photovoltaic",
+                                "name": "PV",
                                 "value": 1
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "ESS",
                                 "label": "Energy Storage System",
+                                "name": "ESS",
                                 "value": 2
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "EV",
                                 "label": "Electric Vehicle",
+                                "name": "EV",
                                 "value": 3
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "INJ",
                                 "label": "Generic Injecting",
+                                "name": "INJ",
                                 "value": 4
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "ABS",
                                 "label": "Generic Absorbing",
+                                "name": "ABS",
                                 "value": 5
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "BIDIR",
                                 "label": "Generic Bidirectional",
+                                "name": "BIDIR",
                                 "value": 6
+                            },
+                            {
+                                "label": "DC to DC",
+                                "name": "DC_DC",
+                                "value": 7
                             }
                         ],
-                        "type": "enum16",
-                        "units": null
+                        "type": "enum16"
                     },
                     {
-                        "access": "r",
-                        "comments": [],
+                        "access": "R",
                         "desc": "Port ID.",
-                        "detail": null,
-                        "id": "ID",
                         "label": "Port ID",
-                        "mandatory": "false",
-                        "sf": null,
-                        "symbols": [],
-                        "type": "uint16",
-                        "units": null
+                        "mandatory": "O",
+                        "name": "ID",
+                        "type": "uint16"
                     },
                     {
-                        "access": "r",
-                        "comments": [],
+                        "access": "R",
                         "desc": "Port ID string.",
-                        "detail": null,
-                        "id": "IDStr",
                         "label": "Port ID String",
-                        "len": 8,
-                        "mandatory": "false",
-                        "sf": null,
-                        "symbols": [],
-                        "type": "string",
-                        "units": null
+                        "mandatory": "O",
+                        "name": "IDStr",
+                        "size": 8,
+                        "type": "string"
                     },
                     {
-                        "access": "r",
-                        "comments": [],
+                        "access": "R",
                         "desc": "DC current for the port.",
-                        "detail": null,
-                        "id": "DCA",
                         "label": "DC Current",
-                        "mandatory": "false",
+                        "mandatory": "O",
+                        "name": "DCA",
                         "sf": "DCA_SF",
-                        "symbols": [],
-                        "type": "int16",
-                        "units": null
+                        "type": "int16"
                     },
                     {
-                        "access": "r",
-                        "comments": [],
+                        "access": "R",
                         "desc": "DC voltage for the port.",
-                        "detail": null,
-                        "id": "DCV",
                         "label": "DC Voltage",
-                        "mandatory": "false",
+                        "mandatory": "O",
+                        "name": "DCV",
                         "sf": "DCV_SF",
-                        "symbols": [],
-                        "type": "uint16",
-                        "units": null
+                        "type": "uint16"
                     },
                     {
-                        "access": "r",
-                        "comments": [],
+                        "access": "R",
                         "desc": "DC power for the port.",
-                        "detail": null,
-                        "id": "DCW",
                         "label": "DC Power",
-                        "mandatory": "false",
+                        "mandatory": "O",
+                        "name": "DCW",
                         "sf": "DCW_SF",
-                        "symbols": [],
-                        "type": "int16",
-                        "units": null
+                        "type": "int16"
                     },
                     {
-                        "access": "r",
-                        "comments": [],
+                        "access": "R",
                         "desc": "Total cumulative DC energy injected for the port.",
-                        "detail": null,
-                        "id": "DCWhInj",
                         "label": "DC Energy Injected",
-                        "mandatory": "false",
+                        "mandatory": "O",
+                        "name": "DCWhInj",
                         "sf": "DCWH_SF",
-                        "symbols": [],
-                        "type": "acc64",
-                        "units": null
+                        "type": "acc64"
                     },
                     {
-                        "access": "r",
-                        "comments": [],
+                        "access": "R",
                         "desc": "Total cumulative DC energy absorbed for the port.",
-                        "detail": null,
-                        "id": "DCWhAbs",
                         "label": "DC Energy Absorbed",
-                        "mandatory": "false",
+                        "mandatory": "O",
+                        "name": "DCWhAbs",
                         "sf": "DCWH_SF",
-                        "symbols": [],
-                        "type": "acc64",
-                        "units": null
+                        "type": "acc64"
                     },
                     {
-                        "access": "r",
-                        "comments": [],
-                        "desc": "DC port timer.",
-                        "detail": null,
-                        "id": "Tms",
-                        "label": "DC Port Timer",
-                        "mandatory": "false",
-                        "sf": null,
-                        "symbols": [],
-                        "type": "uint32",
-                        "units": null
-                    },
-                    {
-                        "access": "r",
-                        "comments": [],
+                        "access": "R",
                         "desc": "DC port temerature.",
-                        "detail": null,
-                        "id": "Tmp",
                         "label": "DC Port Temperature",
-                        "mandatory": "false",
-                        "sf": null,
-                        "symbols": [],
-                        "type": "int16",
-                        "units": null
+                        "mandatory": "O",
+                        "name": "Tmp",
+                        "type": "int16"
                     },
                     {
-                        "access": "r",
-                        "comments": [],
+                        "access": "R",
                         "desc": "DC port status.",
-                        "detail": null,
-                        "id": "DCSt",
                         "label": "DC Port Status",
-                        "mandatory": "false",
-                        "sf": null,
-                        "symbols": [],
-                        "type": "enum16",
-                        "units": null
+                        "mandatory": "O",
+                        "name": "DCSt",
+                        "type": "enum16"
                     },
                     {
-                        "access": "r",
-                        "comments": [],
+                        "access": "R",
                         "desc": "DC port alarm.",
-                        "detail": null,
-                        "id": "DCAlrm",
                         "label": "DC Port Alarm",
-                        "mandatory": "false",
-                        "sf": null,
+                        "mandatory": "O",
+                        "name": "DCAlrm",
                         "symbols": [
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "GROUND_FAULT",
                                 "label": "Ground Fault",
+                                "name": "GROUND_FAULT",
                                 "value": 0
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "INPUT_OVER_VOLTAGE",
                                 "label": "Input Over Voltage",
+                                "name": "INPUT_OVER_VOLTAGE",
                                 "value": 1
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "RESERVED",
                                 "label": "Reserved",
+                                "name": "RESERVED",
                                 "value": 19
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "DC_DISCONNECT",
                                 "label": "DC Disconnect",
+                                "name": "DC_DISCONNECT",
                                 "value": 3
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "CABINET_OPEN",
                                 "label": "Cabinet Open",
+                                "name": "CABINET_OPEN",
                                 "value": 5
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "MANUAL_SHUTDOWN",
                                 "label": "Manual Shutdown",
+                                "name": "MANUAL_SHUTDOWN",
                                 "value": 6
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "OVER_TEMP",
                                 "label": "Over Temperature",
+                                "name": "OVER_TEMP",
                                 "value": 7
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "BLOWN_FUSE",
                                 "label": "Blown Fuse",
+                                "name": "BLOWN_FUSE",
                                 "value": 12
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "UNDER_TEMP",
                                 "label": "Under Temperature",
+                                "name": "UNDER_TEMP",
                                 "value": 13
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "MEMORY_LOSS",
                                 "label": "Memory Loss",
+                                "name": "MEMORY_LOSS",
                                 "value": 14
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "ARC_DETECTION",
                                 "label": "Arc Detection",
+                                "name": "ARC_DETECTION",
                                 "value": 15
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "TEST_FAILED",
                                 "label": "Test Failed",
+                                "name": "TEST_FAILED",
                                 "value": 20
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "INPUT_UNDER_VOLTAGE",
                                 "label": "Under Voltage",
+                                "name": "INPUT_UNDER_VOLTAGE",
                                 "value": 21
                             },
                             {
-                                "comments": [],
-                                "desc": null,
-                                "detail": null,
-                                "id": "INPUT_OVER_CURRENT",
                                 "label": "Over Current",
+                                "name": "INPUT_OVER_CURRENT",
                                 "value": 22
                             }
                         ],
-                        "type": "bitfield32",
-                        "units": null
+                        "type": "bitfield32"
                     }
-                ]
+                ],
+                "type": "group"
             }
         ],
-        "id": "DERMeasureDC",
         "label": "DER DC Measurement",
+        "name": "DERMeasureDC",
         "points": [
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER DC measurement model id.",
-                "detail": null,
-                "id": "ID",
                 "label": "DER DC Measure Model ID",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
+                "mandatory": "M",
+                "name": "ID",
+                "static": "S",
                 "type": "uint16",
-                "units": null,
                 "value": 713
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DER DC measurement model length.",
-                "detail": null,
-                "id": "L",
                 "label": "DER DC MeasureModel Length",
-                "mandatory": "true",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "M",
+                "name": "L",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
+                "access": "R",
                 "comments": [
                     "DC General"
                 ],
                 "desc": "Bitfield of ports with active alarms. Bit is 1 if port has an active alarm. Bit 0 is first port.",
-                "detail": null,
-                "id": "Alrm",
                 "label": "Port Alarms",
-                "mandatory": "false",
-                "sf": null,
-                "symbols": [],
-                "type": "bitfield32",
-                "units": null
+                "mandatory": "O",
+                "name": "Alrm",
+                "type": "bitfield32"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Number of DC ports.",
-                "detail": null,
-                "id": "NPrt",
                 "label": "Number of Ports",
-                "mandatory": "false",
-                "sf": null,
-                "symbols": [],
-                "type": "uint16",
-                "units": null
+                "mandatory": "O",
+                "name": "NPrt",
+                "static": "S",
+                "type": "uint16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Total DC current for all ports.",
-                "detail": null,
-                "id": "DCA",
                 "label": "DC Current",
-                "mandatory": "false",
+                "mandatory": "O",
+                "name": "DCA",
                 "sf": "DCA_SF",
-                "symbols": [],
-                "type": "int16",
-                "units": null
+                "type": "int16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Total DC power for all ports.",
-                "detail": null,
-                "id": "DCW",
                 "label": "DC Power",
-                "mandatory": "false",
+                "mandatory": "O",
+                "name": "DCW",
                 "sf": "DCW_SF",
-                "symbols": [],
-                "type": "int16",
-                "units": null
+                "type": "int16"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Total cumulative DC energy injected for all ports.",
-                "detail": null,
-                "id": "DCWhInj",
                 "label": "DC Energy Injected",
-                "mandatory": "false",
+                "mandatory": "O",
+                "name": "DCWhInj",
                 "sf": "DCWH_SF",
-                "symbols": [],
-                "type": "acc64",
-                "units": null
+                "type": "acc64"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "Total cumulative DC energy absorbed for all ports.",
-                "detail": null,
-                "id": "DCWhAbs",
                 "label": "DC Energy Absorbed",
-                "mandatory": "false",
+                "mandatory": "O",
+                "name": "DCWhAbs",
                 "sf": "DCWH_SF",
-                "symbols": [],
-                "type": "acc64",
-                "units": null
+                "type": "acc64"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DC current scale factor.",
-                "detail": null,
-                "id": "DCA_SF",
                 "label": "DC Current Scale Factor",
-                "mandatory": "false",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "O",
+                "name": "DCA_SF",
+                "static": "S",
+                "type": "sunssf"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DC voltage scale factor.",
-                "detail": null,
-                "id": "DCV_SF",
                 "label": "DC Voltage Scale Factor",
-                "mandatory": "false",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "O",
+                "name": "DCV_SF",
+                "static": "S",
+                "type": "sunssf"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DC power scale factor.",
-                "detail": null,
-                "id": "DCW_SF",
                 "label": "DC Power Scale Factor",
-                "mandatory": "false",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "O",
+                "name": "DCW_SF",
+                "static": "S",
+                "type": "sunssf"
             },
             {
-                "access": "r",
-                "comments": [],
+                "access": "R",
                 "desc": "DC energy scale factor.",
-                "detail": null,
-                "id": "DCWH_SF",
                 "label": "DC Energy Scale Factor",
-                "mandatory": "false",
-                "sf": null,
-                "symbols": [],
-                "type": "sunssf",
-                "units": null
+                "mandatory": "O",
+                "name": "DCWH_SF",
+                "static": "S",
+                "type": "sunssf"
             }
-        ]
+        ],
+        "type": "group"
     },
     "id": 713
 }


### PR DESCRIPTION
Fixes the issues in #76:

All:
----
- Add static attribute to applicable points
- Add 'group' or 'sync' type to all groups

705:
----
- Make labels consistent with other control models

706:
----
- Update Ena to enum16
- Add CrvSt and enums
- Correct AdptCurveReq and AdptCrvRslt point names
- Add reversion timer points missing from the model

707-710:
--------
- Update ModEna to Ena as enum16
- Add CrvSt and enums
- Update AdptCrv points for consistency

711:
----
- Add curve syncronization and reversion support field to model

713:
----
- Remove Tms - remnant from earlier version
- Add DC-DC enumeration to PrtTyp

Excel spreadsheet for reference:
[wb_705_713.xlsx](https://github.com/sunspec/models/files/4555869/wb_705_713.xlsx)
