### PR TITLE
fix typo in model 704 JSON

### DIFF
--- a/json/model_704.json
+++ b/json/model_704.json
@@ -526,7 +526,7 @@
             {
                 "access": "RW",
                 "comments": [
-                    "Set Reacitve Power Level"
+                    "Set Reactive Power Level"
                 ],
                 "desc": "Set reactive power enable.",
                 "label": "Set Reactive Power Enable",


### PR DESCRIPTION
Fix minor typo in Model 704 JSON.

Fixes this [issue](https://github.com/sunspec/models/issues/207).