### PR TITLE
fix to add static to model 715 for ID and L

### DIFF
--- a/json/model_715.json
+++ b/json/model_715.json
@@ -10,6 +10,7 @@
                 "mandatory": "M",
                 "name": "ID",
                 "size": 1,
+                "static": "S",
                 "type": "uint16",
                 "value": 715
             },
@@ -19,6 +20,7 @@
                 "mandatory": "M",
                 "name": "L",
                 "size": 1,
+                "static": "S",
                 "type": "uint16",
                 "value": 7
             },


### PR DESCRIPTION
For consistency among the 700 series models, add static field to model 715 for ID and L points.