### PR TITLE
Cleanup tabs and spaces

### DIFF
--- a/json/model_705.json
+++ b/json/model_705.json
@@ -132,7 +132,7 @@
                                 "label": "Disabled Flag",
                                 "name": "DISABLED",
                                 "value": 0
-                            },                            
+                            },
                             {
                                 "desc": "Enabled flag (Disabled = 0, Enabled = 1).",
                                 "label": "Enabled Flag",

--- a/json/schema.json
+++ b/json/schema.json
@@ -1,164 +1,164 @@
 {
-	"$schema": "http://json-schema.org/draft-07/schema#",
-	"description": "JSON Schema for SunSpec information model definition",
-	"type": "object",
-	"required": ["id", "group"],
-	"properties": {
-		"id": {
-		    "type": "integer",
-		    "minimum": 1,
-		    "maximum": 65535
-		},
-		"group": {
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "description": "JSON Schema for SunSpec information model definition",
+    "type": "object",
+    "required": ["id", "group"],
+    "properties": {
+        "id": {
+            "type": "integer",
+            "minimum": 1,
+            "maximum": 65535
+        },
+        "group": {
             "$ref": "#/definitions/group"
-		},
-		"label": {
-		    "type": "string"
-		},
-		"description": {
+        },
+        "label": {
             "type": "string"
-		},
-		"detail": {
-		    "type": "string"
-		},
-		"comments": {
-			"type": "array",
-			"items": {
-			    "type": "string"
-			}
-		}
+        },
+        "description": {
+            "type": "string"
+        },
+        "detail": {
+            "type": "string"
+        },
+        "comments": {
+            "type": "array",
+            "items": {
+                "type": "string"
+            }
+        }
 
-	},
-	"definitions": {
-		"group": {
-		    "type": "object",
-			"required": ["name", "type"],
-			"properties": {
-				"name": {
-					"type": "string"
-				},
-				"type": {
-				    "enum": ["group", "sync"]
-				},
-				"count": {
-				    "type": ["integer", "string"],
-					"default": 1
-				},
-				"points": {
-				    "type": "array",
-				    "items": {
-				        "$ref": "#/definitions/point"
-				    }
-				},
-				"groups": {
-				    "type": "array",
-				    "items": {
-				        "$ref": "#/definitions/group"
-				    }
-				},
-				"label": {
-				    "type": "string"
-				},
-				"description": {
-				    "type": "string"
-				},
-				"detail": {
-				    "type": "string"
-				},
-				"comments": {
-					"type": "array",
-					"items": {
-					    "type": "string"
-					}
-				}
-			}
-		},
-		"point": {
-		    "type": "object",
-			"required": ["name", "type"],
-			"properties": {
-				"name": {
-					"type": "string"
-				},
-				"type": {
-					"type": "string",
-				    "enum": ["int16", "int32", "int64", "raw16", "uint16", "uint32", "uint64" ,"acc16", "acc32",
-						     "acc64", "bitfield16", "bitfield32", "bitfield64", "enum16", "enum32", "float32",
-						     "float64", "string", "sf", "pad", "ipaddr", "ipv6addr", "eui48", "sunssf", "count"]
-				},
-				"value": {
-					"type": ["integer", "string"]
-				},
-				"count": {
-				    "type": "integer"
-				},
-				"size": {
+    },
+    "definitions": {
+        "group": {
+            "type": "object",
+            "required": ["name", "type"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "enum": ["group", "sync"]
+                },
+                "count": {
+                    "type": ["integer", "string"],
+                    "default": 1
+                },
+                "points": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/point"
+                    }
+                },
+                "groups": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/group"
+                    }
+                },
+                "label": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "comments": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "point": {
+            "type": "object",
+            "required": ["name", "type"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "string",
+                    "enum": ["int16", "int32", "int64", "raw16", "uint16", "uint32", "uint64" ,"acc16", "acc32",
+                             "acc64", "bitfield16", "bitfield32", "bitfield64", "enum16", "enum32", "float32",
+                             "float64", "string", "sf", "pad", "ipaddr", "ipv6addr", "eui48", "sunssf", "count"]
+                },
+                "value": {
+                    "type": ["integer", "string"]
+                },
+                "count": {
                     "type": "integer"
-				},
-				"sf": {
+                },
+                "size": {
+                    "type": "integer"
+                },
+                "sf": {
                     "type": ["integer", "string"],
                     "minimum": -10,
                     "maximum": 10
-				},
-				"units": {
+                },
+                "units": {
                     "type": "string"
-				},
-				"access": {
-				    "type": "string",
+                },
+                "access": {
+                    "type": "string",
                     "enum": ["R", "RW"],
                     "default": "R"
-				},
-				"mandatory": {
-				    "type": "string",
+                },
+                "mandatory": {
+                    "type": "string",
                     "enum": ["M", "O"],
                     "default": "O"
-				},
-				"static": {
-				    "type": "string",
+                },
+                "static": {
+                    "type": "string",
                     "enum": ["D", "S"],
                     "default": "D"
-				},
-				"label": {
-				    "type": "string"
-				},
-				"description": {
-				    "type": "string"
-				},
-				"detail": {
-				    "type": "string"
-				},
-				"comments": {
-					"type": "array",
-					"items": {
-					    "type": "string"
-					}
-				}
-			}
-		},
-		"symbol": {
-		    "type": "object",
-			"required": ["name", "value"],
-			"properties": {
-				"name": {
-					"type": "string"
-				},
-				"value": {},
-				"label": {
-				    "type": "string"
-				},
-				"description": {
-				    "type": "string"
-				},
-				"detail": {
-				    "type": "string"
-				},
-				"comments": {
-					"type": "array",
-					"items": {
-					    "type": "string"
-					}
-				}
-			}
-		}
-	}
+                },
+                "label": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "comments": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        },
+        "symbol": {
+            "type": "object",
+            "required": ["name", "value"],
+            "properties": {
+                "name": {
+                    "type": "string"
+                },
+                "value": {},
+                "label": {
+                    "type": "string"
+                },
+                "description": {
+                    "type": "string"
+                },
+                "detail": {
+                    "type": "string"
+                },
+                "comments": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
 }

--- a/smdx/CHANGELOG
+++ b/smdx/CHANGELOG
@@ -8,7 +8,7 @@
 
 2012 Octoboer 23 : Flo Yee, Solectria renewables reported incorrect type of TmpAmb.  uint16 should be int16.   Models affected: E 308.
 
-2012 October 26: Bill Randle, AEI reported incorrect type for PF in the Watt-PF function.  PF should be a signed value (int16), not unsigned (unit16).  Models affected: IC 131 
+2012 October 26: Bill Randle, AEI reported incorrect type for PF in the Watt-PF function.  PF should be a signed value (int16), not unsigned (unit16).  Models affected: IC 131
 
 2012 November 1: Bob Fox, Loggerware reported use of the degree symbol problematic to denote °C.  It was agreed to use just "C" to denote degrees centrigrade in the units.  Models affected: E 303, 308
 

--- a/smdx/Makefile
+++ b/smdx/Makefile
@@ -1,21 +1,21 @@
-# 
+#
 # Copyright (c) 2011-2012, John D. Blair <jdb@moship.net>
 # All rights reserved.
-# 
+#
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # * Redistributions of source code must retain the above copyright
 #   notice, this list of conditions and the following disclaimer.
-# 
+#
 # * Redistributions in binary form must reproduce the above copyright
 #   notice, this list of conditions and the following disclaimer in the
 #   documentation and/or other materials provided with the distribution.
-# 
+#
 # * Neither the name of John D. Blair nor his lackeys may be used
 #   to endorse or promote products derived from this software
 #   without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 # "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
 # LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS

--- a/smdx/smdx_00120.xml
+++ b/smdx/smdx_00120.xml
@@ -30,7 +30,7 @@
       <point id="MaxChaRte_SF" offset="22" access="r" type="sunssf" len="1" mandatory="false"  />
       <point id="MaxDisChaRte" offset="23" access="r" type="uint16" len="1" mandatory="false" units="W" sf="MaxDisChaRte_SF"/>
       <point id="MaxDisChaRte_SF" offset="24" access="r" type="sunssf" len="1" mandatory="false"  />
-	  <point id="Pad" offset="25" access="r" type="pad" len="1" mandatory="false"  />
+      <point id="Pad" offset="25" access="r" type="pad" len="1" mandatory="false"  />
     </block>
   </model>
   <strings id="120" locale="en">

--- a/smdx/smdx_00122.xml
+++ b/smdx/smdx_00122.xml
@@ -159,7 +159,7 @@
       <description>Seconds since 01-01-2000 00:00 UTC</description>
       <notes> </notes>
     </point>
-	<point id="RtSt">
+    <point id="RtSt">
       <label>RtSt</label>
       <description>Bit Mask indicating active ride-through status.</description>
       <notes> </notes>

--- a/smdx/smdx_00201.xml
+++ b/smdx/smdx_00201.xml
@@ -301,7 +301,7 @@
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="TotVAh_SF"><description>Apparent Energy scale factor</description></point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>

--- a/smdx/smdx_00202.xml
+++ b/smdx/smdx_00202.xml
@@ -309,7 +309,7 @@
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="TotVAh_SF"><description>Apparent Energy scale factor</description></point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>

--- a/smdx/smdx_00203.xml
+++ b/smdx/smdx_00203.xml
@@ -309,7 +309,7 @@
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="TotVAh_SF"><description>Apparent Energy scale factor</description></point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>

--- a/smdx/smdx_00204.xml
+++ b/smdx/smdx_00204.xml
@@ -309,7 +309,7 @@
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="TotVAh_SF"><description>Apparent Energy scale factor</description></point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>

--- a/smdx/smdx_00211.xml
+++ b/smdx/smdx_00211.xml
@@ -291,7 +291,7 @@
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
       <description></description>

--- a/smdx/smdx_00212.xml
+++ b/smdx/smdx_00212.xml
@@ -291,7 +291,7 @@
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
       <description></description>

--- a/smdx/smdx_00213.xml
+++ b/smdx/smdx_00213.xml
@@ -291,7 +291,7 @@
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
       <description></description>

--- a/smdx/smdx_00214.xml
+++ b/smdx/smdx_00214.xml
@@ -291,7 +291,7 @@
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
       <description></description>

--- a/smdx/smdx_00220.xml
+++ b/smdx/smdx_00220.xml
@@ -127,7 +127,7 @@
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="TotVAh_SF"><description>Apparent Energy scale factor</description></point>
     <point id="TotVAhImp">
       <label>Total VA-hours Imported</label>

--- a/smdx/smdx_00401.xml
+++ b/smdx/smdx_00401.xml
@@ -6,7 +6,7 @@
       <point id="DCAhr_SF" offset="1" type="sunssf" />
       <point id="DCV_SF" offset="2" type="sunssf" />
       <point id="DCAMax" offset="3" type="uint16" sf="DCA_SF" units="A" mandatory="true" />
-      <point id="N" offset="4" type="count" mandatory="true" /> 
+      <point id="N" offset="4" type="count" mandatory="true" />
       <point id="Evt" offset="5" type="bitfield32" mandatory="true">
         <symbol id="LOW_VOLTAGE">0</symbol>
         <symbol id="LOW_POWER">1</symbol>

--- a/smdx/smdx_00803.xml
+++ b/smdx/smdx_00803.xml
@@ -557,7 +557,7 @@
         <description></description>
         <notes></notes>
       </symbol>
-    </point>      
+    </point>
     <point id="StrEvt1">
       <label>String Event 1</label>
       <description>Alarms, warnings and status values.  Bit flags.</description>

--- a/smdx/smdx_00804.xml
+++ b/smdx/smdx_00804.xml
@@ -416,7 +416,7 @@
         <description></description>
         <notes></notes>
       </symbol>
-    </point>  
+    </point>
     <point id="Evt1">
       <label>String Event 1</label>
       <description>Alarms, warnings and status values.  Bit flags.</description>
@@ -545,7 +545,7 @@
         <label>Reserved</label>
         <description>Reserved bit.</description>
         <notes>Do not implement.</notes>
-      </symbol>      
+      </symbol>
       <symbol id="OTHER_ALARM">
         <label>Other String Alarm</label>
         <description>A vendor specific alarm has occurred.</description>
@@ -560,7 +560,7 @@
         <label>Reserved</label>
         <description>Reserved bit.</description>
         <notes>Do not implement.</notes>
-      </symbol>      
+      </symbol>
       <symbol id="CONFIGURATION_ALARM">
         <label>Configuration Alarm</label>
         <description>The battery string has been configured incorrectly and will not operate as expected.</description>

--- a/smdx/smdx_00805.xml
+++ b/smdx/smdx_00805.xml
@@ -35,7 +35,7 @@
       <point id="CellTmp" offset="1" sf="Tmp_SF" units="C" type="int16" mandatory="true" />
       <point id="CellSt" offset="2" type="bitfield32">
         <symbol id="CELL_IS_BALANCING">0</symbol>
-      </point>        
+      </point>
     </block>
   </model>
 
@@ -175,7 +175,7 @@
       <label></label>
       <description>Scale factor for module temperature.</description>
       <notes></notes>
-    </point>  
+    </point>
 
     <!-- Repeating Block Strings -->
 

--- a/smdx/smdx_00807.xml
+++ b/smdx/smdx_00807.xml
@@ -205,97 +205,97 @@
       <label>Module Count</label>
       <description>Number of modules in this string.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="NModCon">
       <label>Connected Module Count</label>
       <description>Number of electrically connected modules in this string.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="ModVMax">
       <label>Max Module Voltage</label>
       <description>Maximum voltage for all modules in the string.</description>
       <notes>Measurement.</notes>
-    </point>      
+    </point>
     <point id="ModVMaxMod">
       <label>Max Module Voltage Module</label>
       <description>Module with the maximum voltage.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="ModVMin">
       <label>Min Module Voltage</label>
       <description>Minimum voltage for all modules in the string.</description>
       <notes>Measurement.</notes>
-    </point>      
+    </point>
     <point id="ModVMinMod">
       <label>Min Module Voltage Module</label>
       <description>Module with the minimum voltage.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="ModVAvg">
       <label>Average Module Voltage</label>
       <description>Average voltage for all modules in the string.</description>
       <notes>Calculation based on measurements.</notes>
-    </point>      
+    </point>
     <point id="CellVMax">
       <label>Max Cell Voltage</label>
       <description>Maximum voltage for all cells in the string.</description>
       <notes>Measurement.</notes>
-    </point>      
+    </point>
     <point id="CellVMaxMod">
       <label>Max Cell Voltage Module</label>
       <description>Module containing the cell with the maximum voltage.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="CellVMaxStk">
       <label>Max Cell Voltage Stack</label>
       <description>Stack containing the cell with the maximum voltage.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="CellVMin">
       <label>Min Cell Voltage</label>
       <description>Minimum voltage for all cells in the string.</description>
       <notes>Measurement.</notes>
-    </point>      
+    </point>
     <point id="CellVMinMod">
       <label>Min Cell Voltage Module</label>
       <description>Module containing the cell with the minimum voltage.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="CellVMinStk">
       <label>Min Cell Voltage Stack</label>
       <description>Stack containing the cell with the minimum voltage.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="CellVAvg">
       <label>Average Cell Voltage</label>
       <description>Average voltage for all cells in the string.</description>
       <notes>Calculation based on measurements.</notes>
-    </point>      
+    </point>
     <point id="TmpMax">
       <label>Max Temperature</label>
       <description>Maximum electrolyte temperature for all modules in the string.</description>
       <notes>Measurement.</notes>
-    </point>      
+    </point>
     <point id="TmpMaxMod">
       <label>Max Temperature Module</label>
       <description>Module with the maximum temperature.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="TmpMin">
       <label>Min Temperature</label>
       <description>Minimum electrolyte temperature for all modules in the string.</description>
       <notes>Measurement.</notes>
-    </point>      
+    </point>
     <point id="TmpMinMod">
       <label>Min Temperature Module</label>
       <description>Module with the minimum temperature.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="TmpAvg">
       <label>Average Temperature</label>
       <description>Average electrolyte temperature for all modules in the string.</description>
       <notes>Calculation based on measurements.</notes>
-    </point>      
+    </point>
     <point id="Evt1">
       <label>String Event 1</label>
       <description>Alarms, warnings and status values.  Bit flags.</description>
@@ -533,7 +533,7 @@
       <label>Stack Count</label>
       <description>Number of stacks in this module.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="ModSt">
       <label>Module Status</label>
       <description>Current status of the module.</description>
@@ -553,22 +553,22 @@
       <label>Module State of Charge</label>
       <description>State of charge for this module.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="ModOCV">
       <label>Open Circuit Voltage</label>
       <description>Open circuit voltage for this module.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="ModV">
       <label>External Voltage</label>
       <description>External voltage fo this module.</description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="ModCellVMax">
       <label>Maximum Cell Voltage</label>
       <description>Maximum voltage for all cells in this module.</description>
       <notes>Measurement.</notes>
-    </point>      
+    </point>
     <point id="ModCellVMaxCell">
       <label>Max Cell Voltage Cell</label>
       <description>Cell with the maximum cell voltage.</description>
@@ -578,7 +578,7 @@
       <label>Minimum Cell Voltage</label>
       <description>Minimum voltage for all cells in this module.</description>
       <notes>Measurement.</notes>
-    </point>      
+    </point>
     <point id="ModCellVMinCell">
       <label>Min Cell Voltage Cell</label>
       <description>Cell with the minimum cell voltage.</description>
@@ -588,17 +588,17 @@
       <label>Average Cell Voltage</label>
       <description>Average voltage for all cells in this module.</description>
       <notes>Calculation based on measurements.</notes>
-    </point>      
+    </point>
     <point id="ModAnoTmp">
       <label>Anolyte Temperature</label>
       <description></description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="ModCatTmp">
       <label>Catholyte Temperature</label>
       <description></description>
       <notes></notes>
-    </point>      
+    </point>
     <point id="ModConSt">
       <label>Contactor Status</label>
       <description></description>
@@ -758,7 +758,7 @@
         <description></description>
         <notes></notes>
       </symbol>
-    </point>      
+    </point>
     <point id="ModEvt1">
       <label>Module Event 1</label>
       <description>Alarms, warnings and status values.  Bit flags.</description>
@@ -913,7 +913,7 @@
         <description>The battery module has been configured incorrectly and may not operate as expected.</description>
         <notes></notes>
       </symbol>
-    </point>      
+    </point>
     <point id="ModEvt2">
       <label>Module Event 2</label>
       <description>Alarms, warnings and status values.  Bit flags.</description>
@@ -948,7 +948,7 @@
         <description>Flow approaching minimum value.</description>
         <notes></notes>
       </symbol>
-    </point>      
+    </point>
     <point id="ModConFail">
       <label>Connection Failure Reason</label>
       <description></description>

--- a/smdx/smdx_64020.xml
+++ b/smdx/smdx_64020.xml
@@ -30,15 +30,15 @@
       <point id="Sensor8" offset="24" type="uint16" sf="SensorHz_SF" units="Hz" />
       <point id="Relay1" offset="25" type="uint16"  />
       <point id="Relay2" offset="26" type="uint16"  />
-      <point id="Relay3" offset="27" type="uint16"  />	  
+      <point id="Relay3" offset="27" type="uint16"  />
       <point id="ResetAccumulators" offset="28" type="uint16"  />
-      <point id="Reset" offset="29" type="uint16"  />  
+      <point id="Reset" offset="29" type="uint16"  />
     </block>
     <block type="repeating" len="16">
       <point id="SerialNumber" offset="0" type="string" len="9" mandatory="true" />
       <point id="Firmware" offset="9" type="string" len="6" mandatory="true" />
       <point id="Hardware" offset="15" type="uint16" mandatory="true" />
-    </block>	  
+    </block>
   </model>
   <strings id="64020" locale="en">
     <model>
@@ -85,7 +85,7 @@
       <label>Voltage scale factor for the sensors</label>
       <description></description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="SensorA_SF">
       <label>Current scale factor for the sensors</label>
       <description></description>
@@ -95,37 +95,37 @@
       <label>Frequency scale factor for the sensors</label>
       <description></description>
       <notes></notes>
-    </point>  
+    </point>
     <point id="Sensor1Voltage">
       <label>Sensor1 Voltage</label>
       <description>scale of 0-10V</description>
       <notes></notes>
-    </point> 
-	<point id="Sensor2Voltage">
+    </point>
+    <point id="Sensor2Voltage">
       <label>Sensor2 Voltage</label>
       <description>scale of 0-10V</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Sensor3Voltage">
       <label>Sensor3 Voltage</label>
       <description>scale of 0-10V</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Sensor4Voltage">
       <label>Sensor4 Voltage</label>
       <description>scale of 0-10V</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Sensor5Voltage">
       <label>Sensor5 Voltage</label>
       <description>scale of 0-10V</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Sensor6Voltage">
       <label>Sensor6 Voltage</label>
       <description>scale of 0-10V</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Sensor7Voltage">
       <label>Sensor7 Voltage</label>
       <description>scale of 0-10V</description>
@@ -135,32 +135,32 @@
       <label>Sensor1 Current</label>
       <description>scale of 4-20mA</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Sensor2Current">
       <label>Sensor2 Current</label>
       <description>in 4-20mA or 4-20mA</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Sensor3Current">
       <label>Sensor3 Current</label>
       <description>in 4-20mA or 4-20mA</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Sensor4Current">
       <label>Sensor4 Current</label>
       <description>in 4-20mA or 4-20mA</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Sensor5Current">
       <label>Sensor5 Current</label>
       <description>in 4-20mA or 4-20mA</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Sensor6Current">
       <label>Sensor6 Current</label>
       <description>in 4-20mA or 4-20mA</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Sensor7Current">
       <label>Sensor7 Current</label>
       <description>in 4-20mA or 4-20mA</description>
@@ -170,46 +170,46 @@
       <label>Sensor8 frequency</label>
       <description>frequency in Hz</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Relay1">
       <label>Relay 1 state</label>
       <description></description>
       <notes></notes>
-    </point> 
-	<point id="Relay2">
+    </point>
+    <point id="Relay2">
       <label>Relay 2 state</label>
       <description></description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Relay3">
       <label>Relay 3 state</label>
       <description></description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="ResetAccumulators">
       <label>Reset the accumulators</label>
       <description>always 0 in reading, used the code 0xC0DA during the writing for resetting them</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="Reset">
       <label>Reset the system</label>
       <description>always 0 in reading, used the code 0xC0DA during the writing for resetting the system</description>
       <notes></notes>
-    </point> 
+    </point>
     <point id="SerialNumber">
       <label>Serial number</label>
       <description>strings of 16 characters</description>
       <notes></notes>
-    </point> 
+    </point>
      <point id="Firmware">
       <label>Firmware version</label>
       <description>string of 11 characters</description>
       <notes></notes>
-    </point> 
+    </point>
      <point id="Hardware">
       <label>Hardware version</label>
       <description></description>
       <notes></notes>
-    </point> 
+    </point>
   </strings>
 </sunSpecModels>


### PR DESCRIPTION
I noticed the new code had a lot of tab characters mixed with spaces in some files.
I also found quite a few training spaces which clutter code.

If you do `git diff -w` it will show "nothing changed"