### PR TITLE
Update missing scale factors and more

### DIFF
--- a/json/model_701.json
+++ b/json/model_701.json
@@ -276,7 +276,7 @@
                 "label": "Total Energy Injected",
                 "name": "TotWhInj",
                 "sf": "TotWh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Wh"
             },
             {
@@ -284,7 +284,7 @@
                 "label": "Total Energy Absorbed",
                 "name": "TotWhAbs",
                 "sf": "TotWh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Wh"
             },
             {
@@ -292,7 +292,7 @@
                 "label": "Total Reactive Energy Inj",
                 "name": "TotVarhInj",
                 "sf": "TotVar_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Varh"
             },
             {
@@ -300,7 +300,7 @@
                 "label": "Total Reactive Energy Abs",
                 "name": "TotVarhAbs",
                 "sf": "TotVar_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Varh"
             },
             {
@@ -417,7 +417,7 @@
                 "label": "Total Watt-hours Inj L1",
                 "name": "TotWhInjL1",
                 "sf": "TotWh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Wh"
             },
             {
@@ -425,7 +425,7 @@
                 "label": "Total Watt-hours Abs L1",
                 "name": "TotWhAbsL1",
                 "sf": "TotWh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Wh"
             },
             {
@@ -433,7 +433,7 @@
                 "label": "Total Var-hours Inj L1",
                 "name": "TotVarhInjL1",
                 "sf": "TotVarh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Varh"
             },
             {
@@ -441,7 +441,7 @@
                 "label": "Total Var-hours Abs L1",
                 "name": "TotVarhAbsL1",
                 "sf": "TotVarh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Varh"
             },
             {
@@ -507,7 +507,7 @@
                 "label": "Total Watt-hours Inj L2",
                 "name": "TotWhInjL2",
                 "sf": "TotWh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Wh"
             },
             {
@@ -515,7 +515,7 @@
                 "label": "Total Watt-hours Abs L2",
                 "name": "TotWhAbsL2",
                 "sf": "TotWh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Wh"
             },
             {
@@ -523,7 +523,7 @@
                 "label": "Total Var-hours Inj L2",
                 "name": "TotVarhInjL2",
                 "sf": "TotVarh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Varh"
             },
             {
@@ -531,7 +531,7 @@
                 "label": "Total Var-hours Abs L2",
                 "name": "TotVarhAbsL2",
                 "sf": "TotVarh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Varh"
             },
             {
@@ -597,7 +597,7 @@
                 "label": "Total Watt-hours Inj L3",
                 "name": "TotWhInjL3",
                 "sf": "TotWh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Wh"
             },
             {
@@ -605,7 +605,7 @@
                 "label": "Total Watt-hours Abs L3",
                 "name": "TotWhAbsL3",
                 "sf": "TotWh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Wh"
             },
             {
@@ -613,7 +613,7 @@
                 "label": "Total Var-hours Inj L3",
                 "name": "TotVarhInjL3",
                 "sf": "TotVarh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Varh"
             },
             {
@@ -621,7 +621,7 @@
                 "label": "Total Var-hours Abs L3",
                 "name": "TotVarhAbsL3",
                 "sf": "TotVarh_SF",
-                "type": "acc64",
+                "type": "uint64",
                 "units": "Varh"
             },
             {

--- a/json/model_702.json
+++ b/json/model_702.json
@@ -5,7 +5,6 @@
         "name": "DERCapacity",
         "points": [
             {
-                "access": "R",
                 "desc": "DER capacity model id.",
                 "label": "DER Capacity Model ID",
                 "mandatory": "M",
@@ -15,7 +14,6 @@
                 "value": 702
             },
             {
-                "access": "R",
                 "desc": "DER capacity name  model length.",
                 "label": "DER Capacity Model Length",
                 "mandatory": "M",
@@ -24,180 +22,144 @@
                 "type": "uint16"
             },
             {
-                "access": "R",
                 "comments": [
                     "Nameplate Ratings - Specifies capacity ratings"
                 ],
                 "desc": "Maximum active power rating at unity power factor in watts.",
                 "label": "Active Power Max Rating",
-                "mandatory": "O",
                 "name": "WMaxRtg",
                 "sf": "W_SF",
                 "type": "uint16",
                 "units": "W"
             },
             {
-                "access": "R",
                 "desc": "Active power rating at specified over-excited power factor in watts.",
                 "label": "Active Power (Over-Excited) Rating",
-                "mandatory": "O",
                 "name": "WOvrExtRtg",
                 "sf": "W_SF",
                 "type": "uint16",
                 "units": "W"
             },
             {
-                "access": "R",
                 "desc": "Specified over-excited power factor.",
                 "label": "Specified Over-Excited PF",
-                "mandatory": "O",
                 "name": "WOvrExtRtgPF",
                 "sf": "PF_SF",
                 "type": "uint16"
             },
             {
-                "access": "R",
                 "desc": "Active power rating at specified under-excited power factor in watts.",
                 "label": "Active Power (Under-Excited) Rating",
-                "mandatory": "O",
                 "name": "WUndExtRtg",
                 "sf": "W_SF",
                 "type": "uint16",
                 "units": "W"
             },
             {
-                "access": "R",
                 "desc": "Specified under-excited power factor.",
                 "label": "Specified Under-Excited PF",
-                "mandatory": "O",
                 "name": "WUndExtRtgPF",
                 "sf": "PF_SF",
                 "type": "uint16"
             },
             {
-                "access": "R",
                 "desc": "Maximum apparent power rating in voltamperes.",
                 "label": "Apparent Power Max Rating",
-                "mandatory": "O",
                 "name": "VAMaxRtg",
                 "sf": "VA_SF",
                 "type": "uint16",
                 "units": "VA"
             },
             {
-                "access": "R",
                 "desc": "Maximum injected reactive power rating in vars.",
                 "label": "Reactive Power Injected Rating",
-                "mandatory": "O",
                 "name": "VarMaxInjRtg",
                 "sf": "Var_SF",
                 "type": "uint16",
                 "units": "Var"
             },
             {
-                "access": "R",
                 "desc": "Maximum absorbed reactive power rating in vars.",
                 "label": "Reactive Power Absorbed Rating",
-                "mandatory": "O",
                 "name": "VarMaxAbsRtg",
                 "sf": "Var_SF",
                 "type": "uint16",
                 "units": "Var"
             },
             {
-                "access": "R",
                 "desc": "Maximum active power charge rate in watts.",
                 "label": "Charge Rate Max Rating",
-                "mandatory": "O",
                 "name": "WChaRteMaxRtg",
                 "sf": "W_SF",
                 "type": "uint16",
                 "units": "W"
             },
             {
-                "access": "R",
                 "desc": "Maximum active power discharge rate in watts.",
                 "label": "Discharge Rate Max Rating",
-                "mandatory": "O",
                 "name": "WDisChaRteMaxRtg",
                 "sf": "W_SF",
                 "type": "uint16",
                 "units": "W"
             },
             {
-                "access": "R",
                 "desc": "Maximum apparent power charge rate in voltamperes.",
                 "label": "Charge Rate Max VA Rating",
-                "mandatory": "O",
                 "name": "VAChaRteMaxRtg",
                 "sf": "VA_SF",
                 "type": "uint16",
                 "units": "VA"
             },
             {
-                "access": "R",
                 "desc": "Maximum apparent power discharge rate in voltamperes.",
                 "label": "Discharge Rate Max VA Rating",
-                "mandatory": "O",
                 "name": "VADisChaRteMaxRtg",
                 "sf": "VA_SF",
                 "type": "uint16",
                 "units": "VA"
             },
             {
-                "access": "R",
                 "desc": "AC voltage nominal rating.",
                 "label": "AC Voltage Nominal Rating",
-                "mandatory": "O",
                 "name": "VNomRtg",
                 "sf": "V_SF",
                 "type": "uint16",
                 "units": "V"
             },
             {
-                "access": "R",
                 "desc": "AC voltage maximum rating.",
                 "label": "AC Voltage Max Rating",
-                "mandatory": "O",
                 "name": "VMaxRtg",
                 "sf": "V_SF",
                 "type": "uint16",
                 "units": "V"
             },
             {
-                "access": "R",
                 "desc": "AC voltage minimum rating.",
                 "label": "AC Voltage Min Rating",
-                "mandatory": "O",
                 "name": "VMinRtg",
                 "sf": "V_SF",
                 "type": "uint16",
                 "units": "V"
             },
             {
-                "access": "R",
                 "desc": "AC current maximum rating in amps.",
                 "label": "AC Current Max Rating",
-                "mandatory": "O",
                 "name": "AMaxRtg",
                 "sf": "A_SF",
                 "type": "uint16",
                 "units": "A"
             },
             {
-                "access": "R",
                 "desc": "Power factor over-excited rating.",
                 "label": "PF Over-Excited Rating",
-                "mandatory": "O",
                 "name": "PFOvrExtRtg",
                 "sf": "PF_SF",
                 "type": "uint16"
             },
             {
-                "access": "R",
                 "desc": "Power factor under-excited rating.",
                 "label": "PF Under-Excited Rating",
-                "mandatory": "O",
                 "name": "PFUndExtRtg",
                 "sf": "PF_SF",
                 "type": "uint16"
@@ -211,10 +173,8 @@
                 "units": "S"
             },
             {
-                "access": "R",
                 "desc": "Normal operating performace category as specified in IEEE 1547-2018.",
                 "label": "Normal Operating Category",
-                "mandatory": "O",
                 "name": "NorOpCatRtg",
                 "symbols": [
                     {
@@ -229,10 +189,8 @@
                 "type": "enum16"
             },
             {
-                "access": "R",
                 "desc": "Abnormal operating performance category as specified in IEEE 1547-2018.",
                 "label": "Abnormal Operating Category",
-                "mandatory": "O",
                 "name": "AbnOpCatRtg",
                 "symbols": [
                     {
@@ -328,8 +286,8 @@
                 ],
                 "desc": "Maximum active power setting used to adjust maximum active power setting.",
                 "label": "Active Power Max Setting",
-                "mandatory": "O",
                 "name": "WMax",
+                "sf": "W_SF",
                 "type": "uint16",
                 "units": "W"
             },
@@ -337,7 +295,6 @@
                 "access": "RW",
                 "desc": "Active power setting at specified over-excited power factor in watts.",
                 "label": "Active Power (Over-Excited) Setting",
-                "mandatory": "O",
                 "name": "WMaxOvrExt",
                 "sf": "W_SF",
                 "type": "uint16",
@@ -347,7 +304,6 @@
                 "access": "RW",
                 "desc": "Specified over-excited power factor.",
                 "label": "Specified Over-Excited PF",
-                "mandatory": "O",
                 "name": "WOvrExtPF",
                 "sf": "PF_SF",
                 "type": "uint16"
@@ -356,7 +312,6 @@
                 "access": "RW",
                 "desc": "Active power setting at specified under-excited power factor in watts.",
                 "label": "Active Power (Under-Excited) Setting",
-                "mandatory": "O",
                 "name": "WMaxUndExt",
                 "sf": "W_SF",
                 "type": "uint16",
@@ -366,7 +321,6 @@
                 "access": "RW",
                 "desc": "Specified under-excited power factor.",
                 "label": "Specified Under-Excited PF",
-                "mandatory": "O",
                 "name": "WUndExtPF",
                 "sf": "PF_SF",
                 "type": "uint16"
@@ -375,8 +329,8 @@
                 "access": "RW",
                 "desc": "Maximum apparent power setting used to adjust maximum apparant power rating.",
                 "label": "Apparent Power Max Setting",
-                "mandatory": "O",
                 "name": "VAMax",
+                "sf": "VA_SF",
                 "type": "uint16",
                 "units": "VA"
             },
@@ -384,8 +338,8 @@
                 "access": "RW",
                 "desc": "Maximum AC current setting used to adjust maximum ac current rating.",
                 "label": "AC Current Max Setting",
-                "mandatory": "O",
                 "name": "AMax",
+                "sf": "A_SF",
                 "type": "uint16",
                 "units": "A"
             },
@@ -393,8 +347,8 @@
                 "access": "RW",
                 "desc": "Nominal AC voltage setting.",
                 "label": "Nominal AC Voltage Setting",
-                "mandatory": "O",
                 "name": "Vnom",
+                "sf": "V_SF",
                 "type": "uint16",
                 "units": "V"
             },
@@ -402,8 +356,8 @@
                 "access": "RW",
                 "desc": "Nominal AC voltage offset setting.",
                 "label": "Nominal AC Voltage Offset Setting",
-                "mandatory": "O",
                 "name": "VRefOfs",
+                "sf": "V_SF",
                 "type": "uint16",
                 "units": "V"
             },
@@ -411,8 +365,8 @@
                 "access": "RW",
                 "desc": "AC voltage maximum setting used to adjust AC voltage maximum rating.",
                 "label": "AC Voltage Max Setting",
-                "mandatory": "O",
                 "name": "VMax",
+                "sf": "V_SF",
                 "type": "uint16",
                 "units": "V"
             },
@@ -420,8 +374,8 @@
                 "access": "RW",
                 "desc": "AC voltage minimum setting used to adjust AC voltage maximum rating.",
                 "label": "AC Voltage Min Setting",
-                "mandatory": "O",
                 "name": "VMin",
+                "sf": "V_SF",
                 "type": "uint16",
                 "units": "V"
             },
@@ -429,8 +383,8 @@
                 "access": "RW",
                 "desc": "Maximum injected reactive power setting used to adjust maximum injected reactive power rating.",
                 "label": "Reactive Power Injected Setting",
-                "mandatory": "O",
                 "name": "VarMaxInj",
+                "sf": "Var_SF",
                 "type": "uint16",
                 "units": "Var"
             },
@@ -438,8 +392,8 @@
                 "access": "RW",
                 "desc": "Maximum absorbed reactive power setting used to adjust maximum absorbed reactive power rating.",
                 "label": "Reactive Power Absorbed Setting",
-                "mandatory": "O",
                 "name": "VarMaxAbs",
+                "sf": "Var_SF",
                 "type": "uint16",
                 "units": "Var"
             },
@@ -447,8 +401,8 @@
                 "access": "RW",
                 "desc": "Maximum active power charge rate setting used to adjust maximum active power charge rate rating.",
                 "label": "Charge Rate Max Setting",
-                "mandatory": "O",
                 "name": "WChaRteMax",
+                "sf": "W_SF",
                 "type": "uint16",
                 "units": "W"
             },
@@ -456,8 +410,8 @@
                 "access": "RW",
                 "desc": "Maximum active power discharge rate setting used to adjust maximum active power discharge rate rating.",
                 "label": "Discharge Rate Max Setting",
-                "mandatory": "O",
                 "name": "WDisChaRteMax",
+                "sf": "W_SF",
                 "type": "uint16",
                 "units": "W"
             },
@@ -465,8 +419,8 @@
                 "access": "RW",
                 "desc": "Maximum apparent power charge rate setting used to adjust maximum apparent power charge rate rating.",
                 "label": "Charge Rate Max VA Setting",
-                "mandatory": "O",
                 "name": "VAChaRteMax",
+                "sf": "VA_SF",
                 "type": "uint16",
                 "units": "VA"
             },
@@ -474,8 +428,8 @@
                 "access": "RW",
                 "desc": "Maximum apparent power discharge rate setting used to adjust maximum apparent power discharge rate rating.",
                 "label": "Discharge Rate Max VA Setting",
-                "mandatory": "O",
                 "name": "VADisChaRteMax",
+                "sf": "VA_SF",
                 "type": "uint16",
                 "units": "VA"
             },
@@ -487,58 +441,46 @@
                 "type": "bitfield16"
             },
             {
-                "access": "R",
                 "comments": [
                     "Scale Factors"
                 ],
                 "desc": "Active power scale factor.",
                 "label": "Active Power Scale Factor",
-                "mandatory": "O",
                 "name": "W_SF",
                 "static": "S",
                 "type": "sunssf"
             },
             {
-                "access": "R",
                 "desc": "Power factor scale factor.",
                 "label": "Power Factor Scale Factor",
-                "mandatory": "O",
                 "name": "PF_SF",
                 "static": "S",
                 "type": "sunssf"
             },
             {
-                "access": "R",
                 "desc": "Apparent power scale factor.",
                 "label": "Apparent Power Scale Factor",
-                "mandatory": "O",
                 "name": "VA_SF",
                 "static": "S",
                 "type": "sunssf"
             },
             {
-                "access": "R",
                 "desc": "Reactive power scale factor.",
                 "label": "Reactive Power Scale Factor",
-                "mandatory": "O",
                 "name": "Var_SF",
                 "static": "S",
                 "type": "sunssf"
             },
             {
-                "access": "R",
                 "desc": "Voltage scale factor.",
                 "label": "Voltage Scale Factor",
-                "mandatory": "O",
                 "name": "V_SF",
                 "static": "S",
                 "type": "sunssf"
             },
             {
-                "access": "R",
                 "desc": "Current scale factor.",
                 "label": "Current Scale Factor",
-                "mandatory": "O",
                 "name": "A_SF",
                 "static": "S",
                 "type": "sunssf"

--- a/json/model_704.json
+++ b/json/model_704.json
@@ -14,7 +14,6 @@
                         "access": "RW",
                         "desc": "Power factor setpoint when injecting active power.",
                         "label": "Power Factor (W Inj) ",
-                        "mandatory": "O",
                         "name": "PF",
                         "sf": "PF_SF",
                         "type": "uint16"
@@ -23,7 +22,6 @@
                         "access": "RW",
                         "desc": "Power factor excitation setpoint when injecting active power.",
                         "label": "Power Factor Excitation (W Inj)",
-                        "mandatory": "O",
                         "name": "Ext",
                         "symbols": [
                             {
@@ -53,7 +51,6 @@
                         "access": "RW",
                         "desc": "Reversion power factor setpoint when injecting active power.",
                         "label": "Reversion Power Factor (W Inj) ",
-                        "mandatory": "O",
                         "name": "PF",
                         "sf": "PF_SF",
                         "type": "uint16"
@@ -62,7 +59,6 @@
                         "access": "RW",
                         "desc": "Reversion power factor excitation setpoint when injecting active power.",
                         "label": "Reversion PF Excitation (W Inj)",
-                        "mandatory": "O",
                         "name": "Ext",
                         "symbols": [
                             {
@@ -92,7 +88,6 @@
                         "access": "RW",
                         "desc": "Power factor setpoint when absorbing active power.",
                         "label": "Power Factor (W Abs) ",
-                        "mandatory": "O",
                         "name": "PF",
                         "sf": "PF_SF",
                         "type": "uint16"
@@ -101,7 +96,6 @@
                         "access": "RW",
                         "desc": "Power factor excitation setpoint when absorbing active power.",
                         "label": "Power Factor Excitation (W Abs)",
-                        "mandatory": "O",
                         "name": "Ext",
                         "symbols": [
                             {
@@ -131,7 +125,6 @@
                         "access": "RW",
                         "desc": "Reversion power factor setpoint when absorbing active power.",
                         "label": "Reversion Power Factor (W Abs) ",
-                        "mandatory": "O",
                         "name": "PF",
                         "sf": "PF_SF",
                         "type": "uint16"
@@ -140,7 +133,6 @@
                         "access": "RW",
                         "desc": "Reversion power factor excitation setpoint when absorbing active power.",
                         "label": "Reversion PF Excitation (W Abs)",
-                        "mandatory": "O",
                         "name": "Ext",
                         "symbols": [
                             {
@@ -166,7 +158,6 @@
         "name": "DERCtlAC",
         "points": [
             {
-                "access": "R",
                 "desc": "Model name model id.",
                 "label": "Model ID",
                 "mandatory": "M",
@@ -176,7 +167,6 @@
                 "value": 704
             },
             {
-                "access": "R",
                 "desc": "Model name  model length.",
                 "label": "Model Length",
                 "mandatory": "M",
@@ -191,7 +181,6 @@
                 ],
                 "desc": "Power factor enable when injecting active power.",
                 "label": "Power Factor Enable (W Inj) Enable",
-                "mandatory": "O",
                 "name": "PFWInjEna",
                 "symbols": [
                     {
@@ -210,8 +199,6 @@
                 "type": "enum16"
             },
             {
-                "access": "R",
-                "mandatory": "O",
                 "name": "PFWInjEnaRvrt",
                 "symbols": [
                     {
@@ -233,16 +220,13 @@
                 "access": "RW",
                 "desc": "Power factor reversion timer when injecting active power.",
                 "label": "PF Reversion Time (W Inj)",
-                "mandatory": "O",
                 "name": "PFWInjRvrtTms",
                 "type": "uint32",
                 "units": "Secs"
             },
             {
-                "access": "R",
                 "desc": "Power factor reversion time remaining when injecting active power.",
                 "label": "PF Reversion Time Rem (W Inj)",
-                "mandatory": "O",
                 "name": "PFWInjRvrtRem",
                 "type": "uint32",
                 "units": "Secs"
@@ -254,7 +238,6 @@
                 ],
                 "desc": "Power factor enable when absorbing active power.",
                 "label": "Power Factor Enable (W Abs) Enable",
-                "mandatory": "O",
                 "name": "PFWAbsEna",
                 "symbols": [
                     {
@@ -273,8 +256,6 @@
                 "type": "enum16"
             },
             {
-                "access": "R",
-                "mandatory": "O",
                 "name": "PFWAbsEnaRvrt",
                 "symbols": [
                     {
@@ -296,16 +277,13 @@
                 "access": "RW",
                 "desc": "Power factor reversion timer when absorbing active power.",
                 "label": "PF Reversion Time (W Abs)",
-                "mandatory": "O",
                 "name": "PFWAbsRvrtTms",
                 "type": "uint32",
                 "units": "Secs"
             },
             {
-                "access": "R",
                 "desc": "Power factor reversion time remaining when absorbing active power.",
                 "label": "PF Reversion Time Rem (W Abs)",
-                "mandatory": "O",
                 "name": "PFWAbsRvrtRem",
                 "type": "uint32",
                 "units": "Secs"
@@ -317,7 +295,6 @@
                 ],
                 "desc": "Limit maximum active power enable.",
                 "label": "Limit Max Active Power Enable",
-                "mandatory": "O",
                 "name": "WMaxLimEna",
                 "symbols": [
                     {
@@ -339,7 +316,6 @@
                 "access": "RW",
                 "desc": "Limit maximum active power value.",
                 "label": "Limit Max Power Setpoint",
-                "mandatory": "O",
                 "name": "WMaxLim",
                 "sf": "WMaxLim_SF",
                 "type": "uint16",
@@ -349,15 +325,12 @@
                 "access": "RW",
                 "desc": "Reversion limit maximum active power value.",
                 "label": "Reversion Limit Max Power",
-                "mandatory": "O",
                 "name": "WMaxLimRvrt",
                 "sf": "WMaxLim_SF",
                 "type": "uint16",
                 "units": "Pct"
             },
             {
-                "access": "R",
-                "mandatory": "O",
                 "name": "WMaxLimEnaRvrt",
                 "symbols": [
                     {
@@ -379,16 +352,13 @@
                 "access": "RW",
                 "desc": "Limit maximum active power reversion time.",
                 "label": "Limit Max Power Reversion Time",
-                "mandatory": "O",
                 "name": "WMaxLimRvrtTms",
                 "type": "uint32",
                 "units": "Secs"
             },
             {
-                "access": "R",
                 "desc": "Limit maximum active power reversion time remaining.",
                 "label": "Limit Max Power Rev Time Rem",
-                "mandatory": "O",
                 "name": "WMaxLimRvrtRem",
                 "type": "uint32",
                 "units": "Secs"
@@ -400,7 +370,6 @@
                 ],
                 "desc": "Set active power enable.",
                 "label": "Set Active Power Enable",
-                "mandatory": "O",
                 "name": "WSetEna",
                 "symbols": [
                     {
@@ -422,7 +391,6 @@
                 "access": "RW",
                 "desc": "Set active power mode.",
                 "label": "Set Active Power Mode",
-                "mandatory": "O",
                 "name": "WSetMod",
                 "symbols": [
                     {
@@ -444,7 +412,6 @@
                 "access": "RW",
                 "desc": "Active power setting value in watts.",
                 "label": "Active Power Setpoint (W)",
-                "mandatory": "O",
                 "name": "WSet",
                 "sf": "WSet_SF",
                 "type": "int32",
@@ -454,7 +421,6 @@
                 "access": "RW",
                 "desc": "Reversion active power setting value in watts.",
                 "label": "Reversion Active Power (W)",
-                "mandatory": "O",
                 "name": "WSetRvrt",
                 "sf": "WSet_SF",
                 "type": "int32",
@@ -464,7 +430,6 @@
                 "access": "RW",
                 "desc": "Active power setting value as percent.",
                 "label": "Active Power Setpoint (Pct)",
-                "mandatory": "O",
                 "name": "WSetPct",
                 "sf": "WSetPct_SF",
                 "type": "int32",
@@ -474,15 +439,12 @@
                 "access": "RW",
                 "desc": "Reversion active power setting value as percent.",
                 "label": "Reversion Active Power (Pct)",
-                "mandatory": "O",
                 "name": "WSetPctRvrt",
                 "sf": "WSetPct_SF",
                 "type": "int32",
                 "units": "Pct"
             },
             {
-                "access": "R",
-                "mandatory": "O",
                 "name": "WSetEnaRvrt",
                 "symbols": [
                     {
@@ -504,16 +466,13 @@
                 "access": "RW",
                 "desc": "Set active power reversion time.",
                 "label": "Active Power Reversion Time",
-                "mandatory": "O",
                 "name": "WSetRvrtTms",
                 "type": "uint32",
                 "units": "Secs"
             },
             {
-                "access": "R",
                 "desc": "Set active power reversion time remaining.",
                 "label": "Active Power Rev Time Rem",
-                "mandatory": "O",
                 "name": "WSetRvrtRem",
                 "type": "uint32",
                 "units": "Secs"
@@ -525,7 +484,6 @@
                 ],
                 "desc": "Set reactive power enable.",
                 "label": "Set Reactive Power Enable",
-                "mandatory": "O",
                 "name": "VarSetEna",
                 "symbols": [
                     {
@@ -547,7 +505,6 @@
                 "access": "RW",
                 "desc": "Set reactive power mode.",
                 "label": "Set Reactive Power Mode",
-                "mandatory": "O",
                 "name": "VarSetMod",
                 "symbols": [
                     {
@@ -578,8 +535,6 @@
                 "type": "enum16"
             },
             {
-                "access": "R",
-                "mandatory": "O",
                 "name": "VarSetPri",
                 "symbols": [
                     {
@@ -619,7 +574,6 @@
                 "access": "RW",
                 "desc": "Reactive power setting value in vars.",
                 "label": "Reactive Power Setpoint (Vars)",
-                "mandatory": "O",
                 "name": "VarSet",
                 "sf": "VarSet_SF",
                 "type": "int32",
@@ -629,7 +583,6 @@
                 "access": "RW",
                 "desc": "Reversion reactive power setting value in vars.",
                 "label": "Reversion Reactive Power (Vars)",
-                "mandatory": "O",
                 "name": "VarSetRvrt",
                 "sf": "VarSet_SF",
                 "type": "int32",
@@ -639,7 +592,6 @@
                 "access": "RW",
                 "desc": "Reactive power setting value as percent.",
                 "label": "Reactive Power Setpoint (Pct)",
-                "mandatory": "O",
                 "name": "VarSetPct",
                 "sf": "VarSetPct_SF",
                 "type": "int32",
@@ -649,7 +601,6 @@
                 "access": "RW",
                 "desc": "Reversion reactive power setting value as percent.",
                 "label": "Reversion Reactive Power (Pct)",
-                "mandatory": "O",
                 "name": "VarSetPctRvrt",
                 "sf": "VarSetPct_SF",
                 "symbols": [
@@ -673,16 +624,13 @@
                 "access": "RW",
                 "desc": "Set reactive power reversion time.",
                 "label": "Reactive Power Reversion Time",
-                "mandatory": "O",
                 "name": "VarSetRvrtTms",
                 "type": "uint32",
                 "units": "Secs"
             },
             {
-                "access": "R",
                 "desc": "Set reactive power reversion time remaining.",
                 "label": "Reactive Power Rev Time Rem",
-                "mandatory": "O",
                 "name": "VarSetRvrtRem",
                 "type": "uint32",
                 "units": "Secs"
@@ -710,61 +658,49 @@
                     }
                 ],
                 "type": "uint32",
-                "units": "%WMax/Sec"
+                "units": "%Max/Sec"
             },
             {
-                "access": "R",
                 "comments": [
                     "Scale Factors"
                 ],
                 "desc": "Power factor scale factor.",
                 "label": "Power Factor Scale Factor",
-                "mandatory": "O",
                 "name": "PF_SF",
                 "static": "S",
                 "type": "sunssf"
             },
             {
-                "access": "R",
                 "desc": "Limit maximum power scale factor.",
                 "label": "Limit Max Power Scale Factor",
-                "mandatory": "O",
                 "name": "WMaxLim_SF",
                 "static": "S",
                 "type": "sunssf"
             },
             {
-                "access": "R",
                 "desc": "Active power scale factor.",
                 "label": "Active Power Scale Factor",
-                "mandatory": "O",
                 "name": "WSet_SF",
                 "static": "S",
                 "type": "sunssf"
             },
             {
-                "access": "R",
                 "desc": "Active power pct scale factor.",
                 "label": "Active Power Pct Scale Factor",
-                "mandatory": "O",
                 "name": "WSetPct_SF",
                 "static": "S",
                 "type": "sunssf"
             },
             {
-                "access": "R",
                 "desc": "Reactive power scale factor.",
                 "label": "Reactive Power Scale Factor",
-                "mandatory": "O",
                 "name": "VarSet_SF",
                 "static": "S",
                 "type": "sunssf"
             },
             {
-                "access": "R",
                 "desc": "Reactive power pct scale factor.",
                 "label": "Reactive Power Pct Scale Factor",
-                "mandatory": "O",
                 "name": "VarSetPct_SF",
                 "static": "S",
                 "type": "sunssf"

--- a/json/model_705.json
+++ b/json/model_705.json
@@ -24,6 +24,7 @@
                                 "label": "Voltage Point",
                                 "mandatory": "M",
                                 "name": "V",
+                                "sf": "V_SF",
                                 "type": "uint16",
                                 "units": "VRefPct"
                             },
@@ -78,8 +79,6 @@
                         "type": "enum16"
                     },
                     {
-                        "access": "R",
-                        "mandatory": "O",
                         "name": "Pri",
                         "symbols": [
                             {
@@ -119,7 +118,6 @@
                         "access": "RW",
                         "desc": "Vref adjustment as percentage.",
                         "label": "Vref adjustment",
-                        "mandatory": "O",
                         "name": "VRef",
                         "type": "uint16"
                     },
@@ -127,7 +125,6 @@
                         "access": "RW",
                         "desc": "Enable automonous vref",
                         "label": "Autonomous Vref Enable",
-                        "mandatory": "O",
                         "name": "VRefAuto",
                         "symbols": [
                             {
@@ -143,7 +140,6 @@
                         "access": "RW",
                         "desc": "Autonomous vref time constant.",
                         "label": "Auto Vref Time Constant",
-                        "mandatory": "O",
                         "name": "VRefTms",
                         "type": "uint16"
                     },
@@ -151,7 +147,6 @@
                         "access": "RW",
                         "desc": "Open loop response time.",
                         "label": "Open Loop Response Time",
-                        "mandatory": "O",
                         "name": "RspTms",
                         "type": "uint16"
                     },
@@ -159,7 +154,6 @@
                         "access": "RW",
                         "desc": "Curve read-write access.",
                         "label": "Curve Access",
-                        "mandatory": "O",
                         "name": "ReadOnly",
                         "symbols": [
                             {
@@ -185,7 +179,6 @@
         "name": "DERVoltVar",
         "points": [
             {
-                "access": "R",
                 "desc": "DER Volt-Var model id.",
                 "label": "Model ID",
                 "mandatory": "M",
@@ -195,7 +188,6 @@
                 "value": 705
             },
             {
-                "access": "R",
                 "desc": "DER Volt-Var model length.",
                 "label": "Model Length",
                 "mandatory": "M",
@@ -226,7 +218,6 @@
                 "type": "enum16"
             },
             {
-                "access": "R",
                 "desc": "Current active  curve state.",
                 "detail": " ",
                 "label": "Active Curve State",
@@ -257,7 +248,6 @@
                 "type": "uint16"
             },
             {
-                "access": "R",
                 "desc": "Result of last adopt curve operation.",
                 "label": "Adopt Curve Result",
                 "mandatory": "M",
@@ -285,7 +275,6 @@
                 "type": "enum16"
             },
             {
-                "access": "R",
                 "desc": "Number of curve points supported.",
                 "detail": " ",
                 "label": "Number of Points",
@@ -295,7 +284,6 @@
                 "type": "uint16"
             },
             {
-                "access": "R",
                 "desc": "Number of stored curves supported.",
                 "label": "Stored Curve Count",
                 "mandatory": "M",
@@ -307,15 +295,12 @@
                 "access": "RW",
                 "desc": "Reversion time in seconds.  0 = No reversion time.",
                 "label": "Reversion Timeout",
-                "mandatory": "O",
                 "name": "RvrtTms",
                 "type": "uint32"
             },
             {
-                "access": "R",
                 "desc": "Reversion time remaining in seconds.",
                 "label": "Reversion Time Remaining",
-                "mandatory": "O",
                 "name": "RvrtRem",
                 "type": "uint32"
             },
@@ -323,12 +308,10 @@
                 "access": "RW",
                 "desc": "Default curve after reversion timeout.",
                 "label": "Reversion Curve",
-                "mandatory": "O",
                 "name": "RvrtCrv",
                 "type": "uint16"
             },
             {
-                "access": "R",
                 "desc": "Scale factor for curve voltage points.",
                 "label": "Voltage Scale Factor",
                 "mandatory": "M",
@@ -337,7 +320,6 @@
                 "type": "sunssf"
             },
             {
-                "access": "R",
                 "desc": "Scale factor for curve var points.",
                 "label": "Var  Scale Factor",
                 "mandatory": "M",

--- a/json/model_712.json
+++ b/json/model_712.json
@@ -24,8 +24,9 @@
                                 "label": "Active Power Point",
                                 "mandatory": "M",
                                 "name": "W",
+                                "sf": "W_SF",
                                 "type": "uint16",
-                                "units": "VRefPct"
+                                "units": "WMaxPct"
                             },
                             {
                                 "access": "RW",
@@ -253,6 +254,14 @@
                 "label": "Reversion curve",
                 "name": "RvrtCrv",
                 "type": "uint16"
+            },
+            {
+                "desc": "Scale factor for curve active power points.",
+                "label": "Active Power Scale Factor",
+                "mandatory": "M",
+                "name": "W_SF",
+                "static": "S",
+                "type": "sunssf"
             },
             {
                 "desc": "Scale factor for curve var points.",

--- a/json/model_713.json
+++ b/json/model_713.json
@@ -91,14 +91,14 @@
                         "label": "DC Energy Injected",
                         "name": "DCWhInj",
                         "sf": "DCWH_SF",
-                        "type": "acc64"
+                        "type": "uint64"
                     },
                     {
                         "desc": "Total cumulative DC energy absorbed for the port.",
                         "label": "DC Energy Absorbed",
                         "name": "DCWhAbs",
                         "sf": "DCWH_SF",
-                        "type": "acc64"
+                        "type": "uint64"
                     },
                     {
                         "desc": "DC port temerature.",
@@ -249,14 +249,14 @@
                 "label": "DC Energy Injected",
                 "name": "DCWhInj",
                 "sf": "DCWH_SF",
-                "type": "acc64"
+                "type": "uint64"
             },
             {
                 "desc": "Total cumulative DC energy absorbed for all ports.",
                 "label": "DC Energy Absorbed",
                 "name": "DCWhAbs",
                 "sf": "DCWH_SF",
-                "type": "acc64"
+                "type": "uint64"
             },
             {
                 "desc": "DC current scale factor.",
@@ -283,6 +283,13 @@
                 "desc": "DC energy scale factor.",
                 "label": "DC Energy Scale Factor",
                 "name": "DCWH_SF",
+                "static": "S",
+                "type": "sunssf"
+            },
+            {
+                "desc": "Temperature Scale Factor.",
+                "label": "Temperature Scale Factor",
+                "name": "Tmp_SF",
                 "static": "S",
                 "type": "sunssf"
             }

--- a/json/schema.json
+++ b/json/schema.json
@@ -82,9 +82,9 @@
 				},
 				"type": {
 					"type": "string",
-				    "enum": ["int16", "int32", "int64", "raw16", "uint16", "uint32", "acc16", "acc32", "acc64",
-				             "bitfield16", "bitfield32", "bitfield64", "enum16", "enum32", "float32", "float64",
-						     "string", "sf", "pad", "ipaddr", "ipv6addr", "eui48", "sunssf", "count"]
+				    "enum": ["int16", "int32", "int64", "raw16", "uint16", "uint32", "uint64" ,"acc16", "acc32",
+						     "acc64", "bitfield16", "bitfield32", "bitfield64", "enum16", "enum32", "float32",
+						     "float64", "string", "sf", "pad", "ipaddr", "ipv6addr", "eui48", "sunssf", "count"]
 				},
 				"value": {
 					"type": ["integer", "string"]


### PR DESCRIPTION
- Add missing scale factors for points in models 702, 705, 712, 713. (#83)
- Update
 RGra units to reflect W or A in model 704. (#84)
- Redo update accumulator points in 701, 713. (#78) (701, 713)
- Add uint64 type to schema. (#85)

See spread summary:
[wb_update.xlsx](https://github.com/sunspec/models/files/4562588/wb_update.xlsx)
