### PR TITLE
Fix 2 bugs in json

### DIFF
--- a/json/model_64020.json
+++ b/json/model_64020.json
@@ -90,17 +90,17 @@
                 "units": "C"
             },
             {
+              "label": "Main Temperature",
+              "mandatory": "M",
+              "name": "MainTmp",
+              "size": 1,
+              "type": "int16",
+              "units": "C"
+            },
+            {
                 "label": "Probe Temperature",
                 "mandatory": "M",
                 "name": "ProbeTmp",
-                "size": 1,
-                "type": "int16",
-                "units": "C"
-            },
-            {
-                "label": "Main Temperature",
-                "mandatory": "M",
-                "name": "MainTmp",
                 "size": 1,
                 "type": "int16",
                 "units": "C"

--- a/json/schema.json
+++ b/json/schema.json
@@ -90,7 +90,7 @@
                     "type": "string",
                     "enum": ["int16", "int32", "int64", "raw16", "uint16", "uint32", "uint64" ,"acc16", "acc32",
                              "acc64", "bitfield16", "bitfield32", "bitfield64", "enum16", "enum32", "float32",
-                             "float64", "string", "sf", "pad", "ipaddr", "ipv6addr", "eui48", "sunssf", "count"]
+                             "float64", "string", "pad", "ipaddr", "ipv6addr", "eui48", "sunssf", "count"]
                 },
                 "value": {
                     "type": ["integer", "string"]

--- a/smdx/smdx_64020.xml
+++ b/smdx/smdx_64020.xml
@@ -8,8 +8,8 @@
       <point id="Aux2Tmp" offset="2" type="int16" units="C" />
       <point id="Aux3Tmp" offset="3" type="int16" units="C" />
       <point id="Aux4Tmp" offset="4" type="int16" units="C" />
-      <point id="ProbeTmp" offset="6" type="int16" units="C" mandatory="true" />
       <point id="MainTmp" offset="5" type="int16" units="C" mandatory="true" />
+      <point id="ProbeTmp" offset="6" type="int16" units="C" mandatory="true" />
       <point id="SensorV_SF" offset="7" type="sunssf" mandatory="true" />
       <point id="SensorA_SF" offset="8" type="sunssf" mandatory="true" />
       <point id="SensorHz_SF" offset="9" type="sunssf" mandatory="true" />
@@ -75,12 +75,12 @@
       <label>Probe Temperature</label>
       <description></description>
       <notes></notes>
-    </point>    
+    </point>
     <point id="MainTmp">
       <label>Main Temperature</label>
       <description></description>
       <notes></notes>
-    </point>    
+    </point>
     <point id="SensorV_SF">
       <label>Voltage scale factor for the sensors</label>
       <description></description>


### PR DESCRIPTION
This fixes 2 bugs in the json variant of the specification:
1. 'sf' is the name of an attribute of a point with either a [-10:10] integer of the name of a point which holds the number. It is not a type.
2. https://github.com/sunspec/models/issues/240