### PR TITLE
Cleanup xml

### DIFF
--- a/smdx/smdx_00001.xml
+++ b/smdx/smdx_00001.xml
@@ -15,42 +15,42 @@
     <model>
       <label>Common</label>
       <description>All SunSpec compliant devices must include this as the first model</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Mn">
       <label>Manufacturer</label>
       <description>Well known value registered with SunSpec for compliance</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Md">
       <label>Model</label>
       <description>Manufacturer specific value (32 chars)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Opt">
       <label>Options</label>
       <description>Manufacturer specific value (16 chars)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Vr">
       <label>Version</label>
       <description>Manufacturer specific value (16 chars)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SN">
       <label>Serial Number</label>
       <description>Manufacturer specific value (32 chars)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DA">
       <label>Device Address</label>
       <description>Modbus device address</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pad">
-      <label></label>
+      <label/>
       <description>Force even alignment</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00001.xml
+++ b/smdx/smdx_00001.xml
@@ -1,14 +1,14 @@
 <sunSpecModels v="1">
   <!-- 1: common -->
   <model id="1" len="66" name="common">
-    <block len="66">
+    <block len="66" type="fixed">
       <point id="Mn" offset="0" type="string" len="16" mandatory="true" />
       <point id="Md" offset="16" type="string" len="16" mandatory="true" />
       <point id="Opt" offset="32" type="string" len="8" />
       <point id="Vr" offset="40" type="string" len="8" />
       <point id="SN" offset="48" type="string" len="16" mandatory="true" />
-      <point id="DA" offset="64" type="uint16" access="rw" />
-      <point id="Pad" offset="65" type="pad" access="r" />
+      <point id="DA" offset="64" type="uint16" len="1" access="rw" />
+      <point id="Pad" offset="65" type="pad" len="1" />
     </block>
   </model>
   <strings id="1" locale="en">

--- a/smdx/smdx_00002.xml
+++ b/smdx/smdx_00002.xml
@@ -1,18 +1,18 @@
 <sunSpecModels v="1">
   <!-- 2: basic aggregator -->
   <model id="2" len="14" name="aggregator">
-    <block len="14">
-      <point id="AID" offset="0" type="uint16" mandatory="true" />
-      <point id="N" offset="1" type="uint16" mandatory="true" />
-      <point id="UN" offset="2" type="uint16" mandatory="true" />
-      <point id="St" offset="3" type="enum16" mandatory="true">
+    <block len="14" type="fixed">
+      <point id="AID" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="N" offset="1" type="uint16" len="1" mandatory="true" />
+      <point id="UN" offset="2" type="uint16" len="1" mandatory="true" />
+      <point id="St" offset="3" type="enum16" len="1" mandatory="true" >
         <symbol id="OFF">1</symbol>
         <symbol id="ON">2</symbol>
         <symbol id="FULL">3</symbol>
         <symbol id="FAULT">4</symbol>
       </point>
-      <point id="StVnd" offset="4" type="enum16" />
-      <point id="Evt" offset="5" type="bitfield32" mandatory="true" >
+      <point id="StVnd" offset="4" type="enum16" len="1" />
+      <point id="Evt" offset="5" type="bitfield32" len="2" mandatory="true" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="INPUT_OVER_VOLTAGE">1</symbol>
         <symbol id="RESERVED_2">2</symbol>
@@ -35,16 +35,16 @@
         <symbol id="OUTPUT_UNDER_VOLTAGE">19</symbol>
         <symbol id="TEST_FAILED">20</symbol>
       </point>
-      <point id="EvtVnd" offset="7" type="bitfield32" />
-      <point id="Ctl" offset="9" type="enum16" >
+      <point id="EvtVnd" offset="7" type="bitfield32" len="2" />
+      <point id="Ctl" offset="9" type="enum16" len="1" >
         <symbol id="NONE">0</symbol>
         <symbol id="AUTOMATIC">1</symbol>
         <symbol id="FORCE_OFF">2</symbol>
         <symbol id="TEST">3</symbol>
         <symbol id="THROTTLE">4</symbol>
       </point>
-      <point id="CtlVnd" offset="10" type="enum32" />
-      <point id="CtlVl" offset="12" type="enum32" />
+      <point id="CtlVnd" offset="10" type="enum32" len="2" />
+      <point id="CtlVl" offset="12" type="enum32" len="2" />
     </block>
   </model>
   <strings id="2" locale="en">

--- a/smdx/smdx_00002.xml
+++ b/smdx/smdx_00002.xml
@@ -51,57 +51,57 @@
     <model>
       <label>Basic Aggregator</label>
       <description>Aggregates a collection of models for a given model id</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="AID">
       <label>AID</label>
       <description>Aggregated model id</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="N">
       <label>N</label>
       <description>Number of aggregated models</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="UN">
       <label>UN</label>
       <description>Update Number.  Incrementing number each time the mapping is changed.  If the number is not changed from the last reading the direct access to a specific offset will result in reading the same logical model as before.  Otherwise the entire model must be read to refresh the changes</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="St">
       <label>Status</label>
       <description>Enumerated status code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StVnd">
       <label>Vendor Status</label>
       <description>Vendor specific status code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Event Code</label>
       <description>Bitmask event code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd">
       <label>Vendor Event Code</label>
       <description>Vendor specific event code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ctl">
       <label>Control</label>
       <description>Control register for all aggregated devices</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CtlVnd">
       <label>Vendor Control</label>
       <description>Vendor control register for all aggregated devices</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CtlVl">
       <label>Control Value</label>
       <description>Numerical value used as a parameter to the control</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00003.xml
+++ b/smdx/smdx_00003.xml
@@ -1,71 +1,71 @@
 <sunSpecModels v="1">
   <!-- 3: secure dataset read request model -->
   <model id="3" len="59">
-    <block len="58">
-      <point id="X" offset="0" type="uint16" access="rw" mandatory="true"/>
-      <point id="Off1" offset="1" type="uint16" access="rw" mandatory="true" />
-      <point id="Off2" offset="2" type="uint16" access="rw" mandatory="true" />
-      <point id="Off3" offset="3" type="uint16" access="rw" mandatory="true" />
-      <point id="Off4" offset="4" type="uint16" access="rw" mandatory="true" />
-      <point id="Off5" offset="5" type="uint16" access="rw" mandatory="true" />
-      <point id="Off6" offset="6" type="uint16" access="rw" mandatory="true" />
-      <point id="Off7" offset="7" type="uint16" access="rw" mandatory="true" />
-      <point id="Off8" offset="8" type="uint16" access="rw" mandatory="true" />
-      <point id="Off9" offset="9" type="uint16" access="rw" mandatory="true" />
-      <point id="Off10" offset="10" type="uint16" access="rw" mandatory="true" />
-      <point id="Off11" offset="11" type="uint16" access="rw" mandatory="true" />
-      <point id="Off12" offset="12" type="uint16" access="rw" mandatory="true" />
-      <point id="Off13" offset="13" type="uint16" access="rw" mandatory="true" />
-      <point id="Off14" offset="14" type="uint16" access="rw" mandatory="true" />
-      <point id="Off15" offset="15" type="uint16" access="rw" mandatory="true" />
-      <point id="Off16" offset="16" type="uint16" access="rw" mandatory="true" />
-      <point id="Off17" offset="17" type="uint16" access="rw" mandatory="true" />
-      <point id="Off18" offset="18" type="uint16" access="rw" mandatory="true" />
-      <point id="Off19" offset="19" type="uint16" access="rw" mandatory="true" />
-      <point id="Off20" offset="20" type="uint16" access="rw" mandatory="true" />
-      <point id="Off21" offset="21" type="uint16" access="rw" mandatory="true" />
-      <point id="Off22" offset="22" type="uint16" access="rw" mandatory="true" />
-      <point id="Off23" offset="23" type="uint16" access="rw" mandatory="true" />
-      <point id="Off24" offset="24" type="uint16" access="rw" mandatory="true" />
-      <point id="Off25" offset="25" type="uint16" access="rw" mandatory="true" />
-      <point id="Off26" offset="26" type="uint16" access="rw" mandatory="true" />
-      <point id="Off27" offset="27" type="uint16" access="rw" mandatory="true" />
-      <point id="Off28" offset="28" type="uint16" access="rw" mandatory="true" />
-      <point id="Off29" offset="29" type="uint16" access="rw" mandatory="true" />
-      <point id="Off30" offset="30" type="uint16" access="rw" mandatory="true" />
-      <point id="Off31" offset="31" type="uint16" access="rw" mandatory="true" />
-      <point id="Off32" offset="32" type="uint16" access="rw" mandatory="true" />
-      <point id="Off33" offset="33" type="uint16" access="rw" mandatory="true" />
-      <point id="Off34" offset="34" type="uint16" access="rw" mandatory="true" />
-      <point id="Off35" offset="35" type="uint16" access="rw" mandatory="true" />
-      <point id="Off36" offset="36" type="uint16" access="rw" mandatory="true" />
-      <point id="Off37" offset="37" type="uint16" access="rw" mandatory="true" />
-      <point id="Off38" offset="38" type="uint16" access="rw" mandatory="true" />
-      <point id="Off39" offset="39" type="uint16" access="rw" mandatory="true" />
-      <point id="Off40" offset="40" type="uint16" access="rw" mandatory="true" />
-      <point id="Off41" offset="41" type="uint16" access="rw" mandatory="true" />
-      <point id="Off42" offset="42" type="uint16" access="rw" mandatory="true" />
-      <point id="Off43" offset="43" type="uint16" access="rw" mandatory="true" />
-      <point id="Off44" offset="44" type="uint16" access="rw" mandatory="true" />
-      <point id="Off45" offset="45" type="uint16" access="rw" mandatory="true" />
-      <point id="Off46" offset="46" type="uint16" access="rw" mandatory="true" />
-      <point id="Off47" offset="47" type="uint16" access="rw" mandatory="true" />
-      <point id="Off48" offset="48" type="uint16" access="rw" mandatory="true" />
-      <point id="Off49" offset="49" type="uint16" access="rw" mandatory="true" />
-      <point id="Off50" offset="50" type="uint16" access="rw" mandatory="true" />
-      <point id="Ts"   offset="51" type="uint32" access="rw" mandatory="true" />
-      <point id="Ms" offset="53" type="uint16" access="rw" mandatory="true" />
-      <point id="Seq" offset="54" type="uint16" access="rw" mandatory="true" />
-      <point id="Role" offset="55" type="uint16" access="rw" mandatory="true" />
-      <point id="Alg"   offset="56" type="enum16" access="r" mandatory="true">
+    <block len="58" type="fixed">
+      <point id="X" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off1" offset="1" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off2" offset="2" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off3" offset="3" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off4" offset="4" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off5" offset="5" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off6" offset="6" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off7" offset="7" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off8" offset="8" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off9" offset="9" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off10" offset="10" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off11" offset="11" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off12" offset="12" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off13" offset="13" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off14" offset="14" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off15" offset="15" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off16" offset="16" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off17" offset="17" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off18" offset="18" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off19" offset="19" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off20" offset="20" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off21" offset="21" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off22" offset="22" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off23" offset="23" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off24" offset="24" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off25" offset="25" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off26" offset="26" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off27" offset="27" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off28" offset="28" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off29" offset="29" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off30" offset="30" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off31" offset="31" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off32" offset="32" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off33" offset="33" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off34" offset="34" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off35" offset="35" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off36" offset="36" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off37" offset="37" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off38" offset="38" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off39" offset="39" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off40" offset="40" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off41" offset="41" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off42" offset="42" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off43" offset="43" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off44" offset="44" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off45" offset="45" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off46" offset="46" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off47" offset="47" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off48" offset="48" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off49" offset="49" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off50" offset="50" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Ts" offset="51" type="uint32" len="2" access="rw" mandatory="true" />
+      <point id="Ms" offset="53" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Seq" offset="54" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Role" offset="55" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Alg" offset="56" type="enum16" len="1" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="AES-GMAC-64">1</symbol>
         <symbol id="ECC-256">2</symbol>
       </point>
-      <point id="N" offset="57" type="uint16" access="r" mandatory="true" />
+      <point id="N" offset="57" type="uint16" len="1" mandatory="true" />
     </block>
-    <block type="repeating" len="1">
-      <point id="DS" offset="0" type="uint16" access="r" mandatory="true" />
+    <block len="1" type="repeating">
+      <point id="DS" offset="0" type="uint16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="3" locale="en">

--- a/smdx/smdx_00003.xml
+++ b/smdx/smdx_00003.xml
@@ -77,17 +77,17 @@
     <point id="Off1">
       <label>Offset1</label>
       <description>Offset of value to read</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ts">
       <label>Timestamp</label>
       <description>Timestamp value is the number of seconds since January 1, 2000</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ms">
       <label>Milliseconds</label>
       <description>Millisecond counter 0-999</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Alg">
       <label>Algorithm</label>
@@ -101,12 +101,12 @@
       <symbol id="AES-GMAC-64">
         <label>AES-GMAC-64</label>
         <description>64 bit AES signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ECC-256">
         <label>ECC-256</label>
         <description>256 bit ECC signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="N">

--- a/smdx/smdx_00004.xml
+++ b/smdx/smdx_00004.xml
@@ -82,16 +82,16 @@
     <model>
       <label>Secure Dataset Read Response</label>
       <description>Compute a digital signature over a specified set of data registers</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Alm">
       <label>Alarm</label>
       <description>Bitmask alarm code</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NONE">
         <label>NONE</label>
         <description>No Alarms</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ALM">
         <label>ALARM</label>
@@ -102,12 +102,12 @@
     <point id="Ts">
       <label>Timestamp</label>
       <description>Timestamp value is the number of seconds since January 1, 2000</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ms">
       <label>Milliseconds</label>
       <description>Millisecond counter 0-999</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Alg">
       <label>Algorithm</label>
@@ -121,27 +121,27 @@
       <symbol id="AES-GMAC-64">
         <label>AES-GMAC-64</label>
         <description>64 bit AES signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ECC-256">
         <label>ECC-256</label>
         <description>256 bit ECC signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Sts">
       <label>Status</label>
       <description>Status of last read operation</description>
-      <notes></notes>
+      <notes/>
       <symbol id="SUCCESS">
         <label>SUCCESS</label>
         <description>Operation succeeded</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DS">
         <label>DS</label>
         <description>Operation failed digital signature check</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ACL">
         <label>ACL</label>
@@ -177,7 +177,7 @@
     <point id="RqSeq">
       <label>Request Sequence</label>
       <description>Sequence number from the request</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Seq">
       <label>Sequence</label>

--- a/smdx/smdx_00004.xml
+++ b/smdx/smdx_00004.xml
@@ -1,81 +1,81 @@
 <sunSpecModels v="1">
   <!-- 4: secure dataset read response model -->
   <model id="4" len="61">
-    <block len="60">
-      <point id="RqSeq" offset="0" type="uint16" access="r" mandatory="true"/>
-      <point id="Sts" offset="1" type="enum16" access="r" mandatory="true">
+    <block len="60" type="fixed">
+      <point id="RqSeq" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="Sts" offset="1" type="enum16" len="1" mandatory="true" >
         <symbol id="SUCCESS">0</symbol>
         <symbol id="DS">1</symbol>
         <symbol id="ACL">2</symbol>
         <symbol id="OFF">3</symbol>
       </point>
-      <point id="X" offset="2" type="uint16" access="r" mandatory="true"/>
-      <point id="Val1" offset="3" type="uint16" access="r" mandatory="true" />
-      <point id="Val2" offset="4" type="uint16" access="r" mandatory="true" />
-      <point id="Val3" offset="5" type="uint16" access="r" mandatory="true" />
-      <point id="Val4" offset="6" type="uint16" access="r" mandatory="true" />
-      <point id="Val5" offset="7" type="uint16" access="r" mandatory="true" />
-      <point id="Val6" offset="8" type="uint16" access="r" mandatory="true" />
-      <point id="Val7" offset="9" type="uint16" access="r" mandatory="true" />
-      <point id="Val8" offset="10" type="uint16" access="r" mandatory="true" />
-      <point id="Val9" offset="11" type="uint16" access="r" mandatory="true" />
-      <point id="Val10" offset="12" type="uint16" access="r" mandatory="true" />
-      <point id="Val11" offset="13" type="uint16" access="r" mandatory="true" />
-      <point id="Val12" offset="14" type="uint16" access="r" mandatory="true" />
-      <point id="Val13" offset="15" type="uint16" access="r" mandatory="true" />
-      <point id="Val14" offset="16" type="uint16" access="r" mandatory="true" />
-      <point id="Val15" offset="17" type="uint16" access="r" mandatory="true" />
-      <point id="Val16" offset="18" type="uint16" access="r" mandatory="true" />
-      <point id="Val17" offset="19" type="uint16" access="r" mandatory="true" />
-      <point id="Val18" offset="20" type="uint16" access="r" mandatory="true" />
-      <point id="Val19" offset="21" type="uint16" access="r" mandatory="true" />
-      <point id="Val20" offset="22" type="uint16" access="r" mandatory="true" />
-      <point id="Val21" offset="23" type="uint16" access="r" mandatory="true" />
-      <point id="Val22" offset="24" type="uint16" access="r" mandatory="true" />
-      <point id="Val23" offset="25" type="uint16" access="r" mandatory="true" />
-      <point id="Val24" offset="26" type="uint16" access="r" mandatory="true" />
-      <point id="Val25" offset="27" type="uint16" access="r" mandatory="true" />
-      <point id="Val26" offset="28" type="uint16" access="r" mandatory="true" />
-      <point id="Val27" offset="29" type="uint16" access="r" mandatory="true" />
-      <point id="Val28" offset="30" type="uint16" access="r" mandatory="true" />
-      <point id="Val29" offset="31" type="uint16" access="r" mandatory="true" />
-      <point id="Val30" offset="32" type="uint16" access="r" mandatory="true" />
-      <point id="Val31" offset="33" type="uint16" access="r" mandatory="true" />
-      <point id="Val32" offset="34" type="uint16" access="r" mandatory="true" />
-      <point id="Val33" offset="35" type="uint16" access="r" mandatory="true" />
-      <point id="Val34" offset="36" type="uint16" access="r" mandatory="true" />
-      <point id="Val35" offset="37" type="uint16" access="r" mandatory="true" />
-      <point id="Val36" offset="38" type="uint16" access="r" mandatory="true" />
-      <point id="Val37" offset="39" type="uint16" access="r" mandatory="true" />
-      <point id="Val38" offset="40" type="uint16" access="r" mandatory="true" />
-      <point id="Val39" offset="41" type="uint16" access="r" mandatory="true" />
-      <point id="Val40" offset="42" type="uint16" access="r" mandatory="true" />
-      <point id="Val41" offset="43" type="uint16" access="r" mandatory="true" />
-      <point id="Val42" offset="44" type="uint16" access="r" mandatory="true" />
-      <point id="Val43" offset="45" type="uint16" access="r" mandatory="true" />
-      <point id="Val44" offset="46" type="uint16" access="r" mandatory="true" />
-      <point id="Val45" offset="47" type="uint16" access="r" mandatory="true" />
-      <point id="Val46" offset="48" type="uint16" access="r" mandatory="true" />
-      <point id="Val47" offset="49" type="uint16" access="r" mandatory="true" />
-      <point id="Val48" offset="50" type="uint16" access="r" mandatory="true" />
-      <point id="Val49" offset="51" type="uint16" access="r" mandatory="true" />
-      <point id="Val50" offset="52" type="uint16" access="r" mandatory="true" />
-      <point id="Ts"   offset="53" type="uint32" access="r" mandatory="true" />
-      <point id="Ms" offset="55" type="uint16" access="r" mandatory="true" />
-      <point id="Seq" offset="56" type="uint16" access="r" mandatory="true" />
-      <point id="Alm" offset="57" type="enum16" mandatory="true">
+      <point id="X" offset="2" type="uint16" len="1" mandatory="true" />
+      <point id="Val1" offset="3" type="uint16" len="1" mandatory="true" />
+      <point id="Val2" offset="4" type="uint16" len="1" mandatory="true" />
+      <point id="Val3" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="Val4" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Val5" offset="7" type="uint16" len="1" mandatory="true" />
+      <point id="Val6" offset="8" type="uint16" len="1" mandatory="true" />
+      <point id="Val7" offset="9" type="uint16" len="1" mandatory="true" />
+      <point id="Val8" offset="10" type="uint16" len="1" mandatory="true" />
+      <point id="Val9" offset="11" type="uint16" len="1" mandatory="true" />
+      <point id="Val10" offset="12" type="uint16" len="1" mandatory="true" />
+      <point id="Val11" offset="13" type="uint16" len="1" mandatory="true" />
+      <point id="Val12" offset="14" type="uint16" len="1" mandatory="true" />
+      <point id="Val13" offset="15" type="uint16" len="1" mandatory="true" />
+      <point id="Val14" offset="16" type="uint16" len="1" mandatory="true" />
+      <point id="Val15" offset="17" type="uint16" len="1" mandatory="true" />
+      <point id="Val16" offset="18" type="uint16" len="1" mandatory="true" />
+      <point id="Val17" offset="19" type="uint16" len="1" mandatory="true" />
+      <point id="Val18" offset="20" type="uint16" len="1" mandatory="true" />
+      <point id="Val19" offset="21" type="uint16" len="1" mandatory="true" />
+      <point id="Val20" offset="22" type="uint16" len="1" mandatory="true" />
+      <point id="Val21" offset="23" type="uint16" len="1" mandatory="true" />
+      <point id="Val22" offset="24" type="uint16" len="1" mandatory="true" />
+      <point id="Val23" offset="25" type="uint16" len="1" mandatory="true" />
+      <point id="Val24" offset="26" type="uint16" len="1" mandatory="true" />
+      <point id="Val25" offset="27" type="uint16" len="1" mandatory="true" />
+      <point id="Val26" offset="28" type="uint16" len="1" mandatory="true" />
+      <point id="Val27" offset="29" type="uint16" len="1" mandatory="true" />
+      <point id="Val28" offset="30" type="uint16" len="1" mandatory="true" />
+      <point id="Val29" offset="31" type="uint16" len="1" mandatory="true" />
+      <point id="Val30" offset="32" type="uint16" len="1" mandatory="true" />
+      <point id="Val31" offset="33" type="uint16" len="1" mandatory="true" />
+      <point id="Val32" offset="34" type="uint16" len="1" mandatory="true" />
+      <point id="Val33" offset="35" type="uint16" len="1" mandatory="true" />
+      <point id="Val34" offset="36" type="uint16" len="1" mandatory="true" />
+      <point id="Val35" offset="37" type="uint16" len="1" mandatory="true" />
+      <point id="Val36" offset="38" type="uint16" len="1" mandatory="true" />
+      <point id="Val37" offset="39" type="uint16" len="1" mandatory="true" />
+      <point id="Val38" offset="40" type="uint16" len="1" mandatory="true" />
+      <point id="Val39" offset="41" type="uint16" len="1" mandatory="true" />
+      <point id="Val40" offset="42" type="uint16" len="1" mandatory="true" />
+      <point id="Val41" offset="43" type="uint16" len="1" mandatory="true" />
+      <point id="Val42" offset="44" type="uint16" len="1" mandatory="true" />
+      <point id="Val43" offset="45" type="uint16" len="1" mandatory="true" />
+      <point id="Val44" offset="46" type="uint16" len="1" mandatory="true" />
+      <point id="Val45" offset="47" type="uint16" len="1" mandatory="true" />
+      <point id="Val46" offset="48" type="uint16" len="1" mandatory="true" />
+      <point id="Val47" offset="49" type="uint16" len="1" mandatory="true" />
+      <point id="Val48" offset="50" type="uint16" len="1" mandatory="true" />
+      <point id="Val49" offset="51" type="uint16" len="1" mandatory="true" />
+      <point id="Val50" offset="52" type="uint16" len="1" mandatory="true" />
+      <point id="Ts" offset="53" type="uint32" len="2" mandatory="true" />
+      <point id="Ms" offset="55" type="uint16" len="1" mandatory="true" />
+      <point id="Seq" offset="56" type="uint16" len="1" mandatory="true" />
+      <point id="Alm" offset="57" type="enum16" len="1" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="ALM">1</symbol>
       </point>
-      <point id="Alg"   offset="58" type="enum16" access="r" mandatory="true">
+      <point id="Alg" offset="58" type="enum16" len="1" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="AES-GMAC-64">1</symbol>
         <symbol id="ECC-256">2</symbol>
       </point>
-      <point id="N" offset="59" type="uint16" access="r" mandatory="true" />
+      <point id="N" offset="59" type="uint16" len="1" mandatory="true" />
     </block>
-    <block type="repeating" len="1">
-      <point id="DS" offset="0" type="uint16" access="r" mandatory="true" />
+    <block len="1" type="repeating">
+      <point id="DS" offset="0" type="uint16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="4" locale="en">

--- a/smdx/smdx_00005.xml
+++ b/smdx/smdx_00005.xml
@@ -102,7 +102,7 @@
     <model>
       <label>Secure Write Request</label>
       <description>Include a digital signature along with the control data</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Alg">
       <label>Algorithm</label>
@@ -116,23 +116,23 @@
       <symbol id="AES-GMAC-64">
         <label>AES-GMAC-64</label>
         <description>64 bit AES signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ECC-256">
         <label>ECC-256</label>
         <description>256 bit ECC signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Ts">
       <label>Timestamp</label>
       <description>Timestamp value is the number of seconds since January 1, 2000</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ms">
       <label>Milliseconds</label>
       <description>Millisecond counter 0-999</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Seq">
       <label>Sequence</label>
@@ -157,12 +157,12 @@
     <point id="Off1">
       <label>Offset1</label>
       <description>Offset of control register to write value to</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Val1">
       <label>Value1</label>
       <description>Value to write to control register at offset</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DS">
       <label>DS</label>

--- a/smdx/smdx_00005.xml
+++ b/smdx/smdx_00005.xml
@@ -1,101 +1,101 @@
 <sunSpecModels v="1">
   <!-- 5: security write request model -->
   <model id="5" len="89">
-    <block len="88">
-      <point id="X" offset="0" type="uint16" access="rw" mandatory="true"/>
-      <point id="Off1" offset="1" type="uint16" access="rw" mandatory="true" />
-      <point id="Val1" offset="2" type="uint16" access="rw" mandatory="true" />
-      <point id="Off2" offset="3" type="uint16" access="rw" mandatory="true" />
-      <point id="Val2" offset="4" type="uint16" access="rw" mandatory="true" />
-      <point id="Off3" offset="5" type="uint16" access="rw" mandatory="true" />
-      <point id="Val3" offset="6" type="uint16" access="rw" mandatory="true" />
-      <point id="Off4" offset="7" type="uint16" access="rw" mandatory="true" />
-      <point id="Val4" offset="8" type="uint16" access="rw" mandatory="true" />
-      <point id="Off5" offset="9" type="uint16" access="rw" mandatory="true" />
-      <point id="Val5" offset="10" type="uint16" access="rw" mandatory="true" />
-      <point id="Off6" offset="11" type="uint16" access="rw" mandatory="true" />
-      <point id="Val6" offset="12" type="uint16" access="rw" mandatory="true" />
-      <point id="Off7" offset="13" type="uint16" access="rw" mandatory="true" />
-      <point id="Val7" offset="14" type="uint16" access="rw" mandatory="true" />
-      <point id="Off8" offset="15" type="uint16" access="rw" mandatory="true" />
-      <point id="Val8" offset="16" type="uint16" access="rw" mandatory="true" />
-      <point id="Off9" offset="17" type="uint16" access="rw" mandatory="true" />
-      <point id="Val9" offset="18" type="uint16" access="rw" mandatory="true" />
-      <point id="Off10" offset="19" type="uint16" access="rw" mandatory="true" />
-      <point id="Val10" offset="20" type="uint16" access="rw" mandatory="true" />
-      <point id="Off11" offset="21" type="uint16" access="rw" mandatory="true" />
-      <point id="Val11" offset="22" type="uint16" access="rw" mandatory="true" />
-      <point id="Off12" offset="23" type="uint16" access="rw" mandatory="true" />
-      <point id="Val12" offset="24" type="uint16" access="rw" mandatory="true" />
-      <point id="Off13" offset="25" type="uint16" access="rw" mandatory="true" />
-      <point id="Val13" offset="26" type="uint16" access="rw" mandatory="true" />
-      <point id="Off14" offset="27" type="uint16" access="rw" mandatory="true" />
-      <point id="Val14" offset="28" type="uint16" access="rw" mandatory="true" />
-      <point id="Off15" offset="29" type="uint16" access="rw" mandatory="true" />
-      <point id="Val15" offset="30" type="uint16" access="rw" mandatory="true" />
-      <point id="Off16" offset="31" type="uint16" access="rw" mandatory="true" />
-      <point id="Val16" offset="32" type="uint16" access="rw" mandatory="true" />
-      <point id="Off17" offset="33" type="uint16" access="rw" mandatory="true" />
-      <point id="Val17" offset="34" type="uint16" access="rw" mandatory="true" />
-      <point id="Off18" offset="35" type="uint16" access="rw" mandatory="true" />
-      <point id="Val18" offset="36" type="uint16" access="rw" mandatory="true" />
-      <point id="Off19" offset="37" type="uint16" access="rw" mandatory="true" />
-      <point id="Val19" offset="38" type="uint16" access="rw" mandatory="true" />
-      <point id="Off20" offset="39" type="uint16" access="rw" mandatory="true" />
-      <point id="Val20" offset="40" type="uint16" access="rw" mandatory="true" />
-      <point id="Off21" offset="41" type="uint16" access="rw" mandatory="true" />
-      <point id="Val21" offset="42" type="uint16" access="rw" mandatory="true" />
-      <point id="Off22" offset="43" type="uint16" access="rw" mandatory="true" />
-      <point id="Val22" offset="44" type="uint16" access="rw" mandatory="true" />
-      <point id="Off23" offset="45" type="uint16" access="rw" mandatory="true" />
-      <point id="Val23" offset="46" type="uint16" access="rw" mandatory="true" />
-      <point id="Off24" offset="47" type="uint16" access="rw" mandatory="true" />
-      <point id="Val24" offset="48" type="uint16" access="rw" mandatory="true" />
-      <point id="Off25" offset="49" type="uint16" access="rw" mandatory="true" />
-      <point id="Val25" offset="50" type="uint16" access="rw" mandatory="true" />
-      <point id="Off26" offset="51" type="uint16" access="rw" mandatory="true" />
-      <point id="Val26" offset="52" type="uint16" access="rw" mandatory="true" />
-      <point id="Off27" offset="53" type="uint16" access="rw" mandatory="true" />
-      <point id="Val27" offset="54" type="uint16" access="rw" mandatory="true" />
-      <point id="Off28" offset="55" type="uint16" access="rw" mandatory="true" />
-      <point id="Val28" offset="56" type="uint16" access="rw" mandatory="true" />
-      <point id="Off29" offset="57" type="uint16" access="rw" mandatory="true" />
-      <point id="Val29" offset="58" type="uint16" access="rw" mandatory="true" />
-      <point id="Off30" offset="59" type="uint16" access="rw" mandatory="true" />
-      <point id="Val30" offset="60" type="uint16" access="rw" mandatory="true" />
-      <point id="Off31" offset="61" type="uint16" access="rw" mandatory="true" />
-      <point id="Val31" offset="62" type="uint16" access="rw" mandatory="true" />
-      <point id="Off32" offset="63" type="uint16" access="rw" mandatory="true" />
-      <point id="Val32" offset="64" type="uint16" access="rw" mandatory="true" />
-      <point id="Off33" offset="65" type="uint16" access="rw" mandatory="true" />
-      <point id="Val33" offset="66" type="uint16" access="rw" mandatory="true" />
-      <point id="Off34" offset="67" type="uint16" access="rw" mandatory="true" />
-      <point id="Val34" offset="68" type="uint16" access="rw" mandatory="true" />
-      <point id="Off35" offset="69" type="uint16" access="rw" mandatory="true" />
-      <point id="Val35" offset="70" type="uint16" access="rw" mandatory="true" />
-      <point id="Off36" offset="71" type="uint16" access="rw" mandatory="true" />
-      <point id="Val36" offset="72" type="uint16" access="rw" mandatory="true" />
-      <point id="Off37" offset="73" type="uint16" access="rw" mandatory="true" />
-      <point id="Val37" offset="74" type="uint16" access="rw" mandatory="true" />
-      <point id="Off38" offset="75" type="uint16" access="rw" mandatory="true" />
-      <point id="Val38" offset="76" type="uint16" access="rw" mandatory="true" />
-      <point id="Off39" offset="77" type="uint16" access="rw" mandatory="true" />
-      <point id="Val39" offset="78" type="uint16" access="rw" mandatory="true" />
-      <point id="Off40" offset="79" type="uint16" access="rw" mandatory="true" />
-      <point id="Val40" offset="80" type="uint16" access="rw" mandatory="true" />
-      <point id="Ts"   offset="81" type="uint32" access="rw" mandatory="true" />
-      <point id="Ms" offset="83" type="uint16" access="rw" mandatory="true" />
-      <point id="Seq" offset="84" type="uint16" access="rw" mandatory="true" />
-      <point id="Role" offset="85" type="uint16" access="rw" mandatory="true" />
-      <point id="Alg"   offset="86" type="enum16" access="rw" mandatory="true">
+    <block len="88" type="fixed">
+      <point id="X" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off1" offset="1" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val1" offset="2" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off2" offset="3" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val2" offset="4" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off3" offset="5" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val3" offset="6" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off4" offset="7" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val4" offset="8" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off5" offset="9" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val5" offset="10" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off6" offset="11" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val6" offset="12" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off7" offset="13" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val7" offset="14" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off8" offset="15" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val8" offset="16" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off9" offset="17" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val9" offset="18" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off10" offset="19" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val10" offset="20" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off11" offset="21" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val11" offset="22" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off12" offset="23" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val12" offset="24" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off13" offset="25" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val13" offset="26" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off14" offset="27" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val14" offset="28" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off15" offset="29" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val15" offset="30" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off16" offset="31" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val16" offset="32" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off17" offset="33" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val17" offset="34" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off18" offset="35" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val18" offset="36" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off19" offset="37" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val19" offset="38" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off20" offset="39" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val20" offset="40" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off21" offset="41" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val21" offset="42" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off22" offset="43" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val22" offset="44" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off23" offset="45" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val23" offset="46" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off24" offset="47" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val24" offset="48" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off25" offset="49" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val25" offset="50" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off26" offset="51" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val26" offset="52" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off27" offset="53" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val27" offset="54" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off28" offset="55" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val28" offset="56" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off29" offset="57" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val29" offset="58" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off30" offset="59" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val30" offset="60" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off31" offset="61" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val31" offset="62" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off32" offset="63" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val32" offset="64" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off33" offset="65" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val33" offset="66" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off34" offset="67" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val34" offset="68" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off35" offset="69" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val35" offset="70" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off36" offset="71" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val36" offset="72" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off37" offset="73" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val37" offset="74" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off38" offset="75" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val38" offset="76" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off39" offset="77" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val39" offset="78" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off40" offset="79" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val40" offset="80" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Ts" offset="81" type="uint32" len="2" access="rw" mandatory="true" />
+      <point id="Ms" offset="83" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Seq" offset="84" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Role" offset="85" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Alg" offset="86" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="AES-GMAC-64">1</symbol>
         <symbol id="ECC-256">2</symbol>
       </point>
-      <point id="N" offset="87" type="uint16" access="rw" mandatory="true" />
+      <point id="N" offset="87" type="uint16" len="1" access="rw" mandatory="true" />
     </block>
-    <block type="repeating" len="1">
-      <point id="DS" offset="0" type="uint16" access="rw" mandatory="true" />
+    <block len="1" type="repeating">
+      <point id="DS" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
     </block>
   </model>
   <strings id="5" locale="en">

--- a/smdx/smdx_00006.xml
+++ b/smdx/smdx_00006.xml
@@ -1,103 +1,103 @@
 <sunSpecModels v="1">
   <!-- 6: security write sequential request model -->
   <model id="6" len="91">
-    <block len="90">
-      <point id="X" offset="0" type="uint16" access="rw" mandatory="true"/>
-      <point id="Off" offset="1" type="uint16" access="rw" mandatory="true" />
-      <point id="Val1" offset="2" type="uint16" access="rw" mandatory="true" />
-      <point id="Val2" offset="3" type="uint16" access="rw" mandatory="true" />
-      <point id="Val3" offset="4" type="uint16" access="rw" mandatory="true" />
-      <point id="Val4" offset="5" type="uint16" access="rw" mandatory="true" />
-      <point id="Val5" offset="6" type="uint16" access="rw" mandatory="true" />
-      <point id="Val6" offset="7" type="uint16" access="rw" mandatory="true" />
-      <point id="Val7" offset="8" type="uint16" access="rw" mandatory="true" />
-      <point id="Val8" offset="9" type="uint16" access="rw" mandatory="true" />
-      <point id="Val9" offset="10" type="uint16" access="rw" mandatory="true" />
-      <point id="Val10" offset="11" type="uint16" access="rw" mandatory="true" />
-      <point id="Val11" offset="12" type="uint16" access="rw" mandatory="true" />
-      <point id="Val12" offset="13" type="uint16" access="rw" mandatory="true" />
-      <point id="Val13" offset="14" type="uint16" access="rw" mandatory="true" />
-      <point id="Val14" offset="15" type="uint16" access="rw" mandatory="true" />
-      <point id="Val15" offset="16" type="uint16" access="rw" mandatory="true" />
-      <point id="Val16" offset="17" type="uint16" access="rw" mandatory="true" />
-      <point id="Val17" offset="18" type="uint16" access="rw" mandatory="true" />
-      <point id="Val18" offset="19" type="uint16" access="rw" mandatory="true" />
-      <point id="Val19" offset="20" type="uint16" access="rw" mandatory="true" />
-      <point id="Val20" offset="21" type="uint16" access="rw" mandatory="true" />
-      <point id="Val21" offset="22" type="uint16" access="rw" mandatory="true" />
-      <point id="Val22" offset="23" type="uint16" access="rw" mandatory="true" />
-      <point id="Val23" offset="24" type="uint16" access="rw" mandatory="true" />
-      <point id="Val24" offset="25" type="uint16" access="rw" mandatory="true" />
-      <point id="Val25" offset="26" type="uint16" access="rw" mandatory="true" />
-      <point id="Val26" offset="27" type="uint16" access="rw" mandatory="true" />
-      <point id="Val27" offset="28" type="uint16" access="rw" mandatory="true" />
-      <point id="Val28" offset="29" type="uint16" access="rw" mandatory="true" />
-      <point id="Val29" offset="30" type="uint16" access="rw" mandatory="true" />
-      <point id="Val30" offset="31" type="uint16" access="rw" mandatory="true" />
-      <point id="Val31" offset="32" type="uint16" access="rw" mandatory="true" />
-      <point id="Val32" offset="33" type="uint16" access="rw" mandatory="true" />
-      <point id="Val33" offset="34" type="uint16" access="rw" mandatory="true" />
-      <point id="Val34" offset="35" type="uint16" access="rw" mandatory="true" />
-      <point id="Val35" offset="36" type="uint16" access="rw" mandatory="true" />
-      <point id="Val36" offset="37" type="uint16" access="rw" mandatory="true" />
-      <point id="Val37" offset="38" type="uint16" access="rw" mandatory="true" />
-      <point id="Val38" offset="39" type="uint16" access="rw" mandatory="true" />
-      <point id="Val39" offset="40" type="uint16" access="rw" mandatory="true" />
-      <point id="Val40" offset="41" type="uint16" access="rw" mandatory="true" />
-      <point id="Val41" offset="42" type="uint16" access="rw" mandatory="true" />
-      <point id="Val42" offset="43" type="uint16" access="rw" mandatory="true" />
-      <point id="Val43" offset="44" type="uint16" access="rw" mandatory="true" />
-      <point id="Val44" offset="45" type="uint16" access="rw" mandatory="true" />
-      <point id="Val45" offset="46" type="uint16" access="rw" mandatory="true" />
-      <point id="Val46" offset="47" type="uint16" access="rw" mandatory="true" />
-      <point id="Val47" offset="48" type="uint16" access="rw" mandatory="true" />
-      <point id="Val48" offset="49" type="uint16" access="rw" mandatory="true" />
-      <point id="Val49" offset="50" type="uint16" access="rw" mandatory="true" />
-      <point id="Val50" offset="51" type="uint16" access="rw" mandatory="true" />
-      <point id="Val51" offset="52" type="uint16" access="rw" mandatory="true" />
-      <point id="Val52" offset="53" type="uint16" access="rw" mandatory="true" />
-      <point id="Val53" offset="54" type="uint16" access="rw" mandatory="true" />
-      <point id="Val54" offset="55" type="uint16" access="rw" mandatory="true" />
-      <point id="Val55" offset="56" type="uint16" access="rw" mandatory="true" />
-      <point id="Val56" offset="57" type="uint16" access="rw" mandatory="true" />
-      <point id="Val57" offset="58" type="uint16" access="rw" mandatory="true" />
-      <point id="Val58" offset="59" type="uint16" access="rw" mandatory="true" />
-      <point id="Val59" offset="60" type="uint16" access="rw" mandatory="true" />
-      <point id="Val60" offset="61" type="uint16" access="rw" mandatory="true" />
-      <point id="Val61" offset="62" type="uint16" access="rw" mandatory="true" />
-      <point id="Val62" offset="63" type="uint16" access="rw" mandatory="true" />
-      <point id="Val63" offset="64" type="uint16" access="rw" mandatory="true" />
-      <point id="Val64" offset="65" type="uint16" access="rw" mandatory="true" />
-      <point id="Val65" offset="66" type="uint16" access="rw" mandatory="true" />
-      <point id="Val66" offset="67" type="uint16" access="rw" mandatory="true" />
-      <point id="Val67" offset="68" type="uint16" access="rw" mandatory="true" />
-      <point id="Val68" offset="69" type="uint16" access="rw" mandatory="true" />
-      <point id="Val69" offset="70" type="uint16" access="rw" mandatory="true" />
-      <point id="Val70" offset="71" type="uint16" access="rw" mandatory="true" />
-      <point id="Val71" offset="72" type="uint16" access="rw" mandatory="true" />
-      <point id="Val72" offset="73" type="uint16" access="rw" mandatory="true" />
-      <point id="Val73" offset="74" type="uint16" access="rw" mandatory="true" />
-      <point id="Val74" offset="75" type="uint16" access="rw" mandatory="true" />
-      <point id="Val75" offset="76" type="uint16" access="rw" mandatory="true" />
-      <point id="Val76" offset="77" type="uint16" access="rw" mandatory="true" />
-      <point id="Val77" offset="78" type="uint16" access="rw" mandatory="true" />
-      <point id="Val78" offset="79" type="uint16" access="rw" mandatory="true" />
-      <point id="Val79" offset="80" type="uint16" access="rw" mandatory="true" />
-      <point id="Val80" offset="81" type="uint16" access="rw" mandatory="true" />
-      <point id="Ts"   offset="82" type="uint32" access="rw" mandatory="true" />
-      <point id="Ms" offset="84" type="uint16" access="rw" mandatory="true" />
-      <point id="Seq" offset="85" type="uint16" access="rw" mandatory="true" />
-      <point id="Role" offset="86" type="uint16" access="rw" mandatory="true" />
-      <point id="Rsrvd" offset="87" type="pad" access="rw" mandatory="true" />
-      <point id="Alg"   offset="88" type="enum16" access="rw" mandatory="true">
+    <block len="90" type="fixed">
+      <point id="X" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Off" offset="1" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val1" offset="2" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val2" offset="3" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val3" offset="4" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val4" offset="5" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val5" offset="6" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val6" offset="7" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val7" offset="8" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val8" offset="9" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val9" offset="10" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val10" offset="11" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val11" offset="12" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val12" offset="13" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val13" offset="14" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val14" offset="15" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val15" offset="16" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val16" offset="17" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val17" offset="18" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val18" offset="19" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val19" offset="20" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val20" offset="21" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val21" offset="22" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val22" offset="23" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val23" offset="24" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val24" offset="25" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val25" offset="26" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val26" offset="27" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val27" offset="28" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val28" offset="29" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val29" offset="30" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val30" offset="31" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val31" offset="32" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val32" offset="33" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val33" offset="34" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val34" offset="35" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val35" offset="36" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val36" offset="37" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val37" offset="38" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val38" offset="39" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val39" offset="40" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val40" offset="41" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val41" offset="42" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val42" offset="43" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val43" offset="44" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val44" offset="45" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val45" offset="46" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val46" offset="47" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val47" offset="48" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val48" offset="49" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val49" offset="50" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val50" offset="51" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val51" offset="52" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val52" offset="53" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val53" offset="54" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val54" offset="55" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val55" offset="56" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val56" offset="57" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val57" offset="58" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val58" offset="59" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val59" offset="60" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val60" offset="61" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val61" offset="62" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val62" offset="63" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val63" offset="64" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val64" offset="65" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val65" offset="66" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val66" offset="67" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val67" offset="68" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val68" offset="69" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val69" offset="70" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val70" offset="71" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val71" offset="72" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val72" offset="73" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val73" offset="74" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val74" offset="75" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val75" offset="76" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val76" offset="77" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val77" offset="78" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val78" offset="79" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val79" offset="80" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Val80" offset="81" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Ts" offset="82" type="uint32" len="2" access="rw" mandatory="true" />
+      <point id="Ms" offset="84" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Seq" offset="85" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Role" offset="86" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Rsrvd" offset="87" type="pad" len="1" access="rw" mandatory="true" />
+      <point id="Alg" offset="88" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="AES-GMAC-64">1</symbol>
         <symbol id="ECC-256">2</symbol>
       </point>
-      <point id="N" offset="89" type="uint16" access="rw" mandatory="true" />
+      <point id="N" offset="89" type="uint16" len="1" access="rw" mandatory="true" />
     </block>
-    <block type="repeating" len="1">
-      <point id="DS" offset="0" type="uint16" access="rw" mandatory="true" />
+    <block len="1" type="repeating">
+      <point id="DS" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
     </block>
   </model>
   <strings id="6" locale="en">

--- a/smdx/smdx_00006.xml
+++ b/smdx/smdx_00006.xml
@@ -104,7 +104,7 @@
     <model>
       <label>Secure Write Sequential Request</label>
       <description>Include a digital signature along with the control data</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Alg">
       <label>Algorithm</label>
@@ -118,23 +118,23 @@
       <symbol id="AES-GMAC-64">
         <label>AES-GMAC-64</label>
         <description>64 bit AES signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ECC-256">
         <label>ECC-256</label>
         <description>256 bit ECC signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Ts">
       <label>Timestamp</label>
       <description>Timestamp value is the number of seconds since January 1, 2000</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ms">
       <label>Milliseconds</label>
       <description>Millisecond counter 0-999</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Seq">
       <label>Sequence</label>
@@ -164,7 +164,7 @@
     <point id="Val1">
       <label>Value1</label>
       <description>Value to write to control register at offset</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DS">
       <label>DS</label>

--- a/smdx/smdx_00007.xml
+++ b/smdx/smdx_00007.xml
@@ -1,32 +1,32 @@
 <sunSpecModels v="1">
   <!-- 7: security write response model -->
   <model id="7" len="11">
-    <block len="10">
-      <point id="RqSeq" offset="0" type="uint16" access="r" mandatory="true"/>
-      <point id="Sts" offset="1" type="enum16" access="r" mandatory="true">
+    <block len="10" type="fixed">
+      <point id="RqSeq" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="Sts" offset="1" type="enum16" len="1" mandatory="true" >
         <symbol id="SUCCESS">0</symbol>
         <symbol id="DS">1</symbol>
         <symbol id="ACL">2</symbol>
         <symbol id="OFF">3</symbol>
         <symbol id="VAL">4</symbol>
       </point>
-      <point id="Ts"   offset="2" type="uint32" access="r" mandatory="true" />
-      <point id="Ms" offset="4" type="uint16" access="r" mandatory="true" />
-      <point id="Seq" offset="5" type="uint16" access="r" mandatory="true" />
-      <point id="Alm" offset="6" type="enum16" mandatory="true">
+      <point id="Ts" offset="2" type="uint32" len="2" mandatory="true" />
+      <point id="Ms" offset="4" type="uint16" len="1" mandatory="true" />
+      <point id="Seq" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="Alm" offset="6" type="enum16" len="1" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="ALM">1</symbol>
       </point>
-      <point id="Rsrvd" offset="7" type="pad" access="r" mandatory="true" />
-      <point id="Alg"   offset="8" type="enum16" access="r" mandatory="true">
+      <point id="Rsrvd" offset="7" type="pad" len="1" mandatory="true" />
+      <point id="Alg" offset="8" type="enum16" len="1" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="AES-GMAC-64">1</symbol>
         <symbol id="ECC-256">2</symbol>
       </point>
-      <point id="N" offset="9" type="uint16" access="rw" mandatory="true" />
+      <point id="N" offset="9" type="uint16" len="1" access="rw" mandatory="true" />
     </block>
-    <block type="repeating" len="1">
-      <point id="DS" offset="0" type="uint16" access="rw" mandatory="true" />
+    <block len="1" type="repeating">
+      <point id="DS" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
     </block>
   </model>
   <strings id="7" locale="en">

--- a/smdx/smdx_00007.xml
+++ b/smdx/smdx_00007.xml
@@ -47,22 +47,22 @@
       <symbol id="AES-GMAC-64">
         <label>AES-GMAC-64</label>
         <description>64 bit AES signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ECC-256">
         <label>ECC-256</label>
         <description>256 bit ECC signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Sts">
       <label>Status</label>
       <description>Status of last write operation</description>
-      <notes></notes>
+      <notes/>
       <symbol id="SUCCESS">
         <label>SUCCESS</label>
         <description>Operation succeeded</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DS">
         <label>DS</label>
@@ -93,7 +93,7 @@
     <point id="RqSeq">
       <label>Request Sequence</label>
       <description>Sequence number from the request</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Seq">
       <label>Sequence</label>
@@ -103,21 +103,21 @@
     <point id="Ts">
       <label>Timestamp</label>
       <description>Timestamp value is the number of seconds since January 1, 2000</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ms">
       <label>Milliseconds</label>
       <description>Millisecond counter 0-999</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Alm">
       <label>Alarm</label>
       <description>Bitmask alarm code</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NONE">
         <label>NONE</label>
         <description>No Alarms</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ALM">
         <label>ALARM</label>

--- a/smdx/smdx_00008.xml
+++ b/smdx/smdx_00008.xml
@@ -1,16 +1,16 @@
 <sunSpecModels v="1">
   <!-- 8: get device security certificate  -->
   <model id="8" len="3">
-    <block len="2">
-      <point id="Fmt"   offset="0" type="enum16" access="r" mandatory="true">
+    <block len="2" type="fixed">
+      <point id="Fmt" offset="0" type="enum16" len="1" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="X509_PEM">1</symbol>
         <symbol id="X509_DER">2</symbol>
       </point>
-      <point id="N" offset="1" type="uint16" access="r" mandatory="true" />
+      <point id="N" offset="1" type="uint16" len="1" mandatory="true" />
     </block>
-    <block type="repeating" len="1">
-      <point id="Cert" offset="0" type="uint16" access="r" mandatory="true" />
+    <block len="1" type="repeating">
+      <point id="Cert" offset="0" type="uint16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="8" locale="en">

--- a/smdx/smdx_00009.xml
+++ b/smdx/smdx_00009.xml
@@ -1,115 +1,115 @@
 <sunSpecModels v="1">
   <!-- 9: set security certificate  -->
   <model id="9" len="93">
-    <block len="92">
-      <point id="CertUID" offset="0" type="uint16" access="rw" mandatory="true" />
-      <point id="CertRole" offset="1" type="uint16" access="rw" mandatory="true" />
-      <point id="Fmt"   offset="2" type="enum16" access="rw" mandatory="true">
+    <block len="92" type="fixed">
+      <point id="CertUID" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="CertRole" offset="1" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Fmt" offset="2" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="X509_PEM">1</symbol>
         <symbol id="X509_DER">2</symbol>
       </point>
-      <point id="Typ"   offset="3" type="enum16" access="rw" mandatory="true">
+      <point id="Typ" offset="3" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="DEV_KEY_PAIR">0</symbol>
         <symbol id="DEV_SHARED_KEY">1</symbol>
         <symbol id="OPERATOR_PUB">2</symbol>
         <symbol id="OPERATOR_SHARED">3</symbol>
         <symbol id="CA_PUB">4</symbol>
       </point>
-      <point id="TotLn" offset="4" type="uint16" access="rw" mandatory="true" />
-      <point id="FrgLn" offset="5" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg1" offset="6" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg2" offset="7" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg3" offset="8" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg4" offset="9" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg5" offset="10" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg6" offset="11" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg7" offset="12" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg8" offset="13" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg9" offset="14" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg10" offset="15" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg11" offset="16" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg12" offset="17" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg13" offset="18" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg14" offset="19" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg15" offset="20" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg16" offset="21" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg17" offset="22" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg18" offset="23" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg19" offset="24" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg20" offset="25" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg21" offset="26" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg22" offset="27" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg23" offset="28" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg24" offset="29" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg25" offset="30" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg26" offset="31" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg27" offset="32" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg28" offset="33" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg29" offset="34" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg30" offset="35" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg31" offset="36" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg32" offset="37" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg33" offset="38" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg34" offset="39" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg35" offset="40" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg36" offset="41" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg37" offset="42" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg38" offset="43" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg39" offset="44" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg40" offset="45" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg41" offset="46" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg42" offset="47" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg43" offset="48" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg44" offset="49" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg45" offset="50" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg46" offset="51" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg47" offset="52" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg48" offset="53" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg49" offset="54" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg50" offset="55" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg51" offset="56" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg52" offset="57" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg53" offset="58" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg54" offset="59" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg55" offset="60" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg56" offset="61" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg57" offset="62" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg58" offset="63" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg59" offset="64" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg60" offset="65" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg61" offset="66" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg62" offset="67" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg63" offset="68" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg64" offset="69" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg65" offset="70" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg66" offset="71" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg67" offset="72" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg68" offset="73" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg69" offset="74" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg70" offset="75" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg71" offset="76" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg72" offset="77" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg73" offset="78" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg74" offset="79" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg75" offset="80" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg78" offset="81" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg79" offset="82" type="uint16" access="rw" mandatory="true" />
-      <point id="Frg80" offset="83" type="uint16" access="rw" mandatory="true" />
-      <point id="Ts"   offset="84" type="uint32" access="rw" mandatory="true" />
-      <point id="Ms" offset="86" type="uint16" access="rw" mandatory="true" />
-      <point id="Seq" offset="87" type="uint16" access="rw" mandatory="true" />
-      <point id="UID" offset="88" type="uint16" access="rw" mandatory="true" />
-      <point id="Role" offset="89" type="uint16" access="rw" mandatory="true" />
-      <point id="Alg"   offset="90" type="enum16" access="rw" mandatory="true">
+      <point id="TotLn" offset="4" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="FrgLn" offset="5" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg1" offset="6" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg2" offset="7" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg3" offset="8" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg4" offset="9" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg5" offset="10" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg6" offset="11" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg7" offset="12" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg8" offset="13" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg9" offset="14" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg10" offset="15" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg11" offset="16" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg12" offset="17" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg13" offset="18" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg14" offset="19" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg15" offset="20" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg16" offset="21" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg17" offset="22" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg18" offset="23" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg19" offset="24" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg20" offset="25" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg21" offset="26" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg22" offset="27" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg23" offset="28" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg24" offset="29" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg25" offset="30" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg26" offset="31" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg27" offset="32" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg28" offset="33" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg29" offset="34" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg30" offset="35" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg31" offset="36" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg32" offset="37" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg33" offset="38" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg34" offset="39" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg35" offset="40" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg36" offset="41" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg37" offset="42" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg38" offset="43" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg39" offset="44" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg40" offset="45" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg41" offset="46" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg42" offset="47" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg43" offset="48" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg44" offset="49" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg45" offset="50" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg46" offset="51" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg47" offset="52" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg48" offset="53" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg49" offset="54" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg50" offset="55" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg51" offset="56" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg52" offset="57" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg53" offset="58" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg54" offset="59" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg55" offset="60" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg56" offset="61" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg57" offset="62" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg58" offset="63" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg59" offset="64" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg60" offset="65" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg61" offset="66" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg62" offset="67" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg63" offset="68" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg64" offset="69" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg65" offset="70" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg66" offset="71" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg67" offset="72" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg68" offset="73" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg69" offset="74" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg70" offset="75" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg71" offset="76" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg72" offset="77" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg73" offset="78" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg74" offset="79" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg75" offset="80" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg78" offset="81" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg79" offset="82" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Frg80" offset="83" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Ts" offset="84" type="uint32" len="2" access="rw" mandatory="true" />
+      <point id="Ms" offset="86" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Seq" offset="87" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="UID" offset="88" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Role" offset="89" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Alg" offset="90" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="AES-GMAC-64">1</symbol>
         <symbol id="ECC-256">2</symbol>
       </point>
-      <point id="N" offset="91" type="uint16" access="rw" mandatory="true" />
+      <point id="N" offset="91" type="uint16" len="1" access="rw" mandatory="true" />
     </block>
-    <block type="repeating" len="1">
-      <point id="Cert" offset="0" type="uint16" access="rw" mandatory="true" />
+    <block len="1" type="repeating">
+      <point id="Cert" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
     </block>
   </model>
   <strings id="9" locale="en">

--- a/smdx/smdx_00009.xml
+++ b/smdx/smdx_00009.xml
@@ -169,12 +169,12 @@
     <point id="Ts">
       <label>Timestamp</label>
       <description>Timestamp value is the number of seconds since January 1, 2000</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ms">
       <label>Milliseconds</label>
       <description>Millisecond counter 0-999</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Seq">
       <label>Sequence</label>
@@ -198,12 +198,12 @@
       <symbol id="AES-GMAC-64">
         <label>AES-GMAC-64</label>
         <description>64 bit AES signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ECC-256">
         <label>ECC-256</label>
         <description>256 bit ECC signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00010.xml
+++ b/smdx/smdx_00010.xml
@@ -1,21 +1,21 @@
 <sunSpecModels v="1">
   <!-- 10: Communication Interface Header -->
   <model id="10" len="4">
-    <block len="4">
-      <point id="St" offset="0" type="enum16" mandatory="true" >
+    <block len="4" type="fixed">
+      <point id="St" offset="0" type="enum16" len="1" mandatory="true" >
         <symbol id="DOWN">0</symbol>
         <symbol id="UP">1</symbol>
         <symbol id="FAULT">2</symbol>
       </point>
-      <point id="Ctl" offset="1" type="uint16" access="rw" />
-      <point id="Typ" offset="2" type="enum16" >
+      <point id="Ctl" offset="1" type="uint16" len="1" access="rw" />
+      <point id="Typ" offset="2" type="enum16" len="1" >
         <symbol id="UNKNOWN">0</symbol>
         <symbol id="INTERNAL">1</symbol>
         <symbol id="TWISTED_PAIR">2</symbol>
         <symbol id="FIBER">3</symbol>
         <symbol id="WIRELESS">4</symbol>
       </point>
-      <point id="Pad" offset="3" type="pad" />
+      <point id="Pad" offset="3" type="pad" len="1" />
     </block>
   </model>
   <strings id="10" locale="en">

--- a/smdx/smdx_00010.xml
+++ b/smdx/smdx_00010.xml
@@ -22,61 +22,61 @@
     <model>
       <label>Communication Interface Header</label>
       <description>To be included first for a complete interface description</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="St">
       <label>Interface Status</label>
       <description>Overall interface status</description>
-      <notes></notes>
+      <notes/>
       <symbol id="DOWN">
         <label>down</label>
         <description>Interface is down</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UP">
         <label>up</label>
         <description>Interface is up</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>fault</label>
         <description>Interface is in a fault state</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Ctl">
       <label>Interface Control</label>
       <description>Overall interface control (TBD)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Typ">
       <label>Physical Access Type</label>
       <description>Enumerated value.  Type of physical media</description>
-      <notes></notes>
+      <notes/>
       <symbol id="UNKNOWN">
         <label>unknown</label>
         <description>Unknown media</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="INTERNAL">
         <label>internal</label>
         <description>Internal e.g. embedded switch</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TWISTED_PAIR">
         <label>twisted pair</label>
         <description>Twisted Pair</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FIBER">
         <label>fiber</label>
         <description>Fiber</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="WIFI">
         <label>wifi</label>
         <description>WIFI</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00011.xml
+++ b/smdx/smdx_00011.xml
@@ -1,9 +1,9 @@
 <sunSpecModels v="1">
   <!-- 11: ethernet link layer -->
   <model id="11" len="13">
-    <block len="13">
-      <point id="Spd" offset="0" type="uint16" mandatory="true" units="Mbps" />
-      <point id="CfgSt" offset="1" type="bitfield16" mandatory="true" >
+    <block len="13" type="fixed">
+      <point id="Spd" offset="0" type="uint16" len="1" units="Mbps" mandatory="true" />
+      <point id="CfgSt" offset="1" type="bitfield16" len="1" mandatory="true" >
         <symbol id="LINK">0</symbol>
         <symbol id="FULL_DUPLEX">1</symbol>
         <symbol id="AUTO_NEG1">2</symbol>
@@ -12,19 +12,19 @@
         <symbol id="RESET_REQUIRED">5</symbol>
         <symbol id="HW_FAULT">6</symbol>
       </point>
-      <point id="St" offset="2" type="enum16" mandatory="true" >
+      <point id="St" offset="2" type="enum16" len="1" mandatory="true" >
         <symbol id="UNKNOWN">0</symbol>
         <symbol id="ENABLED">1</symbol>
         <symbol id="DISABLED">2</symbol>
         <symbol id="TESTING">3</symbol>
       </point>
-      <point id="MAC" offset="3" type="eui48" />
+      <point id="MAC" offset="3" type="eui48" len="4" />
       <point id="Nam" offset="7" type="string" len="4" access="rw" />
-      <point id="Ctl" offset="11" type="bitfield16" access="rw" >
+      <point id="Ctl" offset="11" type="bitfield16" len="1" access="rw" >
         <symbol id="AUTO">0</symbol>
         <symbol id="FULL_DUPLEX">1</symbol>
       </point>
-      <point id="FrcSpd" offset="12" type="uint16" access="rw" units="Mbps" />
+      <point id="FrcSpd" offset="12" type="uint16" len="1" access="rw" units="Mbps" />
     </block>
   </model>
   <strings id="11" locale="en">

--- a/smdx/smdx_00011.xml
+++ b/smdx/smdx_00011.xml
@@ -31,107 +31,107 @@
     <model>
       <label>Ethernet Link Layer</label>
       <description>Include to support a wired ethernet port</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Spd">
       <label>Ethernet Link Speed</label>
       <description>Interface speed in Mb/s</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CfgSt">
       <label>Interface Status Flags</label>
       <description>Bitmask values Interface flags.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="LINK">
         <label>link status</label>
         <description>link is up</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FULL_DUPLEX">
         <label>full duplex</label>
         <description>link is in full duplex mode</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="AUTO_NEG1">
         <label>auto negotiation 1</label>
         <description>Auto-negotiation bits are encoded as: 000 - in progress.  001 - speed detection has failed.  010 - negotiation has failed.  011 - negotiated speed and duplex.  100 - negotiation not attempted.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="AUTO_NEG2">
         <label>auto negotiation 2</label>
         <description>See AUTO_NEG1</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="AUTO_NEG3">
         <label>auto negotiation 3</label>
         <description>See AUTO_NEG1</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESET_REQUIRED">
         <label>reset required</label>
         <description>Setting requires reset</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="HW_FAULT">
         <label>hw fault</label>
         <description>Hardware fault</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="St">
       <label>Link State</label>
       <description>Enumerated value. State information for this interface</description>
-      <notes></notes>
+      <notes/>
       <symbol id="UNKNOWN">
         <label>unknown</label>
         <description>Unknown state</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ENABLED">
         <label>enabled</label>
         <description>Link is enabled and read</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DISABLED">
         <label>disabled</label>
         <description>Link is disabled</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TESTING">
         <label>testing</label>
         <description>Link is in test</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="MAC">
       <label>MAC</label>
       <description>IEEE MAC address of this interface</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Nam">
       <label>Name</label>
       <description>Interface name (8 chars)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ctl">
       <label>Control</label>
       <description>Control flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="AUTO">
         <label>auto</label>
         <description>Enable auto-negotiation</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FULL_DUPLEX">
         <label>duplex</label>
         <description>Force full duplex</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="FrcSpd">
       <label>Forced Speed</label>
       <description>Forced interface speed in Mb/s when AUTO is disabled</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00012.xml
+++ b/smdx/smdx_00012.xml
@@ -1,17 +1,17 @@
 <sunSpecModels v="1">
   <!-- 12: IPv4 protocol -->
   <model id="12" len="98">
-    <block len="98">
+    <block len="98" type="fixed">
       <point id="Nam" offset="0" type="string" len="4" access="rw" />
-      <point id="CfgSt" offset="4" type="enum16" mandatory="true" >
+      <point id="CfgSt" offset="4" type="enum16" len="1" mandatory="true" >
         <symbol id="NOT_CONFIGURED">0</symbol>
         <symbol id="VALID_SETTING">1</symbol>
         <symbol id="VALID_HW">2</symbol>
       </point>
-      <point id="ChgSt" offset="5" type="bitfield16" mandatory="true" >
+      <point id="ChgSt" offset="5" type="bitfield16" len="1" mandatory="true" >
         <symbol id="PENDING">0</symbol>
       </point>
-      <point id="Cap" offset="6" type="bitfield16" mandatory="true" >
+      <point id="Cap" offset="6" type="bitfield16" len="1" mandatory="true" >
         <symbol id="DHCP">0</symbol>
         <symbol id="BOOTP">1</symbol>
         <symbol id="ZEROCONF">2</symbol>
@@ -21,18 +21,18 @@
         <symbol id="NTP_CLIENT">6</symbol>
         <symbol id="RESET_REQUIRED">7</symbol>
       </point>
-      <point id="Cfg" offset="7" type="enum16" mandatory="true" access="rw" >
+      <point id="Cfg" offset="7" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="STATIC">0</symbol>
         <symbol id="DHCP">1</symbol>
         <symbol id="BOOTP">2</symbol>
         <symbol id="ZEROCONF">3</symbol>
       </point>
-      <point id="Ctl" offset="8" type="enum16" mandatory="true" access="rw" >
+      <point id="Ctl" offset="8" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLE_DNS">0</symbol>
         <symbol id="ENABLE_NTP">1</symbol>
       </point>
-      <point id="Addr" offset="9" type="string" len="8" mandatory="true" access="rw" />
-      <point id="Msk" offset="17" type="string" len="8" mandatory="true" access="rw" />
+      <point id="Addr" offset="9" type="string" len="8" access="rw" mandatory="true" />
+      <point id="Msk" offset="17" type="string" len="8" access="rw" mandatory="true" />
       <point id="Gw" offset="25" type="string" len="8" access="rw" />
       <point id="DNS1" offset="33" type="string" len="8" access="rw" />
       <point id="DNS2" offset="41" type="string" len="8" access="rw" />
@@ -40,7 +40,7 @@
       <point id="NTP2" offset="61" type="string" len="12" access="rw" />
       <point id="DomNam" offset="73" type="string" len="12" access="rw" />
       <point id="HostNam" offset="85" type="string" len="12" access="rw" />
-      <point id="Pad" offset="97" type="pad" />
+      <point id="Pad" offset="97" type="pad" len="1" />
     </block>
   </model>
   <strings id="12" locale="en">

--- a/smdx/smdx_00012.xml
+++ b/smdx/smdx_00012.xml
@@ -47,172 +47,172 @@
     <model>
       <label>IPv4</label>
       <description>Include to support an IPv4 protocol stack on this interface</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Nam">
       <label>Name</label>
       <description>Interface name</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CfgSt">
       <label>Config Status</label>
       <description>Enumerated value.  Configuration status</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NOT_CONFIGURED">
         <label>not configured</label>
         <description>the stack is not configured</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="VALID_SETTING">
         <label>valid setting</label>
         <description>a valid configuration from BOOTP, DHCP, or NV mem</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="VALID_HW">
         <label>valid hardware</label>
         <description>a valid configuration from hardware settings</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="ChgSt">
       <label>Change Status</label>
       <description>Bitmask value.  A configuration change is pending</description>
-      <notes></notes>
+      <notes/>
       <symbol id="PENDING">
         <label>pending</label>
         <description>a configuration change is pending</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Cap">
       <label>Config Capability</label>
       <description>Bitmask value. Identify capable sources of configuration</description>
-      <notes></notes>
+      <notes/>
       <symbol id="DHCP">
         <label>DHCP</label>
         <description>DHCP Client capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="BOOTP">
         <label>BOOTP</label>
         <description>BOOTP client capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ZEROCONF">
         <label>zeroconf</label>
         <description>Zeroconf capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DNS">
         <label>DNS</label>
         <description>DNS Client capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CFG_SETTABLE">
         <label>configurable</label>
         <description>Settable configuration capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="HW_CONFIG">
         <label>hw</label>
         <description>Hardware configuration capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="NTP_CLIENT">
         <label>ntp</label>
         <description>NTP Client capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESET_REQUIRED">
         <label>reset required</label>
         <description>configuration change requires reset</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Cfg">
       <label>IPv4 Config</label>
       <description>Enumerated value.  Configuration method used.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="STATIC">
         <label>static</label>
         <description>Use static IP</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DHCP">
         <label>DHCP</label>
         <description>Use DHCP</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="BOOTP">
         <label>BOOTP</label>
         <description>Use BOOTP</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ZEROCONF">
         <label>zeroconf</label>
         <description>Use Zeroconf</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Ctl">
       <label>Control</label>
       <description>Configure use of services</description>
-      <notes></notes>
+      <notes/>
       <symbol id="ENABLE_DNS">
         <label>DNS</label>
         <description>Enable DNS</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ENABLE_NTP">
         <label>NTP</label>
         <description>Enable NTP</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Addr">
       <label>IP</label>
       <description>IPv4 numeric address as a dotted string xxx.xxx.xxx.xxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Msk">
       <label>Netmask</label>
       <description>IPv4 numeric netmask as a dotted string xxx.xxx.xxx.xxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Gw">
       <label>Gateway</label>
       <description>IPv4 numeric gateway address as a dotted string xxx.xxx.xxx.xxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DNS1">
       <label>DNS1</label>
       <description>IPv4 numeric DNS address as a dotted string xxx.xxx.xxx.xxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DNS2">
       <label>DNS2</label>
       <description>IPv4 numeric DNS address as a dotted string xxx.xxx.xxx.xxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="NTP1">
       <label>NTP1</label>
       <description>IPv4 numeric NTP address as a dotted string xxx.xxx.xxx.xxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="NTP2">
       <label>NTP2</label>
       <description>IPv4 numeric NTP address as a dotted string xxx.xxx.xxx.xxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DomNam">
       <label>Domain</label>
       <description>Domain name (24 chars max)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="HostNam">
       <label>Host Name</label>
       <description>Host name (24 chars max)</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00013.xml
+++ b/smdx/smdx_00013.xml
@@ -47,172 +47,172 @@
     <model>
       <label>IPv6</label>
       <description>Include to support an IPv6 protocol stack on this interface</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Nam">
       <label>Name</label>
       <description>Interface name</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CfgSt">
       <label>Config Status</label>
       <description>Enumerated value.  Configuration status</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NOT_CONFIGURED">
         <label>not configured</label>
         <description>the stack is not configured</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="VALID_SETTING">
         <label>valid setting</label>
         <description>a valid configuration from BOOTP, DHCP, or NV mem</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="VALID_HW">
         <label>valid hardware</label>
         <description>a valid configuration from hardware settings</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="ChgSt">
       <label>Change Status</label>
       <description>Bitmask value.  A configuration change is pending</description>
-      <notes></notes>
+      <notes/>
       <symbol id="PENDING">
         <label>pending</label>
         <description>a configuration change is pending</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Cap">
       <label>Config Capability</label>
       <description>Bitmask value. Identify capable sources of configuration</description>
-      <notes></notes>
+      <notes/>
       <symbol id="DHCP">
         <label>DHCP</label>
         <description>DHCP Client capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="BOOTP">
         <label>BOOTP</label>
         <description>BOOTP client capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ZEROCONF">
         <label>zeroconf</label>
         <description>Zeroconf capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DNS">
         <label>DNS</label>
         <description>DNS Client capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CFG_SETTABLE">
         <label>configurable</label>
         <description>Settable configuration capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="HW_CONFIG">
         <label>hw</label>
         <description>Hardware configuration capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="NTP_CLIENT">
         <label>ntp</label>
         <description>NTP Client capable</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESET_REQUIRED">
         <label>reset required</label>
         <description>configuration change requires reset</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Cfg">
       <label>IPv6 Config</label>
       <description>Enumerated value.  Configuration method used.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="STATIC">
         <label>static</label>
         <description>Use static IP</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DHCP">
         <label>DHCP</label>
         <description>Use DHCP</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="BOOTP">
         <label>BOOTP</label>
         <description>Use BOOTP</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ZEROCONF">
         <label>zeroconf</label>
         <description>Use Zeroconf</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Ctl">
       <label>Control</label>
       <description>Bitmask value.  Configure use of services</description>
-      <notes></notes>
+      <notes/>
       <symbol id="ENABLE_DNS">
         <label>DNS</label>
         <description>Enable DNS</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ENABLE_NTP">
         <label>NTP</label>
         <description>Enable NTP</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Addr">
       <label>IP</label>
       <description>IPv6 numeric address as a dotted string xxxx.xxxx.xxxx.xxxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CIDR">
       <label>CIDR</label>
       <description>Classless Inter-Domain Routing Number</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Gw">
       <label>Gateway</label>
       <description>IPv6 numeric address as a dotted string xxxx.xxxx.xxxx.xxxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DNS1">
       <label>DNS1</label>
       <description>IPv6 numeric DNS address as a dotted string xxxx.xxxx.xxxx.xxxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DNS2">
       <label>DNS2</label>
       <description>IPv6 numeric DNS address as a dotted string xxxx.xxxx.xxxx.xxxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="NTP1">
       <label>NTP1</label>
       <description>IPv6 numeric NTP address as a name or dotted string xxxx.xxxx.xxxx.xxxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="NTP2">
       <label>NTP2</label>
       <description>IPv6 numeric NTP address as a name or dotted string xxxx.xxxx.xxxx.xxxx</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DomNam">
       <label>Domain</label>
       <description>Domain name (24 chars max)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="HostNam">
       <label>Host Name</label>
       <description>Host name (24 chars max)</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00013.xml
+++ b/smdx/smdx_00013.xml
@@ -1,17 +1,17 @@
 <sunSpecModels v="1">
   <!-- 13: IPv6 protocol -->
   <model id="13" len="174">
-    <block len="174">
+    <block len="174" type="fixed">
       <point id="Nam" offset="0" type="string" len="4" access="rw" />
-      <point id="CfgSt" offset="4" type="enum16" mandatory="true" >
+      <point id="CfgSt" offset="4" type="enum16" len="1" mandatory="true" >
         <symbol id="NOT_CONFIGURED">0</symbol>
         <symbol id="VALID_SETTING">1</symbol>
         <symbol id="VALID_HW">2</symbol>
       </point>
-      <point id="ChgSt" offset="5" type="bitfield16" mandatory="true" >
+      <point id="ChgSt" offset="5" type="bitfield16" len="1" mandatory="true" >
         <symbol id="PENDING">0</symbol>
       </point>
-      <point id="Cap" offset="6" type="bitfield16" mandatory="true" >
+      <point id="Cap" offset="6" type="bitfield16" len="1" mandatory="true" >
         <symbol id="DHCP">0</symbol>
         <symbol id="BOOTP">1</symbol>
         <symbol id="ZEROCONF">2</symbol>
@@ -21,17 +21,17 @@
         <symbol id="NTP_CLIENT">6</symbol>
         <symbol id="RESET_REQUIRED">7</symbol>
       </point>
-      <point id="Cfg" offset="7" type="enum16" mandatory="true" access="rw" >
+      <point id="Cfg" offset="7" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="STATIC">0</symbol>
         <symbol id="DHCP">1</symbol>
         <symbol id="BOOTP">2</symbol>
         <symbol id="ZEROCONF">3</symbol>
       </point>
-      <point id="Ctl" offset="8" type="enum16" mandatory="true" access="rw" >
+      <point id="Ctl" offset="8" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLE_DNS">0</symbol>
         <symbol id="ENABLE_NTP">1</symbol>
       </point>
-      <point id="Addr" offset="9" type="string" len="20" mandatory="true" access="rw" />
+      <point id="Addr" offset="9" type="string" len="20" access="rw" mandatory="true" />
       <point id="CIDR" offset="29" type="string" len="20" access="rw" />
       <point id="Gw" offset="49" type="string" len="20" access="rw" />
       <point id="DNS1" offset="69" type="string" len="20" access="rw" />
@@ -40,7 +40,7 @@
       <point id="NTP2" offset="129" type="string" len="20" access="rw" />
       <point id="DomNam" offset="149" type="string" len="12" access="rw" />
       <point id="HostNam" offset="161" type="string" len="12" access="rw" />
-      <point id="Pad" offset="173" type="pad" />
+      <point id="Pad" offset="173" type="pad" len="1" />
     </block>
   </model>
   <strings id="13" locale="en">

--- a/smdx/smdx_00014.xml
+++ b/smdx/smdx_00014.xml
@@ -1,17 +1,17 @@
 <sunSpecModels v="1">
   <!-- 14: Proxy Server -->
   <model id="14" len="52">
-    <block len="52">
+    <block len="52" type="fixed">
       <point id="Nam" offset="0" type="string" len="4" access="rw" />
-      <point id="Cap" offset="4" type="bitfield16" mandatory="true" access="rw" >
+      <point id="Cap" offset="4" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="NO_PROXY">0</symbol>
         <symbol id="IPV4_PROXY">1</symbol>
         <symbol id="IPV6_PROXY">2</symbol>
       </point>
-      <point id="Cfg" offset="5" type="enum16" mandatory="true" access="rw" />
-      <point id="Typ" offset="6" type="bitfield16" mandatory="true" access="rw" />
-      <point id="Addr" offset="7" type="string" len="20" mandatory="true" access="rw" />
-      <point id="Port" offset="27" type="uint16" mandatory="true" access="rw" />
+      <point id="Cfg" offset="5" type="enum16" len="1" access="rw" mandatory="true" />
+      <point id="Typ" offset="6" type="bitfield16" len="1" access="rw" mandatory="true" />
+      <point id="Addr" offset="7" type="string" len="20" access="rw" mandatory="true" />
+      <point id="Port" offset="27" type="uint16" len="1" access="rw" mandatory="true" />
       <point id="User" offset="28" type="string" len="12" access="rw" />
       <point id="Pw" offset="40" type="string" len="12" access="rw" />
     </block>

--- a/smdx/smdx_00014.xml
+++ b/smdx/smdx_00014.xml
@@ -20,62 +20,62 @@
     <model>
       <label>Proxy Server</label>
       <description>Include this block to allow for a proxy server</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Nam">
       <label>name</label>
       <description>Interface name (8 chars)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Cap">
       <label>Capabilities</label>
       <description>Bitmask value.  Proxy configuration capabilities</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NO_PROXY">
         <label>No Proxy</label>
         <description>Turn off the proxy</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="IPV4_PROXY">
         <label>IPv4 Proxy</label>
         <description>Can proxy IPv4</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="IPV6_PROXY">
         <label>IPv6 Proxy</label>
         <description>Can proxy IPv6</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Cfg">
       <label>Config</label>
       <description>Enumerated value.  Set proxy address type</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Typ">
       <label>Type</label>
       <description>Enumerate value.  Proxy server type</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Addr">
       <label>Address</label>
       <description>IPv4 or IPv6 proxy hostname or dotted address (40 chars)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Port">
       <label>Port</label>
       <description>Proxy port number</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="User">
       <label>Username</label>
       <description>Proxy user name</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pw">
       <label>Password</label>
       <description>Proxy password</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00015.xml
+++ b/smdx/smdx_00015.xml
@@ -1,20 +1,20 @@
 <sunSpecModels v="1">
   <!-- 15: Interface Counters -->
   <model id="15" len="24">
-    <block len="24">
-      <point id="Clr" offset="0" type="uint16" access="rw" />
-      <point id="InCnt" offset="1" type="acc32" />
-      <point id="InUcCnt" offset="3" type="acc32" />
-      <point id="InNUcCnt" offset="5" type="acc32" />
-      <point id="InDscCnt" offset="7" type="acc32" />
-      <point id="InErrCnt" offset="9" type="acc32" />
-      <point id="InUnkCnt" offset="11" type="acc32" />
-      <point id="OutCnt" offset="13" type="acc32" />
-      <point id="OutUcCnt" offset="15" type="acc32" />
-      <point id="OutNUcCnt" offset="17" type="acc32" />
-      <point id="OutDscCnt" offset="19" type="acc32" />
-      <point id="OutErrCnt" offset="21" type="acc32" />
-      <point id="Pad" offset="23" type="pad" />
+    <block len="24" type="fixed">
+      <point id="Clr" offset="0" type="uint16" len="1" access="rw" />
+      <point id="InCnt" offset="1" type="acc32" len="2" />
+      <point id="InUcCnt" offset="3" type="acc32" len="2" />
+      <point id="InNUcCnt" offset="5" type="acc32" len="2" />
+      <point id="InDscCnt" offset="7" type="acc32" len="2" />
+      <point id="InErrCnt" offset="9" type="acc32" len="2" />
+      <point id="InUnkCnt" offset="11" type="acc32" len="2" />
+      <point id="OutCnt" offset="13" type="acc32" len="2" />
+      <point id="OutUcCnt" offset="15" type="acc32" len="2" />
+      <point id="OutNUcCnt" offset="17" type="acc32" len="2" />
+      <point id="OutDscCnt" offset="19" type="acc32" len="2" />
+      <point id="OutErrCnt" offset="21" type="acc32" len="2" />
+      <point id="Pad" offset="23" type="pad" len="1" />
     </block>
   </model>
   <strings id="15" locale="en">

--- a/smdx/smdx_00015.xml
+++ b/smdx/smdx_00015.xml
@@ -21,67 +21,67 @@
     <model>
       <label>Interface Counters Model</label>
       <description>Interface counters</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Clr">
       <label>Clear</label>
       <description>Write a "1" to clear all counters</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InCnt">
       <label>Input Count</label>
       <description>Number of bytes received</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InUcCnt">
       <label>Input Unicast Count</label>
       <description>Number of Unicast packets received</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InNUcCnt">
       <label>Input Non-Unicast Count</label>
       <description>Number of non-Unicast packets received</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDscCnt">
       <label>Input Discarded Count</label>
       <description>Number of inbound packets received on the interface but discarded</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InErrCnt">
       <label>Input Error Count</label>
       <description>Number of inbound packets that contain errors (excluding discards)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InUnkCnt">
       <label>Input Unknown Count</label>
       <description>Number of inbound packets with unknown protocol</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutCnt">
       <label>Output Count</label>
       <description>Total number of bytes transmitted on this interface</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutUcCnt">
       <label>Output Unicast Count</label>
       <description>Number of Unicast packets transmitted</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutNUcCnt">
       <label>Output Non-Unicast Count</label>
       <description>Number of Non-Unicast packets transmitted</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutDscCnt">
       <label>Output Discarded Count</label>
       <description>Number of Discarded output packets</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutErrCnt">
       <label>Output Error Count</label>
       <description>Number of outbound error packets</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00016.xml
+++ b/smdx/smdx_00016.xml
@@ -1,30 +1,30 @@
 <sunSpecModels v="1">
   <!-- 16: Simple IP Network -->
   <model id="16" len="52">
-    <block len="52">
+    <block len="52" type="fixed">
       <point id="Nam" offset="0" type="string" len="4" access="rw" />
-      <point id="Cfg" offset="4" type="enum16" mandatory="true" >
+      <point id="Cfg" offset="4" type="enum16" len="1" mandatory="true" >
         <symbol id="STATIC">0</symbol>
         <symbol id="DHCP">1</symbol>
       </point>
-      <point id="Ctl" offset="5" type="bitfield16" mandatory="true" access="rw" >
+      <point id="Ctl" offset="5" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLE_DNS">0</symbol>
         <symbol id="ENABLE_NTP">1</symbol>
       </point>
-      <point id="Addr" offset="6" type="string" len="8" mandatory="true" access="rw" />
-      <point id="Msk" offset="14" type="string" len="8" mandatory="true" access="rw" />
+      <point id="Addr" offset="6" type="string" len="8" access="rw" mandatory="true" />
+      <point id="Msk" offset="14" type="string" len="8" access="rw" mandatory="true" />
       <point id="Gw" offset="22" type="string" len="8" access="rw" />
       <point id="DNS1" offset="30" type="string" len="8" access="rw" />
       <point id="DNS2" offset="38" type="string" len="8" access="rw" />
-      <point id="MAC" offset="46" type="eui48" access="r" />
-      <point id="LnkCtl" offset="50" type="bitfield16" access="rw" >
+      <point id="MAC" offset="46" type="eui48" len="4" />
+      <point id="LnkCtl" offset="50" type="bitfield16" len="1" access="rw" >
         <symbol id="AUTONEGOTIATE">0</symbol>
         <symbol id="FULL_DUPLEX">1</symbol>
         <symbol id="FORCE_10MB">2</symbol>
         <symbol id="FORCE_100MB">3</symbol>
         <symbol id="FORCE_1GB">4</symbol>
       </point>
-      <point id="Pad" offset="51" type="pad" />
+      <point id="Pad" offset="51" type="pad" len="1" />
     </block>
   </model>
   <strings id="16" locale="en">

--- a/smdx/smdx_00016.xml
+++ b/smdx/smdx_00016.xml
@@ -31,101 +31,101 @@
     <model>
       <label>Simple IP Network</label>
       <description>Include this model for a simple IPv4 network stack</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Nam">
       <label>Name</label>
       <description>Interface name.  (8 chars)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Cfg">
       <label>Config</label>
       <description>Enumerated value.  Force IPv4 configuration method</description>
-      <notes></notes>
+      <notes/>
       <symbol id="STATIC">
         <label>static</label>
         <description>A static IP address is assigned</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DHCP">
         <label>DHCP</label>
         <description>Use DHCP to acquire an IP address</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Ctl">
       <label>Control</label>
       <description>Bitmask value Configure use of services</description>
-      <notes></notes>
+      <notes/>
       <symbol id="ENABLE_DNS">
         <label>DNS</label>
         <description>Enable DNS use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ENABLE_NTP">
         <label>NTP</label>
         <description>Enable NTP use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Addr">
       <label>Address</label>
       <description>IP address</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Msk">
       <label>Netmask</label>
       <description>Netmask</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Gw">
       <label>Gateway</label>
       <description>Gateway IP address</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DNS1">
       <label>DNS1</label>
       <description>32 bit IP address of DNS server</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DNS2">
       <label>DNS2</label>
       <description>32 bit IP address of DNS server</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="MAC">
       <label>MAC</label>
       <description>IEEE MAC address of this interface</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="LnkCtl">
       <label>Link Control</label>
       <description>Bitmask value.  Link control flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="AUTONEGOTIATE">
         <label>auto-negotiate</label>
         <description>Enable auto-negotiation</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FULL_DUPLEX">
         <label>full duplex</label>
         <description>Force full duplex operation</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FORCE_10MB">
         <label>10Mbs</label>
         <description>Force 10 Mb/s link speed</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FORCE_100MB">
         <label>100Mbs</label>
         <description>Force 100 Mb/s link speed</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FORCE_1GB">
         <label>1Gbs</label>
         <description>Force 1 Gb/s link speed</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00017.xml
+++ b/smdx/smdx_00017.xml
@@ -35,116 +35,116 @@
     <model>
       <label>Serial Interface</label>
       <description>Include this model for serial interface configuration support</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Nam">
       <label>Name</label>
       <description>Interface name (8 chars)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Rte">
       <label>Rate</label>
       <description>Interface baud rate in bits per second</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Bits">
       <label>Bits</label>
       <description>Number of data bits per character</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pty">
       <label>Parity</label>
       <description>Bitmask value.  Parity setting</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NONE">
         <label>none</label>
         <description>No Parity</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ODD">
         <label>odd</label>
         <description>Odd Parity</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="EVEN">
         <label>even</label>
         <description>Even Parity</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Dup">
       <label>Duplex</label>
       <description>Enumerated value.  Duplex mode</description>
-      <notes></notes>
+      <notes/>
       <symbol id="FULL">
         <label>full</label>
         <description>Full Duplex</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="HALF">
         <label>half</label>
         <description>Half Duplex</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Flw">
       <label>Flow Control</label>
       <description>Flow Control Method</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NONE">
         <label>none</label>
         <description>No flow control</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="HW">
         <label>hardware</label>
         <description>Hardware flow control</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="XONXOFF">
         <label>software</label>
         <description>Soft (XON/XOFF) flow control</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Typ">
       <label>Interface Type</label>
       <description>Enumerated value.  Interface type</description>
-      <notes></notes>
+      <notes/>
       <symbol id="UNKNOWN">
         <label>unknown</label>
         <description>Unknown interface type</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RS232">
         <label>RS232</label>
         <description>RS232 interface type</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RS485">
         <label>RS485</label>
         <description>RS485 interface type</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Pcol">
       <label>Protocol</label>
       <description>Enumerated value. Serial protocol selection</description>
-      <notes></notes>
+      <notes/>
       <symbol id="UNKNOWN">
         <label>unknown</label>
         <description>Unknown protocol</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MODBUS">
         <label>Modbus</label>
         <description>Modbus protocol</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="VENDOR">
         <label>vendor specific</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00017.xml
+++ b/smdx/smdx_00017.xml
@@ -1,30 +1,30 @@
 <sunSpecModels v="1">
   <!-- 17: Serial Interface -->
   <model id="17" len="12">
-    <block len="12">
+    <block len="12" type="fixed">
       <point id="Nam" offset="0" type="string" len="4" access="rw" />
-      <point id="Rte" offset="4" type="uint32" mandatory="true" access="rw" units="bps" />
-      <point id="Bits" offset="6" type="uint16" mandatory="true" access="rw" />
-      <point id="Pty" offset="7" type="enum16" mandatory="true" access="rw" >
+      <point id="Rte" offset="4" type="uint32" len="2" access="rw" units="bps" mandatory="true" />
+      <point id="Bits" offset="6" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Pty" offset="7" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="ODD">1</symbol>
         <symbol id="EVEN">2</symbol>
       </point>
-      <point id="Dup" offset="8" type="enum16" access="rw" >
+      <point id="Dup" offset="8" type="enum16" len="1" access="rw" >
         <symbol id="FULL">0</symbol>
         <symbol id="HALF">1</symbol>
       </point>
-      <point id="Flw" offset="9" type="enum16" access="rw" >
+      <point id="Flw" offset="9" type="enum16" len="1" access="rw" >
         <symbol id="NONE">0</symbol>
         <symbol id="HW">1</symbol>
         <symbol id="XONXOFF">2</symbol>
       </point>
-      <point id="Typ" offset="10" type="enum16" >
+      <point id="Typ" offset="10" type="enum16" len="1" >
         <symbol id="UNKNOWN">0</symbol>
         <symbol id="RS232">1</symbol>
         <symbol id="RS485">2</symbol>
       </point>
-      <point id="Pcol" offset="11" type="enum16" >
+      <point id="Pcol" offset="11" type="enum16" len="1" >
         <symbol id="UNKNOWN">0</symbol>
         <symbol id="MODBUS">1</symbol>
         <symbol id="VENDOR">2</symbol>

--- a/smdx/smdx_00018.xml
+++ b/smdx/smdx_00018.xml
@@ -13,32 +13,32 @@
     <model>
       <label>Cellular Link</label>
       <description>Include this model to support a cellular interface link</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Nam">
       <label>Name</label>
       <description>Interface name</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="IMEI">
       <label>IMEI</label>
       <description>International Mobile Equipment Identifier for the interface</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="APN">
       <label>APN</label>
       <description>Access Point Name for the interface</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Num">
       <label>Number</label>
       <description>Phone number for the interface</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pin">
       <label>PIN</label>
       <description>Personal Identification Number for the interface</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00018.xml
+++ b/smdx/smdx_00018.xml
@@ -1,9 +1,9 @@
 <sunSpecModels v="1">
   <!-- 18: Cellular Link -->
   <model id="18" len="22">
-    <block len="22">
+    <block len="22" type="fixed">
       <point id="Nam" offset="0" type="string" len="4" access="rw" />
-      <point id="IMEI" offset="4" type="uint32" access="rw" />
+      <point id="IMEI" offset="4" type="uint32" len="2" access="rw" />
       <point id="APN" offset="6" type="string" len="4" access="rw" />
       <point id="Num" offset="10" type="string" len="6" access="rw" />
       <point id="Pin" offset="16" type="string" len="6" access="rw" />

--- a/smdx/smdx_00019.xml
+++ b/smdx/smdx_00019.xml
@@ -33,107 +33,107 @@
     <model>
       <label>PPP Link</label>
       <description>Include this model to configure a Point-to-Point Protocol link</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Nam">
       <label>Name</label>
       <description>Interface name</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Rte">
       <label>Rate</label>
       <description>Interface baud rate in bits per second</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Bits">
       <label>Bits</label>
       <description>Number of data bits per character</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pty">
       <label>Parity</label>
       <description>Bitmask value.  Parity setting</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NONE">
         <label>none</label>
         <description>No Parity</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ODD">
         <label>odd</label>
         <description>Odd Parity</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="EVEN">
         <label>even</label>
         <description>Even Parity</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Dup">
       <label>Duplex</label>
       <description>Enumerated value.  Duplex mode</description>
-      <notes></notes>
+      <notes/>
       <symbol id="FULL">
         <label>full</label>
         <description>Full Duplex</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="HALF">
         <label>half</label>
         <description>Half Duplex</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Flw">
       <label>Flow Control</label>
       <description>Flow Control Method</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NONE">
         <label>none</label>
         <description>No flow control</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="HW">
         <label>hardware</label>
         <description>Hardware flow control</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="XONXOFF">
         <label>software</label>
         <description>Soft (XON/XOFF) flow control</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Auth">
       <label>Authentication</label>
       <description>Enumerated value.  Authentication method</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NONE">
         <label>none</label>
         <description>No Authentication</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="PAP">
         <label>PAP</label>
         <description>Use PAP authentication</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CHAP">
         <label>CHAP</label>
         <description>Use CHAP authentication</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="UsrNam">
       <label>Username</label>
       <description>Username for authentication</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pw">
       <label>Password</label>
       <description>Password for authentication</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00019.xml
+++ b/smdx/smdx_00019.xml
@@ -1,32 +1,32 @@
 <sunSpecModels v="1">
   <!-- 19: PPP Link -->
   <model id="19" len="30">
-    <block len="30">
+    <block len="30" type="fixed">
       <point id="Nam" offset="0" type="string" len="4" access="rw" />
-      <point id="Rte" offset="4" type="uint32" mandatory="true" access="rw" units="bps" />
-      <point id="Bits" offset="6" type="uint16" mandatory="true" access="rw" />
-      <point id="Pty" offset="7" type="enum16" mandatory="true" access="rw" >
+      <point id="Rte" offset="4" type="uint32" len="2" access="rw" units="bps" mandatory="true" />
+      <point id="Bits" offset="6" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Pty" offset="7" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="ODD">1</symbol>
         <symbol id="EVEN">2</symbol>
       </point>
-      <point id="Dup" offset="8" type="enum16" access="rw" >
+      <point id="Dup" offset="8" type="enum16" len="1" access="rw" >
         <symbol id="FULL">0</symbol>
         <symbol id="HALF">1</symbol>
       </point>
-      <point id="Flw" offset="9" type="enum16" access="rw" >
+      <point id="Flw" offset="9" type="enum16" len="1" access="rw" >
         <symbol id="NONE">0</symbol>
         <symbol id="HW">1</symbol>
         <symbol id="XONXOFF">2</symbol>
       </point>
-      <point id="Auth" offset="10" type="enum16" >
+      <point id="Auth" offset="10" type="enum16" len="1" >
         <symbol id="NONE">0</symbol>
         <symbol id="PAP">1</symbol>
         <symbol id="CHAP">2</symbol>
       </point>
       <point id="UsrNam" offset="11" type="string" len="12" />
       <point id="Pw" offset="23" type="string" len="6" />
-      <point id="Pad" offset="29" type="pad" />
+      <point id="Pad" offset="29" type="pad" len="1" />
     </block>
   </model>
   <strings id="19" locale="en">

--- a/smdx/smdx_00101.xml
+++ b/smdx/smdx_00101.xml
@@ -78,12 +78,12 @@
     <model>
       <label>Inverter (Single Phase)</label>
       <description>Include this model for single phase inverter monitoring</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphA">
       <label>Amps PhaseA</label>
@@ -93,267 +93,267 @@
     <point id="AphB">
       <label>Amps PhaseB</label>
       <description>Phase B Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W">
       <label>Watts</label>
       <description>AC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz">
       <label>Hz</label>
       <description>Line Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAr">
       <label>VAr</label>
       <description>AC Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>AC Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WH">
       <label>WattHours</label>
       <description>AC Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCA">
       <label>DC Amps</label>
       <description>DC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCV">
       <label>DC Voltage</label>
       <description>DC Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCW">
       <label>DC Watts</label>
       <description>DC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpCab">
       <label>Cabinet Temperature</label>
       <description>Cabinet Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpSnk">
       <label>Heat Sink Temperature</label>
       <description>Heat Sink Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpTrns">
       <label>Transformer Temperature</label>
       <description>Transformer Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpOt">
       <label>Other Temperature</label>
       <description>Other Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="St">
       <label>Operating State</label>
       <description>Enumerated value.  Operating state</description>
-      <notes></notes>
+      <notes/>
       <symbol id="OFF">
         <label>Off</label>
         <description>Device is not operating</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SLEEPING">
         <label>Sleeping</label>
         <description>Device is sleeping / auto-shutdown</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STARTING">
         <label>Starting</label>
         <description>Device is staring up</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MPPT">
         <label>MPPT</label>
         <description>Device is auto tracking maximum power point</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="THROTTLED">
         <label>Throttled</label>
         <description>Device is operating at reduced power output</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SHUTTING_DOWN">
         <label>Shutting down</label>
         <description>Device is shutting down</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>Fault</label>
         <description>One or more faults exist</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STANDBY">
         <label>Standby</label>
         <description>Device is in standby mode</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StVnd">
       <label>Vendor Operating State</label>
       <description>Vendor specific operating state code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt1">
       <label>Event1</label>
       <description>Bitmask value. Event fields</description>
-      <notes></notes>
+      <notes/>
       <symbol id="GROUND_FAULT">
         <label>Ground fault</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_OVER_VOLT">
         <label>DC over voltage</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_DISCONNECT">
         <label>AC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_DISCONNECT">
         <label>DC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="GRID_DISCONNECT">
         <label>Grid disconnect</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CABINET_OPEN">
         <label>Cabinet open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MANUAL_SHUTDOWN">
         <label>Manual shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP">
         <label>Over temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_FREQUENCY">
         <label>Frequency above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_FREQUENCY">
         <label>Frequency under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_OVER_VOLT">
         <label>AC Voltage above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_UNDER_VOLT">
         <label>AC Voltage under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="BLOWN_STRING_FUSE">
         <label>Blown String fuse on input</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP">
         <label>Under temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MEMORY_LOSS">
         <label>Generic Memory or Communication error (internal)</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="HW_TEST_FAILURE">
         <label>Hardware test failure</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="Evt2">
       <label>Event Bitfield 2</label>
       <description>Reserved for future use</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd1">
       <label>Vendor Event Bitfield 1</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd2">
       <label>Vendor Event Bitfield 2</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd3">
       <label>Vendor Event Bitfield 3</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd4">
       <label>Vendor Event Bitfield 4</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00101.xml
+++ b/smdx/smdx_00101.xml
@@ -2,43 +2,43 @@
 
   <!-- 101: inverter -->
   <model id="101" len="50" name="inverter">
-    <block len="50">
-      <point id="A" offset="0" type="uint16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphA" offset="1" type="uint16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphB" offset="2" type="uint16" sf="A_SF" units="A" />
-      <point id="AphC" offset="3" type="uint16" sf="A_SF" units="A" />
-      <point id="A_SF" offset="4" type="sunssf" mandatory="true" />
-      <point id="PPVphAB" offset="5" type="uint16" sf="V_SF" units="V" />
-      <point id="PPVphBC" offset="6" type="uint16" sf="V_SF" units="V" />
-      <point id="PPVphCA" offset="7" type="uint16" sf="V_SF" units="V" />
-      <point id="PhVphA" offset="8" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphB" offset="9" type="uint16" sf="V_SF" units="V" />
-      <point id="PhVphC" offset="10" type="uint16" sf="V_SF" units="V" />
-      <point id="V_SF" offset="11" type="sunssf" mandatory="true" />
-      <point id="W" offset="12" type="int16" sf="W_SF" units="W" mandatory="true" />
-      <point id="W_SF" offset="13" type="sunssf" mandatory="true" />
-      <point id="Hz" offset="14" type="uint16" sf="Hz_SF" units="Hz" mandatory="true" />
-      <point id="Hz_SF" offset="15" type="sunssf" mandatory="true" />
-      <point id="VA" offset="16" type="int16" sf="VA_SF" units="VA" />
-      <point id="VA_SF" offset="17" type="sunssf" />
-      <point id="VAr" offset="18" type="int16" sf="VAr_SF" units="var" />
-      <point id="VAr_SF" offset="19" type="sunssf" />
-      <point id="PF" offset="20" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PF_SF" offset="21" type="sunssf" />
-      <point id="WH" offset="22" type="acc32" sf="WH_SF" units="Wh" mandatory="true" />
-      <point id="WH_SF" offset="24" type="sunssf" mandatory="true" />
-      <point id="DCA" offset="25" type="uint16" sf="DCA_SF" units="A" />
-      <point id="DCA_SF" offset="26" type="sunssf" />
-      <point id="DCV" offset="27" type="uint16" sf="DCV_SF" units="V" />
-      <point id="DCV_SF" offset="28" type="sunssf" />
-      <point id="DCW" offset="29" type="int16" sf="DCW_SF" units="W" />
-      <point id="DCW_SF" offset="30" type="sunssf" />
-      <point id="TmpCab" offset="31" type="int16" sf="Tmp_SF" units="C" mandatory="true" />
-      <point id="TmpSnk" offset="32" type="int16" sf="Tmp_SF" units="C" />
-      <point id="TmpTrns" offset="33" type="int16" sf="Tmp_SF" units="C" />
-      <point id="TmpOt" offset="34" type="int16" sf="Tmp_SF" units="C" />
-      <point id="Tmp_SF" offset="35" type="sunssf" mandatory="true" />
-      <point id="St" offset="36" type="enum16" mandatory="true" >
+    <block len="50" type="fixed">
+      <point id="A" offset="0" type="uint16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphA" offset="1" type="uint16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphB" offset="2" type="uint16" len="1" sf="A_SF" units="A" />
+      <point id="AphC" offset="3" type="uint16" len="1" sf="A_SF" units="A" />
+      <point id="A_SF" offset="4" type="sunssf" len="1" mandatory="true" />
+      <point id="PPVphAB" offset="5" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="PPVphBC" offset="6" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="PPVphCA" offset="7" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="PhVphA" offset="8" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphB" offset="9" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="PhVphC" offset="10" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="V_SF" offset="11" type="sunssf" len="1" mandatory="true" />
+      <point id="W" offset="12" type="int16" len="1" sf="W_SF" units="W" mandatory="true" />
+      <point id="W_SF" offset="13" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz" offset="14" type="uint16" len="1" sf="Hz_SF" units="Hz" mandatory="true" />
+      <point id="Hz_SF" offset="15" type="sunssf" len="1" mandatory="true" />
+      <point id="VA" offset="16" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VA_SF" offset="17" type="sunssf" len="1" />
+      <point id="VAr" offset="18" type="int16" len="1" sf="VAr_SF" units="var" />
+      <point id="VAr_SF" offset="19" type="sunssf" len="1" />
+      <point id="PF" offset="20" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PF_SF" offset="21" type="sunssf" len="1" />
+      <point id="WH" offset="22" type="acc32" len="2" sf="WH_SF" units="Wh" mandatory="true" />
+      <point id="WH_SF" offset="24" type="sunssf" len="1" mandatory="true" />
+      <point id="DCA" offset="25" type="uint16" len="1" sf="DCA_SF" units="A" />
+      <point id="DCA_SF" offset="26" type="sunssf" len="1" />
+      <point id="DCV" offset="27" type="uint16" len="1" sf="DCV_SF" units="V" />
+      <point id="DCV_SF" offset="28" type="sunssf" len="1" />
+      <point id="DCW" offset="29" type="int16" len="1" sf="DCW_SF" units="W" />
+      <point id="DCW_SF" offset="30" type="sunssf" len="1" />
+      <point id="TmpCab" offset="31" type="int16" len="1" sf="Tmp_SF" units="C" mandatory="true" />
+      <point id="TmpSnk" offset="32" type="int16" len="1" sf="Tmp_SF" units="C" />
+      <point id="TmpTrns" offset="33" type="int16" len="1" sf="Tmp_SF" units="C" />
+      <point id="TmpOt" offset="34" type="int16" len="1" sf="Tmp_SF" units="C" />
+      <point id="Tmp_SF" offset="35" type="sunssf" len="1" mandatory="true" />
+      <point id="St" offset="36" type="enum16" len="1" mandatory="true" >
         <symbol id="OFF">1</symbol>
         <symbol id="SLEEPING">2</symbol>
         <symbol id="STARTING">3</symbol>
@@ -48,8 +48,8 @@
         <symbol id="FAULT">7</symbol>
         <symbol id="STANDBY">8</symbol>
       </point>
-      <point id="StVnd" offset="37" type="enum16" />
-      <point id="Evt1" offset="38" type="bitfield32" mandatory="true" >
+      <point id="StVnd" offset="37" type="enum16" len="1" />
+      <point id="Evt1" offset="38" type="bitfield32" len="2" mandatory="true" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="DC_OVER_VOLT">1</symbol>
         <symbol id="AC_DISCONNECT">2</symbol>
@@ -67,11 +67,11 @@
         <symbol id="MEMORY_LOSS">14</symbol>
         <symbol id="HW_TEST_FAILURE">15</symbol>
       </point>
-      <point id="Evt2" offset="40" type="bitfield32" mandatory="true" />
-      <point id="EvtVnd1" offset="42" type="bitfield32" />
-      <point id="EvtVnd2" offset="44" type="bitfield32" />
-      <point id="EvtVnd3" offset="46" type="bitfield32" />
-      <point id="EvtVnd4" offset="48" type="bitfield32" />
+      <point id="Evt2" offset="40" type="bitfield32" len="2" mandatory="true" />
+      <point id="EvtVnd1" offset="42" type="bitfield32" len="2" />
+      <point id="EvtVnd2" offset="44" type="bitfield32" len="2" />
+      <point id="EvtVnd3" offset="46" type="bitfield32" len="2" />
+      <point id="EvtVnd4" offset="48" type="bitfield32" len="2" />
     </block>
   </model>
   <strings id="101" locale="en">

--- a/smdx/smdx_00102.xml
+++ b/smdx/smdx_00102.xml
@@ -77,7 +77,7 @@
     <model>
       <label>Inverter (Split-Phase)</label>
       <description>Include this model for split phase inverter monitoring</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="A">
       <label>Amps</label>
@@ -97,262 +97,262 @@
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W">
       <label>Watts</label>
       <description>AC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz">
       <label>Hz</label>
       <description>Line Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAr">
       <label>VAr</label>
       <description>AC Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>AC Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WH">
       <label>WattHours</label>
       <description>AC Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCA">
       <label>DC Amps</label>
       <description>DC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCV">
       <label>DC Voltage</label>
       <description>DC Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCW">
       <label>DC Watts</label>
       <description>DC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpCab">
       <label>Cabinet Temperature</label>
       <description>Cabinet Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpSnk">
       <label>Heat Sink Temperature</label>
       <description>Heat Sink Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpTrns">
       <label>Transformer Temperature</label>
       <description>Transformer Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpOt">
       <label>Other Temperature</label>
       <description>Other Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="St">
       <label>Operating State</label>
       <description>Enumerated value.  Operating state</description>
-      <notes></notes>
+      <notes/>
       <symbol id="OFF">
         <label>Off</label>
         <description>Device is not operating</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SLEEPING">
         <label>Sleeping</label>
         <description>Device is sleeping / auto-shutdown</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STARTING">
         <label>Starting</label>
         <description>Device is staring up</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MPPT">
         <label>MPPT</label>
         <description>Device is auto tracking maximum power point</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="THROTTLED">
         <label>Throttled</label>
         <description>Device is operating at reduced power output</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SHUTTING_DOWN">
         <label>Shutting down</label>
         <description>Device is shutting down</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>Fault</label>
         <description>One or more faults exist</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STANDBY">
         <label>Standby</label>
         <description>Device is in standby mode</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StVnd">
       <label>Vendor Operating State</label>
       <description>Vendor specific operating state code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt1">
       <label>Event1</label>
       <description>Bitmask value. Event fields</description>
-      <notes></notes>
+      <notes/>
       <symbol id="GROUND_FAULT">
         <label>Ground fault</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_OVER_VOLT">
         <label>DC over voltage</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_DISCONNECT">
         <label>AC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_DISCONNECT">
         <label>DC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="GRID_DISCONNECT">
         <label>Grid shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CABINET_OPEN">
         <label>Cabinet open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MANUAL_SHUTDOWN">
         <label>Manual shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP">
         <label>Over temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_FREQUENCY">
         <label>Frequency above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_FREQUENCY">
         <label>Frequency under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_OVER_VOLT">
         <label>AC Voltage above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_UNDER_VOLT">
         <label>AC Voltage under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="BLOWN_STRING_FUSE">
         <label>Blown String fuse on input</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP">
         <label>Under temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MEMORY_LOSS">
         <label>Generic Memory or Communication error (internal)</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="HW_TEST_FAILURE">
         <label>Hardware test failure</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="Evt2">
       <label>Event Bitfield 2</label>
       <description>Reserved for future use</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd1">
       <label>Vendor Event Bitfield 1</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd2">
       <label>Vendor Event Bitfield 2</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd3">
       <label>Vendor Event Bitfield 3</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd4">
       <label>Vendor Event Bitfield 4</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00102.xml
+++ b/smdx/smdx_00102.xml
@@ -1,43 +1,43 @@
 <sunSpecModels v="1">
   <!-- 102: inverter -->
   <model id="102" len="50" name="inverter">
-    <block len="50">
-      <point id="A" offset="0" type="uint16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphA" offset="1" type="uint16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphB" offset="2" type="uint16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphC" offset="3" type="uint16" sf="A_SF" units="A" />
-      <point id="A_SF" offset="4" type="sunssf" mandatory="true" />
-      <point id="PPVphAB" offset="5" type="uint16" sf="V_SF" units="V" />
-      <point id="PPVphBC" offset="6" type="uint16" sf="V_SF" units="V" />
-      <point id="PPVphCA" offset="7" type="uint16" sf="V_SF" units="V" />
-      <point id="PhVphA" offset="8" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphB" offset="9" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphC" offset="10" type="uint16" sf="V_SF" units="V" />
-      <point id="V_SF" offset="11" type="sunssf" mandatory="true" />
-      <point id="W" offset="12" type="int16" sf="W_SF" units="W" mandatory="true" />
-      <point id="W_SF" offset="13" type="sunssf" mandatory="true" />
-      <point id="Hz" offset="14" type="uint16" sf="Hz_SF" units="Hz" mandatory="true" />
-      <point id="Hz_SF" offset="15" type="sunssf" mandatory="true" />
-      <point id="VA" offset="16" type="int16" sf="VA_SF" units="VA" />
-      <point id="VA_SF" offset="17" type="sunssf" />
-      <point id="VAr" offset="18" type="int16" sf="VAr_SF" units="var" />
-      <point id="VAr_SF" offset="19" type="sunssf" />
-      <point id="PF" offset="20" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PF_SF" offset="21" type="sunssf" />
-      <point id="WH" offset="22" type="acc32" sf="WH_SF" units="Wh" mandatory="true" />
-      <point id="WH_SF" offset="24" type="sunssf" mandatory="true" />
-      <point id="DCA" offset="25" type="uint16" sf="DCA_SF" units="A" />
-      <point id="DCA_SF" offset="26" type="sunssf" />
-      <point id="DCV" offset="27" type="uint16" sf="DCV_SF" units="V" />
-      <point id="DCV_SF" offset="28" type="sunssf" />
-      <point id="DCW" offset="29" type="int16" sf="DCW_SF" units="W" />
-      <point id="DCW_SF" offset="30" type="sunssf" />
-      <point id="TmpCab" offset="31" type="int16" sf="Tmp_SF" units="C" mandatory="true" />
-      <point id="TmpSnk" offset="32" type="int16" sf="Tmp_SF" units="C" />
-      <point id="TmpTrns" offset="33" type="int16" sf="Tmp_SF" units="C" />
-      <point id="TmpOt" offset="34" type="int16" sf="Tmp_SF" units="C" />
-      <point id="Tmp_SF" offset="35" type="sunssf" mandatory="true" />
-      <point id="St" offset="36" type="enum16" mandatory="true" >
+    <block len="50" type="fixed">
+      <point id="A" offset="0" type="uint16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphA" offset="1" type="uint16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphB" offset="2" type="uint16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphC" offset="3" type="uint16" len="1" sf="A_SF" units="A" />
+      <point id="A_SF" offset="4" type="sunssf" len="1" mandatory="true" />
+      <point id="PPVphAB" offset="5" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="PPVphBC" offset="6" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="PPVphCA" offset="7" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="PhVphA" offset="8" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphB" offset="9" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphC" offset="10" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="V_SF" offset="11" type="sunssf" len="1" mandatory="true" />
+      <point id="W" offset="12" type="int16" len="1" sf="W_SF" units="W" mandatory="true" />
+      <point id="W_SF" offset="13" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz" offset="14" type="uint16" len="1" sf="Hz_SF" units="Hz" mandatory="true" />
+      <point id="Hz_SF" offset="15" type="sunssf" len="1" mandatory="true" />
+      <point id="VA" offset="16" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VA_SF" offset="17" type="sunssf" len="1" />
+      <point id="VAr" offset="18" type="int16" len="1" sf="VAr_SF" units="var" />
+      <point id="VAr_SF" offset="19" type="sunssf" len="1" />
+      <point id="PF" offset="20" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PF_SF" offset="21" type="sunssf" len="1" />
+      <point id="WH" offset="22" type="acc32" len="2" sf="WH_SF" units="Wh" mandatory="true" />
+      <point id="WH_SF" offset="24" type="sunssf" len="1" mandatory="true" />
+      <point id="DCA" offset="25" type="uint16" len="1" sf="DCA_SF" units="A" />
+      <point id="DCA_SF" offset="26" type="sunssf" len="1" />
+      <point id="DCV" offset="27" type="uint16" len="1" sf="DCV_SF" units="V" />
+      <point id="DCV_SF" offset="28" type="sunssf" len="1" />
+      <point id="DCW" offset="29" type="int16" len="1" sf="DCW_SF" units="W" />
+      <point id="DCW_SF" offset="30" type="sunssf" len="1" />
+      <point id="TmpCab" offset="31" type="int16" len="1" sf="Tmp_SF" units="C" mandatory="true" />
+      <point id="TmpSnk" offset="32" type="int16" len="1" sf="Tmp_SF" units="C" />
+      <point id="TmpTrns" offset="33" type="int16" len="1" sf="Tmp_SF" units="C" />
+      <point id="TmpOt" offset="34" type="int16" len="1" sf="Tmp_SF" units="C" />
+      <point id="Tmp_SF" offset="35" type="sunssf" len="1" mandatory="true" />
+      <point id="St" offset="36" type="enum16" len="1" mandatory="true" >
         <symbol id="OFF">1</symbol>
         <symbol id="SLEEPING">2</symbol>
         <symbol id="STARTING">3</symbol>
@@ -47,8 +47,8 @@
         <symbol id="FAULT">7</symbol>
         <symbol id="STANDBY">8</symbol>
       </point>
-      <point id="StVnd" offset="37" type="enum16" />
-      <point id="Evt1" offset="38" type="bitfield32" mandatory="true" >
+      <point id="StVnd" offset="37" type="enum16" len="1" />
+      <point id="Evt1" offset="38" type="bitfield32" len="2" mandatory="true" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="DC_OVER_VOLT">1</symbol>
         <symbol id="AC_DISCONNECT">2</symbol>
@@ -66,11 +66,11 @@
         <symbol id="MEMORY_LOSS">14</symbol>
         <symbol id="HW_TEST_FAILURE">15</symbol>
       </point>
-      <point id="Evt2" offset="40" type="bitfield32" mandatory="true" />
-      <point id="EvtVnd1" offset="42" type="bitfield32" />
-      <point id="EvtVnd2" offset="44" type="bitfield32" />
-      <point id="EvtVnd3" offset="46" type="bitfield32" />
-      <point id="EvtVnd4" offset="48" type="bitfield32" />
+      <point id="Evt2" offset="40" type="bitfield32" len="2" mandatory="true" />
+      <point id="EvtVnd1" offset="42" type="bitfield32" len="2" />
+      <point id="EvtVnd2" offset="44" type="bitfield32" len="2" />
+      <point id="EvtVnd3" offset="46" type="bitfield32" len="2" />
+      <point id="EvtVnd4" offset="48" type="bitfield32" len="2" />
     </block>
   </model>
   <strings id="102" locale="en">

--- a/smdx/smdx_00103.xml
+++ b/smdx/smdx_00103.xml
@@ -1,43 +1,43 @@
 <sunSpecModels v="1">
   <!-- 103: inverter -->
   <model id="103" len="50" name="inverter">
-    <block len="50">
-      <point id="A" offset="0" type="uint16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphA" offset="1" type="uint16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphB" offset="2" type="uint16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphC" offset="3" type="uint16" sf="A_SF" units="A" mandatory="true" />
-      <point id="A_SF" offset="4" type="sunssf" mandatory="true" />
-      <point id="PPVphAB" offset="5" type="uint16" sf="V_SF" units="V" />
-      <point id="PPVphBC" offset="6" type="uint16" sf="V_SF" units="V" />
-      <point id="PPVphCA" offset="7" type="uint16" sf="V_SF" units="V" />
-      <point id="PhVphA" offset="8" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphB" offset="9" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphC" offset="10" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="V_SF" offset="11" type="sunssf" mandatory="true" />
-      <point id="W" offset="12" type="int16" sf="W_SF" units="W" mandatory="true" />
-      <point id="W_SF" offset="13" type="sunssf" mandatory="true" />
-      <point id="Hz" offset="14" type="uint16" sf="Hz_SF" units="Hz" mandatory="true" />
-      <point id="Hz_SF" offset="15" type="sunssf" mandatory="true" />
-      <point id="VA" offset="16" type="int16" sf="VA_SF" units="VA" />
-      <point id="VA_SF" offset="17" type="sunssf" />
-      <point id="VAr" offset="18" type="int16" sf="VAr_SF" units="var" />
-      <point id="VAr_SF" offset="19" type="sunssf" />
-      <point id="PF" offset="20" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PF_SF" offset="21" type="sunssf" />
-      <point id="WH" offset="22" type="acc32" sf="WH_SF" units="Wh" mandatory="true" />
-      <point id="WH_SF" offset="24" type="sunssf" mandatory="true" />
-      <point id="DCA" offset="25" type="uint16" sf="DCA_SF" units="A" />
-      <point id="DCA_SF" offset="26" type="sunssf" />
-      <point id="DCV" offset="27" type="uint16" sf="DCV_SF" units="V" />
-      <point id="DCV_SF" offset="28" type="sunssf" />
-      <point id="DCW" offset="29" type="int16" sf="DCW_SF" units="W" />
-      <point id="DCW_SF" offset="30" type="sunssf" />
-      <point id="TmpCab" offset="31" type="int16" sf="Tmp_SF" units="C" mandatory="true" />
-      <point id="TmpSnk" offset="32" type="int16" sf="Tmp_SF" units="C" />
-      <point id="TmpTrns" offset="33" type="int16" sf="Tmp_SF" units="C" />
-      <point id="TmpOt" offset="34" type="int16" sf="Tmp_SF" units="C" />
-      <point id="Tmp_SF" offset="35" type="sunssf" mandatory="true" />
-      <point id="St" offset="36" type="enum16" mandatory="true" >
+    <block len="50" type="fixed">
+      <point id="A" offset="0" type="uint16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphA" offset="1" type="uint16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphB" offset="2" type="uint16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphC" offset="3" type="uint16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="A_SF" offset="4" type="sunssf" len="1" mandatory="true" />
+      <point id="PPVphAB" offset="5" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="PPVphBC" offset="6" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="PPVphCA" offset="7" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="PhVphA" offset="8" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphB" offset="9" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphC" offset="10" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="V_SF" offset="11" type="sunssf" len="1" mandatory="true" />
+      <point id="W" offset="12" type="int16" len="1" sf="W_SF" units="W" mandatory="true" />
+      <point id="W_SF" offset="13" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz" offset="14" type="uint16" len="1" sf="Hz_SF" units="Hz" mandatory="true" />
+      <point id="Hz_SF" offset="15" type="sunssf" len="1" mandatory="true" />
+      <point id="VA" offset="16" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VA_SF" offset="17" type="sunssf" len="1" />
+      <point id="VAr" offset="18" type="int16" len="1" sf="VAr_SF" units="var" />
+      <point id="VAr_SF" offset="19" type="sunssf" len="1" />
+      <point id="PF" offset="20" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PF_SF" offset="21" type="sunssf" len="1" />
+      <point id="WH" offset="22" type="acc32" len="2" sf="WH_SF" units="Wh" mandatory="true" />
+      <point id="WH_SF" offset="24" type="sunssf" len="1" mandatory="true" />
+      <point id="DCA" offset="25" type="uint16" len="1" sf="DCA_SF" units="A" />
+      <point id="DCA_SF" offset="26" type="sunssf" len="1" />
+      <point id="DCV" offset="27" type="uint16" len="1" sf="DCV_SF" units="V" />
+      <point id="DCV_SF" offset="28" type="sunssf" len="1" />
+      <point id="DCW" offset="29" type="int16" len="1" sf="DCW_SF" units="W" />
+      <point id="DCW_SF" offset="30" type="sunssf" len="1" />
+      <point id="TmpCab" offset="31" type="int16" len="1" sf="Tmp_SF" units="C" mandatory="true" />
+      <point id="TmpSnk" offset="32" type="int16" len="1" sf="Tmp_SF" units="C" />
+      <point id="TmpTrns" offset="33" type="int16" len="1" sf="Tmp_SF" units="C" />
+      <point id="TmpOt" offset="34" type="int16" len="1" sf="Tmp_SF" units="C" />
+      <point id="Tmp_SF" offset="35" type="sunssf" len="1" mandatory="true" />
+      <point id="St" offset="36" type="enum16" len="1" mandatory="true" >
         <symbol id="OFF">1</symbol>
         <symbol id="SLEEPING">2</symbol>
         <symbol id="STARTING">3</symbol>
@@ -47,8 +47,8 @@
         <symbol id="FAULT">7</symbol>
         <symbol id="STANDBY">8</symbol>
       </point>
-      <point id="StVnd" offset="37" type="enum16" />
-      <point id="Evt1" offset="38" type="bitfield32" mandatory="true" >
+      <point id="StVnd" offset="37" type="enum16" len="1" />
+      <point id="Evt1" offset="38" type="bitfield32" len="2" mandatory="true" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="DC_OVER_VOLT">1</symbol>
         <symbol id="AC_DISCONNECT">2</symbol>
@@ -66,11 +66,11 @@
         <symbol id="MEMORY_LOSS">14</symbol>
         <symbol id="HW_TEST_FAILURE">15</symbol>
       </point>
-      <point id="Evt2" offset="40" type="bitfield32" mandatory="true" />
-      <point id="EvtVnd1" offset="42" type="bitfield32" />
-      <point id="EvtVnd2" offset="44" type="bitfield32" />
-      <point id="EvtVnd3" offset="46" type="bitfield32" />
-      <point id="EvtVnd4" offset="48" type="bitfield32" />
+      <point id="Evt2" offset="40" type="bitfield32" len="2" mandatory="true" />
+      <point id="EvtVnd1" offset="42" type="bitfield32" len="2" />
+      <point id="EvtVnd2" offset="44" type="bitfield32" len="2" />
+      <point id="EvtVnd3" offset="46" type="bitfield32" len="2" />
+      <point id="EvtVnd4" offset="48" type="bitfield32" len="2" />
     </block>
   </model>
   <strings id="103" locale="en">

--- a/smdx/smdx_00103.xml
+++ b/smdx/smdx_00103.xml
@@ -77,7 +77,7 @@
     <model>
       <label>Inverter (Three Phase)</label>
       <description>Include this model for three phase inverter monitoring</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="A">
       <label>Amps</label>
@@ -102,257 +102,257 @@
     <point id="PPVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W">
       <label>Watts</label>
       <description>AC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz">
       <label>Hz</label>
       <description>Line Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAr">
       <label>VAr</label>
       <description>AC Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>AC Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WH">
       <label>WattHours</label>
       <description>AC Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCA">
       <label>DC Amps</label>
       <description>DC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCV">
       <label>DC Voltage</label>
       <description>DC Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCW">
       <label>DC Watts</label>
       <description>DC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpCab">
       <label>Cabinet Temperature</label>
       <description>Cabinet Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpSnk">
       <label>Heat Sink Temperature</label>
       <description>Heat Sink Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpTrns">
       <label>Transformer Temperature</label>
       <description>Transformer Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpOt">
       <label>Other Temperature</label>
       <description>Other Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="St">
       <label>Operating State</label>
       <description>Enumerated value.  Operating state</description>
-      <notes></notes>
+      <notes/>
       <symbol id="OFF">
         <label>Off</label>
         <description>Device is not operating</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SLEEPING">
         <label>Sleeping</label>
         <description>Device is sleeping / auto-shutdown</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STARTING">
         <label>Starting</label>
         <description>Device is staring up</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MPPT">
         <label>MPPT</label>
         <description>Device is auto tracking maximum power point</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="THROTTLED">
         <label>Throttled</label>
         <description>Device is operating at reduced power output</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SHUTTING_DOWN">
         <label>Shutting down</label>
         <description>Device is shutting down</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>Fault</label>
         <description>One or more faults exist</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STANDBY">
         <label>Standby</label>
         <description>Device is in standby mode</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StVnd">
       <label>Vendor Operating State</label>
       <description>Vendor specific operating state code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt1">
       <label>Event1</label>
       <description>Bitmask value. Event fields</description>
-      <notes></notes>
+      <notes/>
       <symbol id="GROUND_FAULT">
         <label>Ground fault</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_OVER_VOLT">
         <label>DC over voltage</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_DISCONNECT">
         <label>AC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_DISCONNECT">
         <label>DC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="GRID_DISCONNECT">
         <label>Grid shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CABINET_OPEN">
         <label>Cabinet open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MANUAL_SHUTDOWN">
         <label>Manual shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP">
         <label>Over temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_FREQUENCY">
         <label>Frequency above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_FREQUENCY">
         <label>Frequency under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_OVER_VOLT">
         <label>AC Voltage above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_UNDER_VOLT">
         <label>AC Voltage under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="BLOWN_STRING_FUSE">
         <label>Blown String fuse on input</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP">
         <label>Under temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MEMORY_LOSS">
         <label>Generic Memory or Communication error (internal)</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="HW_TEST_FAILURE">
         <label>Hardware test failure</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="Evt2">
       <label>Event Bitfield 2</label>
       <description>Reserved for future use</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd1">
       <label>Vendor Event Bitfield 1</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd2">
       <label>Vendor Event Bitfield 2</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd3">
       <label>Vendor Event Bitfield 3</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd4">
       <label>Vendor Event Bitfield 4</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00111.xml
+++ b/smdx/smdx_00111.xml
@@ -1,31 +1,31 @@
 <sunSpecModels v="1">
   <!-- 111: inverter (float) -->
   <model id="111" len="60" name="inverter">
-    <block len="60">
-      <point id="A" offset="0" type="float32" units="A" mandatory="true" />
-      <point id="AphA" offset="2" type="float32" units="A" mandatory="true" />
-      <point id="AphB" offset="4" type="float32" units="A" />
-      <point id="AphC" offset="6" type="float32" units="A" />
-      <point id="PPVphAB" offset="8" type="float32" units="V" />
-      <point id="PPVphBC" offset="10" type="float32" units="V" />
-      <point id="PPVphCA" offset="12" type="float32" units="V" />
-      <point id="PhVphA" offset="14" type="float32" units="V" mandatory="true" />
-      <point id="PhVphB" offset="16" type="float32" units="V" />
-      <point id="PhVphC" offset="18" type="float32" units="V" />
-      <point id="W" offset="20" type="float32" units="W" mandatory="true" />
-      <point id="Hz" offset="22" type="float32" units="Hz" mandatory="true" />
-      <point id="VA" offset="24" type="float32" units="VA" />
-      <point id="VAr" offset="26" type="float32" units="var" />
-      <point id="PF" offset="28" type="float32" units="Pct" />
-      <point id="WH" offset="30" type="float32" units="Wh" mandatory="true" />
-      <point id="DCA" offset="32" type="float32" units="A" />
-      <point id="DCV" offset="34" type="float32" units="V" />
-      <point id="DCW" offset="36" type="float32" units="W" />
-      <point id="TmpCab" offset="38" type="float32" units="C" mandatory="true" />
-      <point id="TmpSnk" offset="40" type="float32" units="C" />
-      <point id="TmpTrns" offset="42" type="float32" units="C" />
-      <point id="TmpOt" offset="44" type="float32" units="C" />
-      <point id="St" offset="46" type="enum16" mandatory="true" >
+    <block len="60" type="fixed">
+      <point id="A" offset="0" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphA" offset="2" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphB" offset="4" type="float32" len="2" units="A" />
+      <point id="AphC" offset="6" type="float32" len="2" units="A" />
+      <point id="PPVphAB" offset="8" type="float32" len="2" units="V" />
+      <point id="PPVphBC" offset="10" type="float32" len="2" units="V" />
+      <point id="PPVphCA" offset="12" type="float32" len="2" units="V" />
+      <point id="PhVphA" offset="14" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PhVphB" offset="16" type="float32" len="2" units="V" />
+      <point id="PhVphC" offset="18" type="float32" len="2" units="V" />
+      <point id="W" offset="20" type="float32" len="2" units="W" mandatory="true" />
+      <point id="Hz" offset="22" type="float32" len="2" units="Hz" mandatory="true" />
+      <point id="VA" offset="24" type="float32" len="2" units="VA" />
+      <point id="VAr" offset="26" type="float32" len="2" units="var" />
+      <point id="PF" offset="28" type="float32" len="2" units="Pct" />
+      <point id="WH" offset="30" type="float32" len="2" units="Wh" mandatory="true" />
+      <point id="DCA" offset="32" type="float32" len="2" units="A" />
+      <point id="DCV" offset="34" type="float32" len="2" units="V" />
+      <point id="DCW" offset="36" type="float32" len="2" units="W" />
+      <point id="TmpCab" offset="38" type="float32" len="2" units="C" mandatory="true" />
+      <point id="TmpSnk" offset="40" type="float32" len="2" units="C" />
+      <point id="TmpTrns" offset="42" type="float32" len="2" units="C" />
+      <point id="TmpOt" offset="44" type="float32" len="2" units="C" />
+      <point id="St" offset="46" type="enum16" len="1" mandatory="true" >
         <symbol id="ggOFF">1</symbol>
         <symbol id="ggSLEEPING">2</symbol>
         <symbol id="ggSTARTING">3</symbol>
@@ -35,8 +35,8 @@
         <symbol id="ggFAULT">7</symbol>
         <symbol id="ggSTANDBY">8</symbol>
       </point>
-      <point id="StVnd" offset="47" type="enum16" />
-      <point id="Evt1" offset="48" type="bitfield32" mandatory="true" >
+      <point id="StVnd" offset="47" type="enum16" len="1" />
+      <point id="Evt1" offset="48" type="bitfield32" len="2" mandatory="true" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="DC_OVER_VOLT">1</symbol>
         <symbol id="AC_DISCONNECT">2</symbol>
@@ -54,11 +54,11 @@
         <symbol id="MEMORY_LOSS">14</symbol>
         <symbol id="HW_TEST_FAILURE">15</symbol>
       </point>
-      <point id="Evt2" offset="50" type="bitfield32" mandatory="true" />
-      <point id="EvtVnd1" offset="52" type="bitfield32" />
-      <point id="EvtVnd2" offset="54" type="bitfield32" />
-      <point id="EvtVnd3" offset="56" type="bitfield32" />
-      <point id="EvtVnd4" offset="58" type="bitfield32" />
+      <point id="Evt2" offset="50" type="bitfield32" len="2" mandatory="true" />
+      <point id="EvtVnd1" offset="52" type="bitfield32" len="2" />
+      <point id="EvtVnd2" offset="54" type="bitfield32" len="2" />
+      <point id="EvtVnd3" offset="56" type="bitfield32" len="2" />
+      <point id="EvtVnd4" offset="58" type="bitfield32" len="2" />
     </block>
   </model>
   <strings id="111" locale="en">

--- a/smdx/smdx_00111.xml
+++ b/smdx/smdx_00111.xml
@@ -65,12 +65,12 @@
     <model>
       <label>Inverter (Single Phase) FLOAT</label>
       <description>Include this model for single phase inverter monitoring using float values</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphA">
       <label>Amps PhaseA</label>
@@ -80,267 +80,267 @@
     <point id="AphB">
       <label>Amps PhaseB</label>
       <description>Phase B Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W">
       <label>Watts</label>
       <description>AC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz">
       <label>Hz</label>
       <description>Line Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAr">
       <label>VAr</label>
       <description>AC Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>AC Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WH">
       <label>WattHours</label>
       <description>AC Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCA">
       <label>DC Amps</label>
       <description>DC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCV">
       <label>DC Voltage</label>
       <description>DC Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCW">
       <label>DC Watts</label>
       <description>DC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpCab">
       <label>Cabinet Temperature</label>
       <description>Cabinet Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpSnk">
       <label>Heat Sink Temperature</label>
       <description>Heat Sink Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpTrns">
       <label>Transformer Temperature</label>
       <description>Transformer Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpOt">
       <label>Other Temperature</label>
       <description>Other Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="St">
       <label>Operating State</label>
       <description>Enumerated value.  Operating state</description>
-      <notes></notes>
+      <notes/>
       <symbol id="OFF">
         <label>Off</label>
         <description>Device is not operating</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SLEEPING">
         <label>Sleeping</label>
         <description>Device is sleeping / auto-shutdown</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STARTING">
         <label>Starting</label>
         <description>Device is staring up</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ggMPPT">
         <label>MPPT</label>
         <description>Device is auto tracking maximum power point</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="THROTTLED">
         <label>Throttled</label>
         <description>Device is operating at reduced power output</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SHUTTING_DOWN">
         <label>Shutting down</label>
         <description>Device is shutting down</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>Fault</label>
         <description>One or more faults exist</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STANDBY">
         <label>Standby</label>
         <description>Device is in standby mode</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StVnd">
       <label>Vendor Operating State</label>
       <description>Vendor specific operating state code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt1">
       <label>Event1</label>
       <description>Bitmask value. Event fields</description>
-      <notes></notes>
+      <notes/>
       <symbol id="GROUND_FAULT">
         <label>Ground fault</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_OVER_VOLT">
         <label>DC over voltage</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_DISCONNECT">
         <label>AC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_DISCONNECT">
         <label>DC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="GRID_DISCONNECT">
         <label>Grid shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CABINET_OPEN">
         <label>Cabinet open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MANUAL_SHUTDOWN">
         <label>Manual shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP">
         <label>Over temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_FREQUENCY">
         <label>Frequency above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_FREQUENCY">
         <label>Frequency under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_OVER_VOLT">
         <label>AC Voltage above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_UNDER_VOLT">
         <label>AC Voltage under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="BLOWN_STRING_FUSE">
         <label>Blown String fuse on input</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP">
         <label>Under temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MEMORY_LOSS">
         <label>Generic Memory or Communication error (internal)</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="HW_TEST_FAILURE">
         <label>Hardware test failure</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="Evt2">
       <label>Event Bitfield 2</label>
       <description>Reserved for future use</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd1">
       <label>Vendor Event Bitfield 1</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd2">
       <label>Vendor Event Bitfield 2</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd3">
       <label>Vendor Event Bitfield 3</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd4">
       <label>Vendor Event Bitfield 4</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00112.xml
+++ b/smdx/smdx_00112.xml
@@ -65,12 +65,12 @@
     <model>
       <label>Inverter (Split Phase) FLOAT</label>
       <description>Include this model for split phase inverter monitoring using float values</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphA">
       <label>Amps PhaseA</label>
@@ -85,262 +85,262 @@
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W">
       <label>Watts</label>
       <description>AC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz">
       <label>Hz</label>
       <description>Line Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAr">
       <label>VAr</label>
       <description>AC Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>AC Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WH">
       <label>WattHours</label>
       <description>AC Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCA">
       <label>DC Amps</label>
       <description>DC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCV">
       <label>DC Voltage</label>
       <description>DC Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCW">
       <label>DC Watts</label>
       <description>DC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpCab">
       <label>Cabinet Temperature</label>
       <description>Cabinet Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpSnk">
       <label>Heat Sink Temperature</label>
       <description>Heat Sink Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpTrns">
       <label>Transformer Temperature</label>
       <description>Transformer Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpOt">
       <label>Other Temperature</label>
       <description>Other Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="St">
       <label>Operating State</label>
       <description>Enumerated value.  Operating state</description>
-      <notes></notes>
+      <notes/>
       <symbol id="OFF">
         <label>Off</label>
         <description>Device is not operating</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SLEEPING">
         <label>Sleeping</label>
         <description>Device is sleeping / auto-shutdown</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STARTING">
         <label>Starting</label>
         <description>Device is staring up</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MPPT">
         <label>MPPT</label>
         <description>Device is auto tracking maximum power point</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="THROTTLED">
         <label>Throttled</label>
         <description>Device is operating at reduced power output</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SHUTTING_DOWN">
         <label>Shutting down</label>
         <description>Device is shutting down</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>Fault</label>
         <description>One or more faults exist</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STANDBY">
         <label>Standby</label>
         <description>Device is in standby mode</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StVnd">
       <label>Vendor Operating State</label>
       <description>Vendor specific operating state code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt1">
       <label>Event1</label>
       <description>Bitmask value. Event fields</description>
-      <notes></notes>
+      <notes/>
       <symbol id="GROUND_FAULT">
         <label>Ground fault</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_OVER_VOLT">
         <label>DC over voltage</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_DISCONNECT">
         <label>AC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_DISCONNECT">
         <label>DC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="GRID_DISCONNECT">
         <label>Grid shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CABINET_OPEN">
         <label>Cabinet open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MANUAL_SHUTDOWN">
         <label>Manual shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP">
         <label>Over temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_FREQUENCY">
         <label>Frequency above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_FREQUENCY">
         <label>Frequency under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_OVER_VOLT">
         <label>AC Voltage above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_UNDER_VOLT">
         <label>AC Voltage under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="BLOWN_STRING_FUSE">
         <label>Blown String fuse on input</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP">
         <label>Under temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MEMORY_LOSS">
         <label>Generic Memory or Communication error (internal)</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="HW_TEST_FAILURE">
         <label>Hardware test failure</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="Evt2">
       <label>Event Bitfield 2</label>
       <description>Reserved for future use</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd1">
       <label>Vendor Event Bitfield 1</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd2">
       <label>Vendor Event Bitfield 2</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd3">
       <label>Vendor Event Bitfield 3</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd4">
       <label>Vendor Event Bitfield 4</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00112.xml
+++ b/smdx/smdx_00112.xml
@@ -1,31 +1,31 @@
 <sunSpecModels v="1">
   <!-- 112: inverter (float) -->
   <model id="112" len="60" name="inverter">
-    <block len="60">
-      <point id="A" offset="0" type="float32" units="A" mandatory="true" />
-      <point id="AphA" offset="2" type="float32" units="A" mandatory="true" />
-      <point id="AphB" offset="4" type="float32" units="A" mandatory="true" />
-      <point id="AphC" offset="6" type="float32" units="A" />
-      <point id="PPVphAB" offset="8" type="float32" units="V" />
-      <point id="PPVphBC" offset="10" type="float32" units="V" />
-      <point id="PPVphCA" offset="12" type="float32" units="V" />
-      <point id="PhVphA" offset="14" type="float32" units="V" mandatory="true" />
-      <point id="PhVphB" offset="16" type="float32" units="V" mandatory="true" />
-      <point id="PhVphC" offset="18" type="float32" units="V" />
-      <point id="W" offset="20" type="float32" units="W" mandatory="true" />
-      <point id="Hz" offset="22" type="float32" units="Hz" mandatory="true" />
-      <point id="VA" offset="24" type="float32" units="VA" />
-      <point id="VAr" offset="26" type="float32" units="var" />
-      <point id="PF" offset="28" type="float32" units="Pct" />
-      <point id="WH" offset="30" type="float32" units="Wh" mandatory="true" />
-      <point id="DCA" offset="32" type="float32" units="A" />
-      <point id="DCV" offset="34" type="float32" units="V" />
-      <point id="DCW" offset="36" type="float32" units="W" />
-      <point id="TmpCab" offset="38" type="float32" units="C" mandatory="true" />
-      <point id="TmpSnk" offset="40" type="float32" units="C" />
-      <point id="TmpTrns" offset="42" type="float32" units="C" />
-      <point id="TmpOt" offset="44" type="float32" units="C" />
-      <point id="St" offset="46" type="enum16" mandatory="true" >
+    <block len="60" type="fixed">
+      <point id="A" offset="0" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphA" offset="2" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphB" offset="4" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphC" offset="6" type="float32" len="2" units="A" />
+      <point id="PPVphAB" offset="8" type="float32" len="2" units="V" />
+      <point id="PPVphBC" offset="10" type="float32" len="2" units="V" />
+      <point id="PPVphCA" offset="12" type="float32" len="2" units="V" />
+      <point id="PhVphA" offset="14" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PhVphB" offset="16" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PhVphC" offset="18" type="float32" len="2" units="V" />
+      <point id="W" offset="20" type="float32" len="2" units="W" mandatory="true" />
+      <point id="Hz" offset="22" type="float32" len="2" units="Hz" mandatory="true" />
+      <point id="VA" offset="24" type="float32" len="2" units="VA" />
+      <point id="VAr" offset="26" type="float32" len="2" units="var" />
+      <point id="PF" offset="28" type="float32" len="2" units="Pct" />
+      <point id="WH" offset="30" type="float32" len="2" units="Wh" mandatory="true" />
+      <point id="DCA" offset="32" type="float32" len="2" units="A" />
+      <point id="DCV" offset="34" type="float32" len="2" units="V" />
+      <point id="DCW" offset="36" type="float32" len="2" units="W" />
+      <point id="TmpCab" offset="38" type="float32" len="2" units="C" mandatory="true" />
+      <point id="TmpSnk" offset="40" type="float32" len="2" units="C" />
+      <point id="TmpTrns" offset="42" type="float32" len="2" units="C" />
+      <point id="TmpOt" offset="44" type="float32" len="2" units="C" />
+      <point id="St" offset="46" type="enum16" len="1" mandatory="true" >
         <symbol id="OFF">1</symbol>
         <symbol id="SLEEPING">2</symbol>
         <symbol id="STARTING">3</symbol>
@@ -35,8 +35,8 @@
         <symbol id="FAULT">7</symbol>
         <symbol id="STANDBY">8</symbol>
       </point>
-      <point id="StVnd" offset="47" type="enum16" />
-      <point id="Evt1" offset="48" type="bitfield32" mandatory="true" >
+      <point id="StVnd" offset="47" type="enum16" len="1" />
+      <point id="Evt1" offset="48" type="bitfield32" len="2" mandatory="true" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="DC_OVER_VOLT">1</symbol>
         <symbol id="AC_DISCONNECT">2</symbol>
@@ -54,11 +54,11 @@
         <symbol id="MEMORY_LOSS">14</symbol>
         <symbol id="HW_TEST_FAILURE">15</symbol>
       </point>
-      <point id="Evt2" offset="50" type="bitfield32" mandatory="true" />
-      <point id="EvtVnd1" offset="52" type="bitfield32" />
-      <point id="EvtVnd2" offset="54" type="bitfield32" />
-      <point id="EvtVnd3" offset="56" type="bitfield32" />
-      <point id="EvtVnd4" offset="58" type="bitfield32" />
+      <point id="Evt2" offset="50" type="bitfield32" len="2" mandatory="true" />
+      <point id="EvtVnd1" offset="52" type="bitfield32" len="2" />
+      <point id="EvtVnd2" offset="54" type="bitfield32" len="2" />
+      <point id="EvtVnd3" offset="56" type="bitfield32" len="2" />
+      <point id="EvtVnd4" offset="58" type="bitfield32" len="2" />
     </block>
   </model>
   <strings id="112" locale="en">

--- a/smdx/smdx_00113.xml
+++ b/smdx/smdx_00113.xml
@@ -1,31 +1,31 @@
 <sunSpecModels v="1">
   <!-- 113: inverter (float) -->
   <model id="113" len="60" name="inverter">
-    <block len="60">
-      <point id="A" offset="0" type="float32" units="A" mandatory="true" />
-      <point id="AphA" offset="2" type="float32" units="A" mandatory="true" />
-      <point id="AphB" offset="4" type="float32" units="A" mandatory="true" />
-      <point id="AphC" offset="6" type="float32" units="A" mandatory="true" />
-      <point id="PPVphAB" offset="8" type="float32" units="V" />
-      <point id="PPVphBC" offset="10" type="float32" units="V" />
-      <point id="PPVphCA" offset="12" type="float32" units="V" />
-      <point id="PhVphA" offset="14" type="float32" units="V" mandatory="true" />
-      <point id="PhVphB" offset="16" type="float32" units="V" mandatory="true" />
-      <point id="PhVphC" offset="18" type="float32" units="V" mandatory="true" />
-      <point id="W" offset="20" type="float32" units="W" mandatory="true" />
-      <point id="Hz" offset="22" type="float32" units="Hz" mandatory="true" />
-      <point id="VA" offset="24" type="float32" units="VA" />
-      <point id="VAr" offset="26" type="float32" units="var" />
-      <point id="PF" offset="28" type="float32" units="Pct" />
-      <point id="WH" offset="30" type="float32" units="Wh" mandatory="true" />
-      <point id="DCA" offset="32" type="float32" units="A" />
-      <point id="DCV" offset="34" type="float32" units="V" />
-      <point id="DCW" offset="36" type="float32" units="W" />
-      <point id="TmpCab" offset="38" type="float32" units="C" mandatory="true" />
-      <point id="TmpSnk" offset="40" type="float32" units="C" />
-      <point id="TmpTrns" offset="42" type="float32" units="C" />
-      <point id="TmpOt" offset="44" type="float32" units="C" />
-      <point id="St" offset="46" type="enum16" mandatory="true" >
+    <block len="60" type="fixed">
+      <point id="A" offset="0" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphA" offset="2" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphB" offset="4" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphC" offset="6" type="float32" len="2" units="A" mandatory="true" />
+      <point id="PPVphAB" offset="8" type="float32" len="2" units="V" />
+      <point id="PPVphBC" offset="10" type="float32" len="2" units="V" />
+      <point id="PPVphCA" offset="12" type="float32" len="2" units="V" />
+      <point id="PhVphA" offset="14" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PhVphB" offset="16" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PhVphC" offset="18" type="float32" len="2" units="V" mandatory="true" />
+      <point id="W" offset="20" type="float32" len="2" units="W" mandatory="true" />
+      <point id="Hz" offset="22" type="float32" len="2" units="Hz" mandatory="true" />
+      <point id="VA" offset="24" type="float32" len="2" units="VA" />
+      <point id="VAr" offset="26" type="float32" len="2" units="var" />
+      <point id="PF" offset="28" type="float32" len="2" units="Pct" />
+      <point id="WH" offset="30" type="float32" len="2" units="Wh" mandatory="true" />
+      <point id="DCA" offset="32" type="float32" len="2" units="A" />
+      <point id="DCV" offset="34" type="float32" len="2" units="V" />
+      <point id="DCW" offset="36" type="float32" len="2" units="W" />
+      <point id="TmpCab" offset="38" type="float32" len="2" units="C" mandatory="true" />
+      <point id="TmpSnk" offset="40" type="float32" len="2" units="C" />
+      <point id="TmpTrns" offset="42" type="float32" len="2" units="C" />
+      <point id="TmpOt" offset="44" type="float32" len="2" units="C" />
+      <point id="St" offset="46" type="enum16" len="1" mandatory="true" >
         <symbol id="OFF">1</symbol>
         <symbol id="SLEEPING">2</symbol>
         <symbol id="STARTING">3</symbol>
@@ -35,8 +35,8 @@
         <symbol id="FAULT">7</symbol>
         <symbol id="STANDBY">8</symbol>
       </point>
-      <point id="StVnd" offset="47" type="enum16" />
-      <point id="Evt1" offset="48" type="bitfield32" mandatory="true" >
+      <point id="StVnd" offset="47" type="enum16" len="1" />
+      <point id="Evt1" offset="48" type="bitfield32" len="2" mandatory="true" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="DC_OVER_VOLT">1</symbol>
         <symbol id="AC_DISCONNECT">2</symbol>
@@ -54,11 +54,11 @@
         <symbol id="MEMORY_LOSS">14</symbol>
         <symbol id="HW_TEST_FAILURE">15</symbol>
       </point>
-      <point id="Evt2" offset="50" type="bitfield32" mandatory="true" />
-      <point id="EvtVnd1" offset="52" type="bitfield32" />
-      <point id="EvtVnd2" offset="54" type="bitfield32" />
-      <point id="EvtVnd3" offset="56" type="bitfield32" />
-      <point id="EvtVnd4" offset="58" type="bitfield32" />
+      <point id="Evt2" offset="50" type="bitfield32" len="2" mandatory="true" />
+      <point id="EvtVnd1" offset="52" type="bitfield32" len="2" />
+      <point id="EvtVnd2" offset="54" type="bitfield32" len="2" />
+      <point id="EvtVnd3" offset="56" type="bitfield32" len="2" />
+      <point id="EvtVnd4" offset="58" type="bitfield32" len="2" />
     </block>
   </model>
   <strings id="113" locale="en">

--- a/smdx/smdx_00113.xml
+++ b/smdx/smdx_00113.xml
@@ -65,7 +65,7 @@
     <model>
       <label>Inverter (Three Phase) FLOAT</label>
       <description>Include this model for three phase inverter monitoring using float values</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="A">
       <label>Amps</label>
@@ -90,257 +90,257 @@
     <point id="PPVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W">
       <label>Watts</label>
       <description>AC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz">
       <label>Hz</label>
       <description>Line Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAr">
       <label>VAr</label>
       <description>AC Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>AC Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WH">
       <label>WattHours</label>
       <description>AC Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCA">
       <label>DC Amps</label>
       <description>DC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCV">
       <label>DC Voltage</label>
       <description>DC Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCW">
       <label>DC Watts</label>
       <description>DC Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpCab">
       <label>Cabinet Temperature</label>
       <description>Cabinet Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpSnk">
       <label>Heat Sink Temperature</label>
       <description>Heat Sink Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpTrns">
       <label>Transformer Temperature</label>
       <description>Transformer Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpOt">
       <label>Other Temperature</label>
       <description>Other Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="St">
       <label>Operating State</label>
       <description>Enumerated value.  Operating state</description>
-      <notes></notes>
+      <notes/>
       <symbol id="OFF">
         <label>Off</label>
         <description>Device is not operating</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SLEEPING">
         <label>Sleeping</label>
         <description>Device is sleeping / auto-shutdown</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STARTING">
         <label>Starting</label>
         <description>Device is staring up</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MPPT">
         <label>MPPT</label>
         <description>Device is auto tracking maximum power point</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="THROTTLED">
         <label>Throttled</label>
         <description>Device is operating at reduced power output</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SHUTTING_DOWN">
         <label>Shutting down</label>
         <description>Device is shutting down</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>Fault</label>
         <description>One or more faults exist</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STANDBY">
         <label>Standby</label>
         <description>Device is in standby mode</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StVnd">
       <label>Vendor Operating State</label>
       <description>Vendor specific operating state code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt1">
       <label>Event1</label>
       <description>Bitmask value. Event fields</description>
-      <notes></notes>
+      <notes/>
       <symbol id="GROUND_FAULT">
         <label>Ground fault</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_OVER_VOLT">
         <label>DC over voltage</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_DISCONNECT">
         <label>AC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_DISCONNECT">
         <label>DC disconnect open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="GRID_DISCONNECT">
         <label>Grid shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CABINET_OPEN">
         <label>Cabinet open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MANUAL_SHUTDOWN">
         <label>Manual shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP">
         <label>Over temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_FREQUENCY">
         <label>Frequency above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_FREQUENCY">
         <label>Frequency under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_OVER_VOLT">
         <label>AC Voltage above limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="AC_UNDER_VOLT">
         <label>AC Voltage under limit</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="BLOWN_STRING_FUSE">
         <label>Blown String fuse on input</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP">
         <label>Under temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MEMORY_LOSS">
         <label>Generic Memory or Communication error (internal)</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="HW_TEST_FAILURE">
         <label>Hardware test failure</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="Evt2">
       <label>Event Bitfield 2</label>
       <description>Reserved for future use</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd1">
       <label>Vendor Event Bitfield 1</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd2">
       <label>Vendor Event Bitfield 2</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd3">
       <label>Vendor Event Bitfield 3</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd4">
       <label>Vendor Event Bitfield 4</label>
       <description>Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00120.xml
+++ b/smdx/smdx_00120.xml
@@ -2,35 +2,35 @@
   <!-- 120: Inverter Controls Nameplate Ratings  -->
   <model id="120" len="26" name="nameplate">
     <block len="26" type="fixed">
-      <point id="DERTyp" offset="0" access="r" type="enum16" len="1" mandatory="true">
+      <point id="DERTyp" offset="0" type="enum16" len="1" mandatory="true" >
         <symbol id="PV">4</symbol>
         <symbol id="PV_STOR">82</symbol>
       </point>
-      <point id="WRtg" offset="1" access="r" type="uint16" len="1" mandatory="true" units="W" sf="WRtg_SF"/>
-      <point id="WRtg_SF" offset="2" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="VARtg" offset="3" access="r" type="uint16" len="1" mandatory="true" units="VA" sf="VARtg_SF"/>
-      <point id="VARtg_SF" offset="4" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="VArRtgQ1" offset="5" access="r" type="int16" len="1" mandatory="true" units="var" sf="VArRtg_SF"/>
-      <point id="VArRtgQ2" offset="6" access="r" type="int16" len="1" mandatory="true" units="var" sf="VArRtg_SF"/>
-      <point id="VArRtgQ3" offset="7" access="r" type="int16" len="1" mandatory="true" units="var" sf="VArRtg_SF"/>
-      <point id="VArRtgQ4" offset="8" access="r" type="int16" len="1" mandatory="true" units="var" sf="VArRtg_SF"/>
-      <point id="VArRtg_SF" offset="9" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="ARtg" offset="10" access="r" type="uint16" len="1" mandatory="true" units="A" sf="ARtg_SF"/>
-      <point id="ARtg_SF" offset="11" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="PFRtgQ1" offset="12" access="r" type="int16" len="1" mandatory="true" units="cos()" sf="PFRtg_SF"/>
-      <point id="PFRtgQ2" offset="13" access="r" type="int16" len="1" mandatory="true" units="cos()" sf="PFRtg_SF"/>
-      <point id="PFRtgQ3" offset="14" access="r" type="int16" len="1" mandatory="true" units="cos()" sf="PFRtg_SF"/>
-      <point id="PFRtgQ4" offset="15" access="r" type="int16" len="1" mandatory="true" units="cos()" sf="PFRtg_SF"/>
-      <point id="PFRtg_SF" offset="16" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="WHRtg" offset="17" access="r" type="uint16" len="1" mandatory="false" units="Wh" sf="WHRtg_SF"/>
-      <point id="WHRtg_SF" offset="18" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="AhrRtg" offset="19" access="r" type="uint16" len="1" mandatory="false" units="AH" sf="AhrRtg_SF"/>
-      <point id="AhrRtg_SF" offset="20" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="MaxChaRte" offset="21" access="r" type="uint16" len="1" mandatory="false" units="W" sf="MaxChaRte_SF"/>
-      <point id="MaxChaRte_SF" offset="22" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="MaxDisChaRte" offset="23" access="r" type="uint16" len="1" mandatory="false" units="W" sf="MaxDisChaRte_SF"/>
-      <point id="MaxDisChaRte_SF" offset="24" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="Pad" offset="25" access="r" type="pad" len="1" mandatory="false"  />
+      <point id="WRtg" offset="1" type="uint16" len="1" sf="WRtg_SF" units="W" mandatory="true" />
+      <point id="WRtg_SF" offset="2" type="sunssf" len="1" mandatory="true" />
+      <point id="VARtg" offset="3" type="uint16" len="1" sf="VARtg_SF" units="VA" mandatory="true" />
+      <point id="VARtg_SF" offset="4" type="sunssf" len="1" mandatory="true" />
+      <point id="VArRtgQ1" offset="5" type="int16" len="1" sf="VArRtg_SF" units="var" mandatory="true" />
+      <point id="VArRtgQ2" offset="6" type="int16" len="1" sf="VArRtg_SF" units="var" mandatory="true" />
+      <point id="VArRtgQ3" offset="7" type="int16" len="1" sf="VArRtg_SF" units="var" mandatory="true" />
+      <point id="VArRtgQ4" offset="8" type="int16" len="1" sf="VArRtg_SF" units="var" mandatory="true" />
+      <point id="VArRtg_SF" offset="9" type="sunssf" len="1" mandatory="true" />
+      <point id="ARtg" offset="10" type="uint16" len="1" sf="ARtg_SF" units="A" mandatory="true" />
+      <point id="ARtg_SF" offset="11" type="sunssf" len="1" mandatory="true" />
+      <point id="PFRtgQ1" offset="12" type="int16" len="1" sf="PFRtg_SF" units="cos()" mandatory="true" />
+      <point id="PFRtgQ2" offset="13" type="int16" len="1" sf="PFRtg_SF" units="cos()" mandatory="true" />
+      <point id="PFRtgQ3" offset="14" type="int16" len="1" sf="PFRtg_SF" units="cos()" mandatory="true" />
+      <point id="PFRtgQ4" offset="15" type="int16" len="1" sf="PFRtg_SF" units="cos()" mandatory="true" />
+      <point id="PFRtg_SF" offset="16" type="sunssf" len="1" mandatory="true" />
+      <point id="WHRtg" offset="17" type="uint16" len="1" sf="WHRtg_SF" units="Wh" />
+      <point id="WHRtg_SF" offset="18" type="sunssf" len="1" />
+      <point id="AhrRtg" offset="19" type="uint16" len="1" sf="AhrRtg_SF" units="AH" />
+      <point id="AhrRtg_SF" offset="20" type="sunssf" len="1" />
+      <point id="MaxChaRte" offset="21" type="uint16" len="1" sf="MaxChaRte_SF" units="W" />
+      <point id="MaxChaRte_SF" offset="22" type="sunssf" len="1" />
+      <point id="MaxDisChaRte" offset="23" type="uint16" len="1" sf="MaxDisChaRte_SF" units="W" />
+      <point id="MaxDisChaRte_SF" offset="24" type="sunssf" len="1" />
+      <point id="Pad" offset="25" type="pad" len="1" />
     </block>
   </model>
   <strings id="120" locale="en">

--- a/smdx/smdx_00121.xml
+++ b/smdx/smdx_00121.xml
@@ -2,46 +2,46 @@
   <!-- 121: Inverter Controls Basic Settings  -->
   <model id="121" len="30" name="settings">
     <block len="30" type="fixed">
-      <point id="WMax" offset="0" access="rw" type="uint16" len="1" mandatory="true" units="W" sf="WMax_SF"/>
-      <point id="VRef" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="V" sf="VRef_SF"/>
-      <point id="VRefOfs" offset="2" access="rw" type="int16" len="1" mandatory="true" units="V" sf="VRefOfs_SF"/>
-      <point id="VMax" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="V" sf="VMinMax_SF"/>
-      <point id="VMin" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="V" sf="VMinMax_SF"/>
-      <point id="VAMax" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="VA" sf="VAMax_SF"/>
-      <point id="VArMaxQ1" offset="6" access="rw" type="int16" len="1" mandatory="false" units="var" sf="VArMax_SF"/>
-      <point id="VArMaxQ2" offset="7" access="rw" type="int16" len="1" mandatory="false" units="var" sf="VArMax_SF"/>
-      <point id="VArMaxQ3" offset="8" access="rw" type="int16" len="1" mandatory="false" units="var" sf="VArMax_SF"/>
-      <point id="VArMaxQ4" offset="9" access="rw" type="int16" len="1" mandatory="false" units="var" sf="VArMax_SF"/>
-      <point id="WGra" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="% WMax/sec" sf="WGra_SF"/>
-      <point id="PFMinQ1" offset="11" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PFMin_SF"/>
-      <point id="PFMinQ2" offset="12" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PFMin_SF"/>
-      <point id="PFMinQ3" offset="13" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PFMin_SF"/>
-      <point id="PFMinQ4" offset="14" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PFMin_SF"/>
-      <point id="VArAct" offset="15" access="rw" type="enum16" len="1" mandatory="false"  >
+      <point id="WMax" offset="0" type="uint16" len="1" sf="WMax_SF" access="rw" units="W" mandatory="true" />
+      <point id="VRef" offset="1" type="uint16" len="1" sf="VRef_SF" access="rw" units="V" mandatory="true" />
+      <point id="VRefOfs" offset="2" type="int16" len="1" sf="VRefOfs_SF" access="rw" units="V" mandatory="true" />
+      <point id="VMax" offset="3" type="uint16" len="1" sf="VMinMax_SF" access="rw" units="V" />
+      <point id="VMin" offset="4" type="uint16" len="1" sf="VMinMax_SF" access="rw" units="V" />
+      <point id="VAMax" offset="5" type="uint16" len="1" sf="VAMax_SF" access="rw" units="VA" />
+      <point id="VArMaxQ1" offset="6" type="int16" len="1" sf="VArMax_SF" access="rw" units="var" />
+      <point id="VArMaxQ2" offset="7" type="int16" len="1" sf="VArMax_SF" access="rw" units="var" />
+      <point id="VArMaxQ3" offset="8" type="int16" len="1" sf="VArMax_SF" access="rw" units="var" />
+      <point id="VArMaxQ4" offset="9" type="int16" len="1" sf="VArMax_SF" access="rw" units="var" />
+      <point id="WGra" offset="10" type="uint16" len="1" sf="WGra_SF" access="rw" units="% WMax/sec" />
+      <point id="PFMinQ1" offset="11" type="int16" len="1" sf="PFMin_SF" access="rw" units="cos()" />
+      <point id="PFMinQ2" offset="12" type="int16" len="1" sf="PFMin_SF" access="rw" units="cos()" />
+      <point id="PFMinQ3" offset="13" type="int16" len="1" sf="PFMin_SF" access="rw" units="cos()" />
+      <point id="PFMinQ4" offset="14" type="int16" len="1" sf="PFMin_SF" access="rw" units="cos()" />
+      <point id="VArAct" offset="15" type="enum16" len="1" access="rw" >
         <symbol id="SWITCH">1</symbol>
         <symbol id="MAINTAIN">2</symbol>
       </point>
-      <point id="ClcTotVA" offset="16" access="rw" type="enum16" len="1" mandatory="false">
+      <point id="ClcTotVA" offset="16" type="enum16" len="1" access="rw" >
         <symbol id="VECTOR">1</symbol>
         <symbol id="ARITHMETIC">2</symbol>
       </point>
-      <point id="MaxRmpRte" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="% WGra" sf="MaxRmpRte_SF"/>
-      <point id="ECPNomHz" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="ECPNomHz_SF"/>
-      <point id="ConnPh" offset="19" access="rw" type="enum16" len="1" mandatory="false">
+      <point id="MaxRmpRte" offset="17" type="uint16" len="1" sf="MaxRmpRte_SF" access="rw" units="% WGra" />
+      <point id="ECPNomHz" offset="18" type="uint16" len="1" sf="ECPNomHz_SF" access="rw" units="Hz" />
+      <point id="ConnPh" offset="19" type="enum16" len="1" access="rw" >
         <symbol id="A">1</symbol>
         <symbol id="B">2</symbol>
         <symbol id="C">3</symbol>
       </point>
-      <point id="WMax_SF" offset="20" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="VRef_SF" offset="21" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="VRefOfs_SF" offset="22" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="VMinMax_SF" offset="23" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="VAMax_SF" offset="24" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="VArMax_SF" offset="25" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="WGra_SF" offset="26" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="PFMin_SF" offset="27" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="MaxRmpRte_SF" offset="28" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="ECPNomHz_SF" offset="29" access="r" type="sunssf" len="1" mandatory="false"  />
+      <point id="WMax_SF" offset="20" type="sunssf" len="1" mandatory="true" />
+      <point id="VRef_SF" offset="21" type="sunssf" len="1" mandatory="true" />
+      <point id="VRefOfs_SF" offset="22" type="sunssf" len="1" mandatory="true" />
+      <point id="VMinMax_SF" offset="23" type="sunssf" len="1" />
+      <point id="VAMax_SF" offset="24" type="sunssf" len="1" />
+      <point id="VArMax_SF" offset="25" type="sunssf" len="1" />
+      <point id="WGra_SF" offset="26" type="sunssf" len="1" />
+      <point id="PFMin_SF" offset="27" type="sunssf" len="1" />
+      <point id="MaxRmpRte_SF" offset="28" type="sunssf" len="1" />
+      <point id="ECPNomHz_SF" offset="29" type="sunssf" len="1" />
     </block>
   </model>
   <strings id="121" locale="en">

--- a/smdx/smdx_00122.xml
+++ b/smdx/smdx_00122.xml
@@ -2,32 +2,32 @@
   <!-- 122: Inverter Controls Extended Measurements and Status  -->
   <model id="122" len="44" name="status">
     <block len="44" type="fixed">
-      <point id="PVConn" offset="0" access="r" type="bitfield16" len="1" mandatory="true">
+      <point id="PVConn" offset="0" type="bitfield16" len="1" mandatory="true" >
         <symbol id="CONNECTED">0</symbol>
         <symbol id="AVAILABLE">1</symbol>
         <symbol id="OPERATING">2</symbol>
         <symbol id="TEST">3</symbol>
       </point>
-      <point id="StorConn" offset="1" access="r" type="bitfield16" len="1" mandatory="true">
+      <point id="StorConn" offset="1" type="bitfield16" len="1" mandatory="true" >
         <symbol id="CONNECTED">0</symbol>
         <symbol id="AVAILABLE">1</symbol>
         <symbol id="OPERATING">2</symbol>
         <symbol id="TEST">3</symbol>
       </point>
-      <point id="ECPConn" offset="2" access="r" type="bitfield16" len="1" mandatory="true">
+      <point id="ECPConn" offset="2" type="bitfield16" len="1" mandatory="true" >
         <symbol id="CONNECTED">0</symbol>
       </point>
-      <point id="ActWh" offset="3" access="r" type="acc64" len="4" mandatory="false" units="Wh" />
-      <point id="ActVAh" offset="7" access="r" type="acc64" len="4" mandatory="false" units="VAh" />
-      <point id="ActVArhQ1" offset="11" access="r" type="acc64" len="4" mandatory="false" units="varh" />
-      <point id="ActVArhQ2" offset="15" access="r" type="acc64" len="4" mandatory="false" units="varh" />
-      <point id="ActVArhQ3" offset="19" access="r" type="acc64" len="4" mandatory="false" units="varh" />
-      <point id="ActVArhQ4" offset="23" access="r" type="acc64" len="4" mandatory="false" units="varh" />
-      <point id="VArAval" offset="27" access="r" type="int16" len="1" mandatory="false" units="var" sf="VArAval_SF"/>
-      <point id="VArAval_SF" offset="28" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="WAval" offset="29" access="r" type="uint16" len="1" mandatory="false" units="var" sf="WAval_SF"/>
-      <point id="WAval_SF" offset="30" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="StSetLimMsk" offset="31" access="r" type="bitfield32" len="2" mandatory="false">
+      <point id="ActWh" offset="3" type="acc64" len="4" units="Wh" />
+      <point id="ActVAh" offset="7" type="acc64" len="4" units="VAh" />
+      <point id="ActVArhQ1" offset="11" type="acc64" len="4" units="varh" />
+      <point id="ActVArhQ2" offset="15" type="acc64" len="4" units="varh" />
+      <point id="ActVArhQ3" offset="19" type="acc64" len="4" units="varh" />
+      <point id="ActVArhQ4" offset="23" type="acc64" len="4" units="varh" />
+      <point id="VArAval" offset="27" type="int16" len="1" sf="VArAval_SF" units="var" />
+      <point id="VArAval_SF" offset="28" type="sunssf" len="1" />
+      <point id="WAval" offset="29" type="uint16" len="1" sf="WAval_SF" units="var" />
+      <point id="WAval_SF" offset="30" type="sunssf" len="1" />
+      <point id="StSetLimMsk" offset="31" type="bitfield32" len="2" >
         <symbol id="WMax">0</symbol>
         <symbol id="VAMax">1</symbol>
         <symbol id="VArAval">2</symbol>
@@ -40,7 +40,7 @@
         <symbol id="PFMinQ3">9</symbol>
         <symbol id="PFMinQ4">10</symbol>
       </point>
-      <point id="StActCtl" offset="33" access="r" type="bitfield32" len="2" mandatory="false">
+      <point id="StActCtl" offset="33" type="bitfield32" len="2" >
         <symbol id="FixedW">0</symbol>
         <symbol id="FixedVAR">1</symbol>
         <symbol id="FixedPF">2</symbol>
@@ -56,16 +56,16 @@
         <symbol id="LFRT">13</symbol>
         <symbol id="HFRT">14</symbol>
       </point>
-      <point id="TmSrc" offset="35" access="r" type="string" len="4" mandatory="false"  />
-      <point id="Tms" offset="39" access="r" type="uint32" len="2" mandatory="false" units="Secs" />
-      <point id="RtSt" offset="41" access="r" type="bitfield16" len="1" mandatory="false">
+      <point id="TmSrc" offset="35" type="string" len="4" />
+      <point id="Tms" offset="39" type="uint32" len="2" units="Secs" />
+      <point id="RtSt" offset="41" type="bitfield16" len="1" >
         <symbol id="LVRT_ACTIVE">0</symbol>
         <symbol id="HVRT_ACTIVE">1</symbol>
         <symbol id="LFRT_ACTIVE">2</symbol>
         <symbol id="HFRT_ACTIVE">3</symbol>
       </point>
-      <point id="Ris" offset="42" access="r" type="uint16" len="1" mandatory="false" units="ohms" sf="Ris_SF"/>
-      <point id="Ris_SF" offset="43" access="r" type="sunssf" len="1" mandatory="false"  />
+      <point id="Ris" offset="42" type="uint16" len="1" sf="Ris_SF" units="ohms" />
+      <point id="Ris_SF" offset="43" type="sunssf" len="1" />
     </block>
   </model>
   <strings id="122" locale="en">

--- a/smdx/smdx_00123.xml
+++ b/smdx/smdx_00123.xml
@@ -2,47 +2,47 @@
   <!-- 123: Immediate Inverter Controls  -->
   <model id="123" len="24" name="controls">
     <block len="24" type="fixed">
-      <point id="Conn_WinTms" offset="0" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="Conn_RvrtTms" offset="1" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="Conn" offset="2" access="rw" type="enum16" len="1" mandatory="true">
+      <point id="Conn_WinTms" offset="0" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="Conn_RvrtTms" offset="1" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="Conn" offset="2" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="DISCONNECT">0</symbol>
         <symbol id="CONNECT">1</symbol>
       </point>
-      <point id="WMaxLimPct" offset="3" access="rw" type="uint16" len="1" mandatory="true" units="% WMax" sf="WMaxLimPct_SF"/>
-      <point id="WMaxLimPct_WinTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="WMaxLimPct_RvrtTms" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="WMaxLimPct_RmpTms" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="WMaxLim_Ena" offset="7" access="rw" type="enum16" len="1" mandatory="true">
+      <point id="WMaxLimPct" offset="3" type="uint16" len="1" sf="WMaxLimPct_SF" access="rw" units="% WMax" mandatory="true" />
+      <point id="WMaxLimPct_WinTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="WMaxLimPct_RvrtTms" offset="5" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="WMaxLimPct_RmpTms" offset="6" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="WMaxLim_Ena" offset="7" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="DISABLED">0</symbol>
         <symbol id="ENABLED">1</symbol>
       </point>
-      <point id="OutPFSet" offset="8" access="rw" type="int16" len="1" mandatory="true" units="cos()" sf="OutPFSet_SF"/>
-      <point id="OutPFSet_WinTms" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="OutPFSet_RvrtTms" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="OutPFSet_RmpTms" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="OutPFSet_Ena" offset="12" access="rw" type="enum16" len="1" mandatory="true">
+      <point id="OutPFSet" offset="8" type="int16" len="1" sf="OutPFSet_SF" access="rw" units="cos()" mandatory="true" />
+      <point id="OutPFSet_WinTms" offset="9" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="OutPFSet_RvrtTms" offset="10" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="OutPFSet_RmpTms" offset="11" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="OutPFSet_Ena" offset="12" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="DISABLED">0</symbol>
         <symbol id="ENABLED">1</symbol>
       </point>
-      <point id="VArWMaxPct" offset="13" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="VArPct_SF"/>
-      <point id="VArMaxPct" offset="14" access="rw" type="int16" len="1" mandatory="false" units="% VArMax" sf="VArPct_SF"/>
-      <point id="VArAvalPct" offset="15" access="rw" type="int16" len="1" mandatory="false" units="% VArAval" sf="VArPct_SF"/>
-      <point id="VArPct_WinTms" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="VArPct_RvrtTms" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="VArPct_RmpTms" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="VArPct_Mod" offset="19" access="rw" type="enum16" len="1" mandatory="false">
+      <point id="VArWMaxPct" offset="13" type="int16" len="1" sf="VArPct_SF" access="rw" units="% WMax" />
+      <point id="VArMaxPct" offset="14" type="int16" len="1" sf="VArPct_SF" access="rw" units="% VArMax" />
+      <point id="VArAvalPct" offset="15" type="int16" len="1" sf="VArPct_SF" access="rw" units="% VArAval" />
+      <point id="VArPct_WinTms" offset="16" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="VArPct_RvrtTms" offset="17" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="VArPct_RmpTms" offset="18" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="VArPct_Mod" offset="19" type="enum16" len="1" access="rw" >
         <symbol id="NONE">0</symbol>
         <symbol id="WMax">1</symbol>
         <symbol id="VArMax">2</symbol>
         <symbol id="VArAval">3</symbol>
       </point>
-      <point id="VArPct_Ena" offset="20" access="rw" type="enum16" len="1" mandatory="true">
+      <point id="VArPct_Ena" offset="20" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="DISABLED">0</symbol>
         <symbol id="ENABLED">1</symbol>
       </point>
-      <point id="WMaxLimPct_SF" offset="21" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="OutPFSet_SF" offset="22" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="VArPct_SF" offset="23" access="r" type="sunssf" len="1" mandatory="false"  />
+      <point id="WMaxLimPct_SF" offset="21" type="sunssf" len="1" mandatory="true" />
+      <point id="OutPFSet_SF" offset="22" type="sunssf" len="1" mandatory="true" />
+      <point id="VArPct_SF" offset="23" type="sunssf" len="1" />
     </block>
   </model>
   <strings id="123" locale="en">

--- a/smdx/smdx_00124.xml
+++ b/smdx/smdx_00124.xml
@@ -2,19 +2,19 @@
   <!-- 124: Basic Storage Controls  -->
   <model id="124" len="24" name="storage">
     <block len="24" type="fixed">
-      <point id="WChaMax" offset="0" access="rw" type="uint16" len="1" mandatory="true" units="W" sf="WChaMax_SF"/>
-      <point id="WChaGra" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="% WChaMax/sec" sf="WChaDisChaGra_SF"/>
-      <point id="WDisChaGra" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="% WChaMax/sec" sf="WChaDisChaGra_SF"/>
-      <point id="StorCtl_Mod" offset="3" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="WChaMax" offset="0" type="uint16" len="1" sf="WChaMax_SF" access="rw" units="W" mandatory="true" />
+      <point id="WChaGra" offset="1" type="uint16" len="1" sf="WChaDisChaGra_SF" access="rw" units="% WChaMax/sec" mandatory="true" />
+      <point id="WDisChaGra" offset="2" type="uint16" len="1" sf="WChaDisChaGra_SF" access="rw" units="% WChaMax/sec" mandatory="true" />
+      <point id="StorCtl_Mod" offset="3" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="CHARGE">0</symbol>
         <symbol id="DiSCHARGE">1</symbol>
       </point>
-      <point id="VAChaMax" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="VA" sf="VAChaMax_SF"/>
-      <point id="MinRsvPct" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="% WChaMax" sf="MinRsvPct_SF"/>
-      <point id="ChaState" offset="6" access="r" type="uint16" len="1" mandatory="false" units="% AhrRtg" sf="ChaState_SF"/>
-      <point id="StorAval" offset="7" access="r" type="uint16" len="1" mandatory="false" units="AH" sf="StorAval_SF"/>
-      <point id="InBatV" offset="8" access="r" type="uint16" len="1" mandatory="false" units="V" sf="InBatV_SF"/>
-      <point id="ChaSt" offset="9" access="r" type="enum16" len="1" mandatory="false">
+      <point id="VAChaMax" offset="4" type="uint16" len="1" sf="VAChaMax_SF" access="rw" units="VA" />
+      <point id="MinRsvPct" offset="5" type="uint16" len="1" sf="MinRsvPct_SF" access="rw" units="% WChaMax" />
+      <point id="ChaState" offset="6" type="uint16" len="1" sf="ChaState_SF" units="% AhrRtg" />
+      <point id="StorAval" offset="7" type="uint16" len="1" sf="StorAval_SF" units="AH" />
+      <point id="InBatV" offset="8" type="uint16" len="1" sf="InBatV_SF" units="V" />
+      <point id="ChaSt" offset="9" type="enum16" len="1" >
         <symbol id="OFF">1</symbol>
         <symbol id="EMPTY">2</symbol>
         <symbol id="DISCHARGING">3</symbol>
@@ -23,23 +23,23 @@
         <symbol id="HOLDING">6</symbol>
         <symbol id="TESTING">7</symbol>
       </point>
-      <point id="OutWRte" offset="10" access="rw" type="int16" len="1" mandatory="false" units="% WDisChaMax" sf="InOutWRte_SF"/>
-      <point id="InWRte" offset="11" access="rw" type="int16" len="1" mandatory="false" units=" % WChaMax" sf="InOutWRte_SF"/>
-      <point id="InOutWRte_WinTms" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="InOutWRte_RvrtTms" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="InOutWRte_RmpTms" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="ChaGriSet" offset="15" access="rw" type="enum16" len="1" mandatory="false">
+      <point id="OutWRte" offset="10" type="int16" len="1" sf="InOutWRte_SF" access="rw" units="% WDisChaMax" />
+      <point id="InWRte" offset="11" type="int16" len="1" sf="InOutWRte_SF" access="rw" units=" % WChaMax" />
+      <point id="InOutWRte_WinTms" offset="12" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="InOutWRte_RvrtTms" offset="13" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="InOutWRte_RmpTms" offset="14" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="ChaGriSet" offset="15" type="enum16" len="1" access="rw" >
         <symbol id="PV">0</symbol>
         <symbol id="GRID">1</symbol>
       </point>
-      <point id="WChaMax_SF" offset="16" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="WChaDisChaGra_SF" offset="17" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="VAChaMax_SF" offset="18" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="MinRsvPct_SF" offset="19" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="ChaState_SF" offset="20" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="StorAval_SF" offset="21" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="InBatV_SF" offset="22" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="InOutWRte_SF" offset="23" access="r" type="sunssf" len="1" mandatory="false"  />
+      <point id="WChaMax_SF" offset="16" type="sunssf" len="1" mandatory="true" />
+      <point id="WChaDisChaGra_SF" offset="17" type="sunssf" len="1" mandatory="true" />
+      <point id="VAChaMax_SF" offset="18" type="sunssf" len="1" />
+      <point id="MinRsvPct_SF" offset="19" type="sunssf" len="1" />
+      <point id="ChaState_SF" offset="20" type="sunssf" len="1" />
+      <point id="StorAval_SF" offset="21" type="sunssf" len="1" />
+      <point id="InBatV_SF" offset="22" type="sunssf" len="1" />
+      <point id="InOutWRte_SF" offset="23" type="sunssf" len="1" />
     </block>
   </model>
   <strings id="124" locale="en">

--- a/smdx/smdx_00125.xml
+++ b/smdx/smdx_00125.xml
@@ -2,22 +2,22 @@
   <!-- 125: Pricing Signal   -->
   <model id="125" len="8" name="pricing">
     <block len="8" type="fixed">
-      <point id="ModEna" offset="0" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ModEna" offset="0" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLE">0</symbol>
       </point>
-      <point id="SigType" offset="1" access="rw" type="enum16" len="1" mandatory="false">
+      <point id="SigType" offset="1" type="enum16" len="1" access="rw" >
         <symbol id="UNKNOWN">0</symbol>
         <symbol id="ABSOLUTE">1</symbol>
         <symbol id="RELATIVE">2</symbol>
         <symbol id="MULTIPLIER">3</symbol>
         <symbol id="LEVEL">4</symbol>
       </point>
-      <point id="Sig" offset="2" access="rw" type="int16" len="1" mandatory="true"  sf="Sig_SF"/>
-      <point id="WinTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvtTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="Sig_SF" offset="6" access="r" type="sunssf" len="1" mandatory="true" />
-      <point id="Pad" offset="7" access="r" type="pad" len="1" mandatory="false"  />
+      <point id="Sig" offset="2" type="int16" len="1" sf="Sig_SF" access="rw" mandatory="true" />
+      <point id="WinTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvtTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="5" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="Sig_SF" offset="6" type="sunssf" len="1" mandatory="true" />
+      <point id="Pad" offset="7" type="pad" len="1" />
     </block>
   </model>
   <strings id="125" locale="en">

--- a/smdx/smdx_00126.xml
+++ b/smdx/smdx_00126.xml
@@ -2,71 +2,71 @@
   <!-- 126: Static Volt-VAR Arrays  -->
   <model id="126" len="64" name="volt_var">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="V_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="DeptRef_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true" />
-      <point id="RmpIncDec_SF" offset="9" access="r" type="sunssf" len="1" mandatory="false"  />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="V_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="DeptRef_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="RmpIncDec_SF" offset="9" type="sunssf" len="1" />
     </block>
     <block len="54" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="DeptRef" offset="1" access="rw" type="enum16" len="1" mandatory="true">
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="DeptRef" offset="1" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="WMax">1</symbol>
         <symbol id="VArMax">2</symbol>
         <symbol id="VArAval">3</symbol>
       </point>
-      <point id="V1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="% VRef" sf="V_SF"/>
-      <point id="VAr1" offset="3" access="rw" type="int16" len="1" mandatory="true"  sf="DeptRef_SF"/>
-      <point id="V2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr2" offset="5" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr3" offset="7" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V4" offset="8" access="rw" type="uint16" len="1" mandatory="false"  units="% VRef" sf="V_SF"/>
-      <point id="VAr4" offset="9" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr5" offset="11" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr6" offset="13" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr7" offset="15" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr8" offset="17" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr9" offset="19" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr10" offset="21" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr11" offset="23" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr12" offset="25" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr13" offset="27" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr14" offset="29" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr15" offset="31" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr16" offset="33" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr17" offset="35" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr18" offset="37" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr19" offset="39" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="V20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="VAr20" offset="41" access="rw" type="int16" len="1" mandatory="false"  sf="DeptRef_SF"/>
-      <point id="CrvNam" offset="42" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="RmpTms" offset="50" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpDecTmm" offset="51" access="rw" type="uint16" len="1" mandatory="false" units="% ref_value/min" sf="RmpIncDec_SF"/>
-      <point id="RmpIncTmm" offset="52" access="rw" type="uint16" len="1" mandatory="false" units="% ref_value/min" sf="RmpIncDec_SF"/>
-      <point id="ReadOnly" offset="53" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="V1" offset="2" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" mandatory="true" />
+      <point id="VAr1" offset="3" type="int16" len="1" sf="DeptRef_SF" access="rw" mandatory="true" />
+      <point id="V2" offset="4" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr2" offset="5" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V3" offset="6" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr3" offset="7" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V4" offset="8" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr4" offset="9" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V5" offset="10" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr5" offset="11" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V6" offset="12" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr6" offset="13" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V7" offset="14" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr7" offset="15" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V8" offset="16" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr8" offset="17" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V9" offset="18" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr9" offset="19" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V10" offset="20" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr10" offset="21" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V11" offset="22" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr11" offset="23" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V12" offset="24" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr12" offset="25" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V13" offset="26" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr13" offset="27" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V14" offset="28" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr14" offset="29" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V15" offset="30" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr15" offset="31" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V16" offset="32" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr16" offset="33" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V17" offset="34" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr17" offset="35" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V18" offset="36" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr18" offset="37" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V19" offset="38" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr19" offset="39" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="V20" offset="40" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="VAr20" offset="41" type="int16" len="1" sf="DeptRef_SF" access="rw" />
+      <point id="CrvNam" offset="42" type="string" len="8" access="rw" />
+      <point id="RmpTms" offset="50" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpDecTmm" offset="51" type="uint16" len="1" sf="RmpIncDec_SF" access="rw" units="% ref_value/min" />
+      <point id="RmpIncTmm" offset="52" type="uint16" len="1" sf="RmpIncDec_SF" access="rw" units="% ref_value/min" />
+      <point id="ReadOnly" offset="53" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00127.xml
+++ b/smdx/smdx_00127.xml
@@ -2,20 +2,20 @@
   <!-- 127: Parameterized Frequency-Watt  -->
   <model id="127" len="10" name="freq_watt_param">
     <block len="10" type="fixed">
-      <point id="WGra" offset="0" access="rw" type="uint16" len="1" mandatory="true" units="% PM/Hz" sf="WGra_SF"/>
-      <point id="HzStr" offset="1" access="rw" type="int16" len="1" mandatory="true" units="Hz" sf="HzStrStop_SF"/>
-      <point id="HzStop" offset="2" access="rw" type="int16" len="1" mandatory="true" units="Hz" sf="HzStrStop_SF"/>
-      <point id="HysEna" offset="3" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="WGra" offset="0" type="uint16" len="1" sf="WGra_SF" access="rw" units="% PM/Hz" mandatory="true" />
+      <point id="HzStr" offset="1" type="int16" len="1" sf="HzStrStop_SF" access="rw" units="Hz" mandatory="true" />
+      <point id="HzStop" offset="2" type="int16" len="1" sf="HzStrStop_SF" access="rw" units="Hz" mandatory="true" />
+      <point id="HysEna" offset="3" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="ModEna" offset="4" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ModEna" offset="4" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="HzStopWGra" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="% WMax/min" sf="RmpIncDec_SF"/>
-      <point id="WGra_SF" offset="6" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="HzStrStop_SF" offset="7" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="RmpIncDec_SF" offset="8" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="Pad" offset="9" access="r" type="pad" len="1" mandatory="false"  />
+      <point id="HzStopWGra" offset="5" type="uint16" len="1" sf="RmpIncDec_SF" access="rw" units="% WMax/min" />
+      <point id="WGra_SF" offset="6" type="sunssf" len="1" />
+      <point id="HzStrStop_SF" offset="7" type="sunssf" len="1" />
+      <point id="RmpIncDec_SF" offset="8" type="sunssf" len="1" />
+      <point id="Pad" offset="9" type="pad" len="1" />
     </block>
   </model>
   <strings id="127" locale="en">

--- a/smdx/smdx_00128.xml
+++ b/smdx/smdx_00128.xml
@@ -2,25 +2,25 @@
   <!-- 128: Dynamic Reactive Current  -->
   <model id="128" len="14" name="reactive_current">
     <block len="14" type="fixed">
-      <point id="ArGraMod" offset="0" access="rw" type="enum16" len="1" mandatory="true">
+      <point id="ArGraMod" offset="0" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="EDGE">0</symbol>
         <symbol id="CENTER">1</symbol>
       </point>
-      <point id="ArGraSag" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="%ARtg/%dV" sf="ArGra_SF"/>
-      <point id="ArGraSwell" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="%ARtg/%dV" sf="ArGra_SF"/>
-      <point id="ModEna" offset="3" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ArGraSag" offset="1" type="uint16" len="1" sf="ArGra_SF" access="rw" units="%ARtg/%dV" mandatory="true" />
+      <point id="ArGraSwell" offset="2" type="uint16" len="1" sf="ArGra_SF" access="rw" units="%ARtg/%dV" mandatory="true" />
+      <point id="ModEna" offset="3" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="FilTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="DbVMin" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="VRefPct_SF"/>
-      <point id="DbVMax" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="VRefPct_SF"/>
-      <point id="BlkZnV" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="VRefPct_SF"/>
-      <point id="HysBlkZnV" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="VRefPct_SF"/>
-      <point id="BlkZnTmms" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="mSecs" />
-      <point id="HoldTmms" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="mSecs" />
-      <point id="ArGra_SF" offset="11" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="VRefPct_SF" offset="12" access="r" type="sunssf" len="1" mandatory="false"  />
-      <point id="Pad" offset="13" access="r" type="pad" len="1" mandatory="false"  />
+      <point id="FilTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="DbVMin" offset="5" type="uint16" len="1" sf="VRefPct_SF" access="rw" units="% VRef" />
+      <point id="DbVMax" offset="6" type="uint16" len="1" sf="VRefPct_SF" access="rw" units="% VRef" />
+      <point id="BlkZnV" offset="7" type="uint16" len="1" sf="VRefPct_SF" access="rw" units="% VRef" />
+      <point id="HysBlkZnV" offset="8" type="uint16" len="1" sf="VRefPct_SF" access="rw" units="% VRef" />
+      <point id="BlkZnTmms" offset="9" type="uint16" len="1" access="rw" units="mSecs" />
+      <point id="HoldTmms" offset="10" type="uint16" len="1" access="rw" units="mSecs" />
+      <point id="ArGra_SF" offset="11" type="sunssf" len="1" mandatory="true" />
+      <point id="VRefPct_SF" offset="12" type="sunssf" len="1" />
+      <point id="Pad" offset="13" type="pad" len="1" />
     </block>
   </model>
   <strings id="128" locale="en">

--- a/smdx/smdx_00129.xml
+++ b/smdx/smdx_00129.xml
@@ -2,63 +2,63 @@
   <!-- 129: LVRT Must Disconnect  -->
   <model id="129" len="60" name="lvrt">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="V_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Pad" offset="9" access="r" type="pad" len="1" mandatory="false" />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="V_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="Pad" offset="9" type="pad" len="1" />
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="V1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="% VRef" sf="V_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="V1" offset="2" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V2" offset="4" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V3" offset="6" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V4" offset="8" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V5" offset="10" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V6" offset="12" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V7" offset="14" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V8" offset="16" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V9" offset="18" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V10" offset="20" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V11" offset="22" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V12" offset="24" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V13" offset="26" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V14" offset="28" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V15" offset="30" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V16" offset="32" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V17" offset="34" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V18" offset="36" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V19" offset="38" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V20" offset="40" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00130.xml
+++ b/smdx/smdx_00130.xml
@@ -2,63 +2,63 @@
   <!-- 130: HVRT Must Disconnect  -->
   <model id="130" len="60" name="hvrt">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="V_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Pad" offset="9" access="r" type="pad" len="1" mandatory="false" />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="V_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="Pad" offset="9" type="pad" len="1" />
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="V1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="% VRef" sf="V_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="V1" offset="2" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V2" offset="4" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V3" offset="6" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V4" offset="8" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V5" offset="10" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V6" offset="12" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V7" offset="14" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V8" offset="16" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V9" offset="18" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V10" offset="20" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V11" offset="22" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V12" offset="24" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V13" offset="26" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V14" offset="28" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V15" offset="30" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V16" offset="32" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V17" offset="34" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V18" offset="36" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V19" offset="38" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V20" offset="40" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00131.xml
+++ b/smdx/smdx_00131.xml
@@ -2,70 +2,70 @@
   <!-- 131: Watt-Power Factor (PF in EEI format) -->
   <model id="131" len="64" name="watt_pf">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="W_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="PF_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="RmpIncDec_SF" offset="9" access="r" type="sunssf" len="1" mandatory="false"  />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="W_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="PF_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="RmpIncDec_SF" offset="9" type="sunssf" len="1" />
     </block>
     <block len="54" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true" />
-      <point id="W1" offset="1" access="rw" type="int16" len="1" mandatory="true" units="% WMax" sf="W_SF"/>
-      <point id="PF1" offset="2" access="rw" type="int16" len="1" mandatory="true" units="cos()" sf="PF_SF"/>
-      <point id="W2" offset="3" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF2" offset="4" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W3" offset="5" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF3" offset="6" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W4" offset="7" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF4" offset="8" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W5" offset="9" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF5" offset="10" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W6" offset="11" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF6" offset="12" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W7" offset="13" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF7" offset="14" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W8" offset="15" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF8" offset="16" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W9" offset="17" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF9" offset="18" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W10" offset="19" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF10" offset="20" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W11" offset="21" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF11" offset="22" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W12" offset="23" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF12" offset="24" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W13" offset="25" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF13" offset="26" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W14" offset="27" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF14" offset="28" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W15" offset="29" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF15" offset="30" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W16" offset="31" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF16" offset="32" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W17" offset="33" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF17" offset="34" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W18" offset="35" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF18" offset="36" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W19" offset="37" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF19" offset="38" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="W20" offset="39" access="rw" type="int16" len="1" mandatory="false" units="% WMax" sf="W_SF"/>
-      <point id="PF20" offset="40" access="rw" type="int16" len="1" mandatory="false" units="cos()" sf="PF_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="RmpPT1Tms" offset="49" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpDecTmm" offset="50" access="rw" type="uint16" len="1" mandatory="false" units="% PF/min" sf="RmpIncDec_SF"/>
-      <point id="RmpIncTmm" offset="51" access="rw" type="uint16" len="1" mandatory="false" units="% PF/min" sf="RmpIncDec_SF"/>
-      <point id="ReadOnly" offset="52" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="W1" offset="1" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" mandatory="true" />
+      <point id="PF1" offset="2" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" mandatory="true" />
+      <point id="W2" offset="3" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF2" offset="4" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W3" offset="5" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF3" offset="6" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W4" offset="7" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF4" offset="8" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W5" offset="9" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF5" offset="10" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W6" offset="11" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF6" offset="12" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W7" offset="13" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF7" offset="14" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W8" offset="15" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF8" offset="16" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W9" offset="17" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF9" offset="18" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W10" offset="19" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF10" offset="20" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W11" offset="21" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF11" offset="22" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W12" offset="23" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF12" offset="24" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W13" offset="25" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF13" offset="26" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W14" offset="27" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF14" offset="28" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W15" offset="29" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF15" offset="30" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W16" offset="31" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF16" offset="32" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W17" offset="33" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF17" offset="34" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W18" offset="35" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF18" offset="36" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W19" offset="37" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF19" offset="38" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="W20" offset="39" type="int16" len="1" sf="W_SF" access="rw" units="% WMax" />
+      <point id="PF20" offset="40" type="int16" len="1" sf="PF_SF" access="rw" units="cos()" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="RmpPT1Tms" offset="49" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpDecTmm" offset="50" type="uint16" len="1" sf="RmpIncDec_SF" access="rw" units="% PF/min" />
+      <point id="RmpIncTmm" offset="51" type="uint16" len="1" sf="RmpIncDec_SF" access="rw" units="% PF/min" />
+      <point id="ReadOnly" offset="52" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>
-      <point id="Pad" offset="53" access="r" type="pad" len="1" mandatory="false"  />
+      <point id="Pad" offset="53" type="pad" len="1" />
     </block>
   </model>
   <strings id="131" locale="en">

--- a/smdx/smdx_00132.xml
+++ b/smdx/smdx_00132.xml
@@ -2,70 +2,70 @@
   <!-- 132: Volt-Watt  -->
   <model id="132" len="64" name="volt_watt">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="V_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="DeptRef_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="RmpIncDec_SF" offset="9" access="r" type="sunssf" len="1" mandatory="false"  />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="V_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="DeptRef_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="RmpIncDec_SF" offset="9" type="sunssf" len="1" />
     </block>
     <block len="54" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="DeptRef" offset="1" access="rw" type="enum16" len="1" mandatory="true">
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="DeptRef" offset="1" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="%WMax">1</symbol>
         <symbol id="%WAval">2</symbol>
       </point>
-      <point id="V1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="% VRef" sf="V_SF"/>
-      <point id="W1" offset="3" access="rw" type="int16" len="1" mandatory="true" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W2" offset="5" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W3" offset="7" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W4" offset="9" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W5" offset="11" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W6" offset="13" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W7" offset="15" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W8" offset="17" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W9" offset="19" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W10" offset="21" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W11" offset="23" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W12" offset="25" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W13" offset="27" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W14" offset="29" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W15" offset="31" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W16" offset="33" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W17" offset="35" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W18" offset="37" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W19" offset="39" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="V20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="W20" offset="41" access="rw" type="int16" len="1" mandatory="false" units="% VRef" sf="DeptRef_SF"/>
-      <point id="CrvNam" offset="42" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="RmpPt1Tms" offset="50" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpDecTmm" offset="51" access="rw" type="uint16" len="1" mandatory="false" units="% WMax/min" sf="RmpIncDec_SF"/>
-      <point id="RmpIncTmm" offset="52" access="rw" type="uint16" len="1" mandatory="false" units="% WMax/min" sf="RmpIncDec_SF"/>
-      <point id="ReadOnly" offset="53" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="V1" offset="2" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" mandatory="true" />
+      <point id="W1" offset="3" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" mandatory="true" />
+      <point id="V2" offset="4" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W2" offset="5" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V3" offset="6" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W3" offset="7" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V4" offset="8" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W4" offset="9" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V5" offset="10" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W5" offset="11" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V6" offset="12" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W6" offset="13" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V7" offset="14" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W7" offset="15" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V8" offset="16" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W8" offset="17" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V9" offset="18" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W9" offset="19" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V10" offset="20" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W10" offset="21" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V11" offset="22" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W11" offset="23" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V12" offset="24" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W12" offset="25" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V13" offset="26" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W13" offset="27" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V14" offset="28" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W14" offset="29" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V15" offset="30" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W15" offset="31" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V16" offset="32" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W16" offset="33" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V17" offset="34" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W17" offset="35" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V18" offset="36" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W18" offset="37" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V19" offset="38" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W19" offset="39" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="V20" offset="40" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="W20" offset="41" type="int16" len="1" sf="DeptRef_SF" access="rw" units="% VRef" />
+      <point id="CrvNam" offset="42" type="string" len="8" access="rw" />
+      <point id="RmpPt1Tms" offset="50" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpDecTmm" offset="51" type="uint16" len="1" sf="RmpIncDec_SF" access="rw" units="% WMax/min" />
+      <point id="RmpIncTmm" offset="52" type="uint16" len="1" sf="RmpIncDec_SF" access="rw" units="% WMax/min" />
+      <point id="ReadOnly" offset="53" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00133.xml
+++ b/smdx/smdx_00133.xml
@@ -2,7 +2,7 @@
   <!-- 133: Basic Scheduling  -->
   <model id="133" len="66" name="schedule">
     <block len="6" type="fixed">
-      <point id="ActSchd" offset="0" access="rw" type="bitfield32" len="2" mandatory="true">
+      <point id="ActSchd" offset="0" type="bitfield32" len="2" access="rw" mandatory="true" >
         <symbol id="SCHED1">0</symbol>
         <symbol id="SCHED2">1</symbol>
         <symbol id="SCHED3">2</symbol>
@@ -35,18 +35,18 @@
         <symbol id="SCHED31">30</symbol>
         <symbol id="SCHED32">31</symbol>
       </point>
-      <point id="ModEna" offset="2" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ModEna" offset="2" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="NSchd" offset="3" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPts" offset="4" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Pad" offset="5" access="r" type="pad" len="1" mandatory="false" />
+      <point id="NSchd" offset="3" type="uint16" len="1" mandatory="true" />
+      <point id="NPts" offset="4" type="uint16" len="1" mandatory="true" />
+      <point id="Pad" offset="5" type="pad" len="1" />
     </block>
     <block len="60" type="repeating">
-      <point id="ActPts" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="StrTms" offset="1" access="rw" type="uint32" len="2" mandatory="true" units="Secs" />
-      <point id="RepPer" offset="3" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="IntvTyp" offset="4" access="rw" type="enum16" len="1" mandatory="true">
+      <point id="ActPts" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="StrTms" offset="1" type="uint32" len="2" access="rw" units="Secs" mandatory="true" />
+      <point id="RepPer" offset="3" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="IntvTyp" offset="4" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="ONETIME">0</symbol>
         <symbol id="DAILY">1</symbol>
         <symbol id="WEEKLY">2</symbol>
@@ -56,15 +56,15 @@
         <symbol id="WEEKEND">6</symbol>
         <symbol id="YEARLY">7</symbol>
       </point>
-      <point id="XTyp" offset="5" access="rw" type="enum16" len="1" mandatory="true">
+      <point id="XTyp" offset="5" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="UNSET">0</symbol>
         <symbol id="TIME">1</symbol>
         <symbol id="TEMP">2</symbol>
         <symbol id="PRICE">3</symbol>
         <symbol id="OTHER">99</symbol>
       </point>
-      <point id="X_SF" offset="6" access="rw" type="sunssf" len="1" mandatory="true"  />
-      <point id="YTyp" offset="7" access="rw" type="enum16" len="1" mandatory="true">
+      <point id="X_SF" offset="6" type="sunssf" len="1" access="rw" mandatory="true" />
+      <point id="YTyp" offset="7" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="UNSET">0</symbol>
         <symbol id="WMax">1</symbol>
         <symbol id="RSRVD2">2</symbol>
@@ -80,31 +80,31 @@
         <symbol id="Schedule">12</symbol>
         <symbol id="OTHER">99</symbol>
       </point>
-      <point id="Y_SF" offset="8" access="rw" type="sunssf" len="1" mandatory="true"  />
-      <point id="X1" offset="9" access="rw" type="int32" len="2" mandatory="true"  sf="X_SF"/>
-      <point id="Y1" offset="11" access="rw" type="int32" len="2" mandatory="true"  sf="Y_SF"/>
-      <point id="X2" offset="13" access="rw" type="int32" len="2" mandatory="false"  sf="X_SF"/>
-      <point id="Y2" offset="15" access="rw" type="int32" len="2" mandatory="false"  sf="Y_SF"/>
-      <point id="X3" offset="17" access="rw" type="int32" len="2" mandatory="false"  sf="X_SF"/>
-      <point id="Y3" offset="19" access="rw" type="int32" len="2" mandatory="false"  sf="Y_SF"/>
-      <point id="X4" offset="21" access="rw" type="int32" len="2" mandatory="false"  sf="X_SF"/>
-      <point id="Y4" offset="23" access="rw" type="int32" len="2" mandatory="false"  sf="Y_SF"/>
-      <point id="X5" offset="25" access="rw" type="int32" len="2" mandatory="false"  sf="X_SF"/>
-      <point id="Y5" offset="27" access="rw" type="int32" len="2" mandatory="false"  sf="Y_SF"/>
-      <point id="X6" offset="29" access="rw" type="int32" len="2" mandatory="false"  sf="X_SF"/>
-      <point id="Y6" offset="31" access="rw" type="int32" len="2" mandatory="false"  sf="Y_SF"/>
-      <point id="X7" offset="33" access="rw" type="int32" len="2" mandatory="false"  sf="X_SF"/>
-      <point id="Y7" offset="35" access="rw" type="int32" len="2" mandatory="false"  sf="Y_SF"/>
-      <point id="X8" offset="37" access="rw" type="int32" len="2" mandatory="false"  sf="X_SF"/>
-      <point id="Y8" offset="39" access="rw" type="int32" len="2" mandatory="false"  sf="Y_SF"/>
-      <point id="X9" offset="41" access="rw" type="int32" len="2" mandatory="false"  sf="X_SF"/>
-      <point id="Y9" offset="43" access="rw" type="int32" len="2" mandatory="false"  sf="Y_SF"/>
-      <point id="X10" offset="45" access="rw" type="int32" len="2" mandatory="false"  sf="X_SF"/>
-      <point id="Y10" offset="47" access="rw" type="int32" len="2" mandatory="false"  sf="Y_SF"/>
-      <point id="Nam" offset="49" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="WinTms" offset="57" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="58" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="ActIndx" offset="59" access="r" type="uint16" len="1" mandatory="true"  />
+      <point id="Y_SF" offset="8" type="sunssf" len="1" access="rw" mandatory="true" />
+      <point id="X1" offset="9" type="int32" len="2" sf="X_SF" access="rw" mandatory="true" />
+      <point id="Y1" offset="11" type="int32" len="2" sf="Y_SF" access="rw" mandatory="true" />
+      <point id="X2" offset="13" type="int32" len="2" sf="X_SF" access="rw" />
+      <point id="Y2" offset="15" type="int32" len="2" sf="Y_SF" access="rw" />
+      <point id="X3" offset="17" type="int32" len="2" sf="X_SF" access="rw" />
+      <point id="Y3" offset="19" type="int32" len="2" sf="Y_SF" access="rw" />
+      <point id="X4" offset="21" type="int32" len="2" sf="X_SF" access="rw" />
+      <point id="Y4" offset="23" type="int32" len="2" sf="Y_SF" access="rw" />
+      <point id="X5" offset="25" type="int32" len="2" sf="X_SF" access="rw" />
+      <point id="Y5" offset="27" type="int32" len="2" sf="Y_SF" access="rw" />
+      <point id="X6" offset="29" type="int32" len="2" sf="X_SF" access="rw" />
+      <point id="Y6" offset="31" type="int32" len="2" sf="Y_SF" access="rw" />
+      <point id="X7" offset="33" type="int32" len="2" sf="X_SF" access="rw" />
+      <point id="Y7" offset="35" type="int32" len="2" sf="Y_SF" access="rw" />
+      <point id="X8" offset="37" type="int32" len="2" sf="X_SF" access="rw" />
+      <point id="Y8" offset="39" type="int32" len="2" sf="Y_SF" access="rw" />
+      <point id="X9" offset="41" type="int32" len="2" sf="X_SF" access="rw" />
+      <point id="Y9" offset="43" type="int32" len="2" sf="Y_SF" access="rw" />
+      <point id="X10" offset="45" type="int32" len="2" sf="X_SF" access="rw" />
+      <point id="Y10" offset="47" type="int32" len="2" sf="Y_SF" access="rw" />
+      <point id="Nam" offset="49" type="string" len="8" access="rw" />
+      <point id="WinTms" offset="57" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="58" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="ActIndx" offset="59" type="uint16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="133" locale="en">

--- a/smdx/smdx_00134.xml
+++ b/smdx/smdx_00134.xml
@@ -2,71 +2,71 @@
   <!-- 134: Curve-Based Frequency-Watt  -->
   <model id="134" len="68" name="freq_watt">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Hz_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true" units="SF" />
-      <point id="W_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true" units="SF" />
-      <point id="RmpIncDec_SF" offset="9" access="r" type="sunssf" len="1" mandatory="false" units="SF" />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Hz_SF" offset="7" type="sunssf" len="1" units="SF" mandatory="true" />
+      <point id="W_SF" offset="8" type="sunssf" len="1" units="SF" mandatory="true" />
+      <point id="RmpIncDec_SF" offset="9" type="sunssf" len="1" units="SF" />
     </block>
     <block len="58" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Hz1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Hz" sf="Hz_SF"/>
-      <point id="W1" offset="2" access="rw" type="int16" len="1" mandatory="true" units="% WRef" sf="W_SF"/>
-      <point id="Hz2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W2" offset="4" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W3" offset="6" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W4" offset="8" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W5" offset="10" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W6" offset="12" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W7" offset="14" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W8" offset="16" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W9" offset="18" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W10" offset="20" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W11" offset="22" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W12" offset="24" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W13" offset="26" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W14" offset="28" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W15" offset="30" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W16" offset="32" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W17" offset="34" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W18" offset="36" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W19" offset="38" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="Hz20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="W20" offset="40" access="rw" type="int16" len="1" mandatory="false" units="% WRef" sf="W_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="RmpPT1Tms" offset="49" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpDecTmm" offset="50" access="rw" type="uint16" len="1" mandatory="false" units="% WMax/min" sf="RmpIncDec_SF"/>
-      <point id="RmpIncTmm" offset="51" access="rw" type="uint16" len="1" mandatory="false" units="% WMax/min" sf="RmpIncDec_SF"/>
-      <point id="RmpRsUp" offset="52" access="rw" type="uint16" len="1" mandatory="false" units="% WMax/min" sf="RmpIncDec_SF"/>
-      <point id="SnptW" offset="53" access="rw" type="bitfield16" len="1" mandatory="true"  />
-      <point id="WRef" offset="54" access="rw" type="uint16" len="1" mandatory="false" units="W" sf="W_SF"/>
-      <point id="WRefStrHz" offset="55" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="WRefStopHz" offset="56" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="ReadOnly" offset="57" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Hz1" offset="1" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" mandatory="true" />
+      <point id="W1" offset="2" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" mandatory="true" />
+      <point id="Hz2" offset="3" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W2" offset="4" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz3" offset="5" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W3" offset="6" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz4" offset="7" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W4" offset="8" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz5" offset="9" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W5" offset="10" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz6" offset="11" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W6" offset="12" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz7" offset="13" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W7" offset="14" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz8" offset="15" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W8" offset="16" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz9" offset="17" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W9" offset="18" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz10" offset="19" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W10" offset="20" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz11" offset="21" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W11" offset="22" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz12" offset="23" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W12" offset="24" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz13" offset="25" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W13" offset="26" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz14" offset="27" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W14" offset="28" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz15" offset="29" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W15" offset="30" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz16" offset="31" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W16" offset="32" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz17" offset="33" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W17" offset="34" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz18" offset="35" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W18" offset="36" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz19" offset="37" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W19" offset="38" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="Hz20" offset="39" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="W20" offset="40" type="int16" len="1" sf="W_SF" access="rw" units="% WRef" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="RmpPT1Tms" offset="49" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpDecTmm" offset="50" type="uint16" len="1" sf="RmpIncDec_SF" access="rw" units="% WMax/min" />
+      <point id="RmpIncTmm" offset="51" type="uint16" len="1" sf="RmpIncDec_SF" access="rw" units="% WMax/min" />
+      <point id="RmpRsUp" offset="52" type="uint16" len="1" sf="RmpIncDec_SF" access="rw" units="% WMax/min" />
+      <point id="SnptW" offset="53" type="bitfield16" len="1" access="rw" mandatory="true" />
+      <point id="WRef" offset="54" type="uint16" len="1" sf="W_SF" access="rw" units="W" />
+      <point id="WRefStrHz" offset="55" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="WRefStopHz" offset="56" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="ReadOnly" offset="57" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00135.xml
+++ b/smdx/smdx_00135.xml
@@ -2,63 +2,63 @@
   <!-- 135: LFRT -->
   <model id="135" len="60" name="lfrt">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Hz_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Pad" offset="9" access="r" type="pad" len="1" mandatory="false" />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="Pad" offset="9" type="pad" len="1" />
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="Hz1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="Hz" sf="Hz_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="Hz1" offset="2" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz2" offset="4" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz3" offset="6" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz4" offset="8" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz5" offset="10" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz6" offset="12" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz7" offset="14" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz8" offset="16" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz9" offset="18" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz10" offset="20" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz11" offset="22" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz12" offset="24" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz13" offset="26" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz14" offset="28" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz15" offset="30" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz16" offset="32" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz17" offset="34" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz18" offset="36" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz19" offset="38" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz20" offset="40" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00136.xml
+++ b/smdx/smdx_00136.xml
@@ -2,63 +2,63 @@
   <!-- 136: HFRT -->
   <model id="136" len="60" name="hfrt">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Hz_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Pad" offset="9" access="r" type="pad" len="1" mandatory="false" />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="Pad" offset="9" type="pad" len="1" />
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="Hz1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="Hz" sf="Hz_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="Hz1" offset="2" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz2" offset="4" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz3" offset="6" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz4" offset="8" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz5" offset="10" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz6" offset="12" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz7" offset="14" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz8" offset="16" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz9" offset="18" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz10" offset="20" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz11" offset="22" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz12" offset="24" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz13" offset="26" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz14" offset="28" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz15" offset="30" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz16" offset="32" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz17" offset="34" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz18" offset="36" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz19" offset="38" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz20" offset="40" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00137.xml
+++ b/smdx/smdx_00137.xml
@@ -2,63 +2,63 @@
   <!-- 137: LVRT Must Remain Connected  -->
   <model id="137" len="60" name="lvrtc">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="V_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Pad" offset="9" access="r" type="pad" len="1" mandatory="false" />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="V_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="Pad" offset="9" type="pad" len="1" />
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="V1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="% VRef" sf="V_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="V1" offset="2" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V2" offset="4" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V3" offset="6" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V4" offset="8" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V5" offset="10" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V6" offset="12" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V7" offset="14" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V8" offset="16" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V9" offset="18" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V10" offset="20" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V11" offset="22" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V12" offset="24" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V13" offset="26" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V14" offset="28" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V15" offset="30" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V16" offset="32" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V17" offset="34" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V18" offset="36" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V19" offset="38" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V20" offset="40" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00138.xml
+++ b/smdx/smdx_00138.xml
@@ -2,63 +2,63 @@
   <!-- 138: HVRT Must Remain Connected  -->
   <model id="138" len="60" name="hvrtc">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="V_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Pad" offset="9" access="r" type="pad" len="1" mandatory="false" />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="V_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="Pad" offset="9" type="pad" len="1" />
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="V1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="% VRef" sf="V_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="V1" offset="2" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V2" offset="4" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V3" offset="6" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V4" offset="8" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V5" offset="10" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V6" offset="12" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V7" offset="14" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V8" offset="16" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V9" offset="18" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V10" offset="20" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V11" offset="22" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V12" offset="24" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V13" offset="26" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V14" offset="28" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V15" offset="30" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V16" offset="32" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V17" offset="34" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V18" offset="36" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V19" offset="38" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V20" offset="40" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00139.xml
+++ b/smdx/smdx_00139.xml
@@ -2,65 +2,65 @@
   <!-- 139: LVRT Extended Curve  -->
   <model id="139" len="60" name="lvrtx" status="test">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="V_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="CrvType" offset="9" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="V_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="CrvType" offset="9" type="enum16" len="1" mandatory="true" >
         <symbol id="CEASE_TO_ENERGIZE">1</symbol>
       </point>
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="V1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="% VRef" sf="V_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="V1" offset="2" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V2" offset="4" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V3" offset="6" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V4" offset="8" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V5" offset="10" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V6" offset="12" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V7" offset="14" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V8" offset="16" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V9" offset="18" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V10" offset="20" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V11" offset="22" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V12" offset="24" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V13" offset="26" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V14" offset="28" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V15" offset="30" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V16" offset="32" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V17" offset="34" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V18" offset="36" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V19" offset="38" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V20" offset="40" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00140.xml
+++ b/smdx/smdx_00140.xml
@@ -2,65 +2,65 @@
   <!-- 140: HVRT Extended Curve  -->
   <model id="140" len="60" name="hvrtx" status="test">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="V_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="CrvType" offset="9" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="V_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="CrvType" offset="9" type="enum16" len="1" mandatory="true" >
         <symbol id="CEASE_TO_ENERGIZE">1</symbol>
       </point>
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="V1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="% VRef" sf="V_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="V20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="% VRef" sf="V_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="V1" offset="2" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V2" offset="4" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V3" offset="6" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V4" offset="8" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V5" offset="10" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V6" offset="12" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V7" offset="14" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V8" offset="16" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V9" offset="18" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V10" offset="20" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V11" offset="22" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V12" offset="24" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V13" offset="26" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V14" offset="28" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V15" offset="30" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V16" offset="32" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V17" offset="34" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V18" offset="36" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V19" offset="38" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="V20" offset="40" type="uint16" len="1" sf="V_SF" access="rw" units="% VRef" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00141.xml
+++ b/smdx/smdx_00141.xml
@@ -2,63 +2,63 @@
   <!-- 141: LFRTC -->
   <model id="141" len="60" name="lfrtc" status="test">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Hz_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Pad" offset="9" access="r" type="pad" len="1" mandatory="false" />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="Pad" offset="9" type="pad" len="1" />
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="Hz1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="Hz" sf="Hz_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="Hz1" offset="2" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz2" offset="4" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz3" offset="6" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz4" offset="8" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz5" offset="10" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz6" offset="12" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz7" offset="14" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz8" offset="16" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz9" offset="18" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz10" offset="20" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz11" offset="22" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz12" offset="24" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz13" offset="26" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz14" offset="28" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz15" offset="30" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz16" offset="32" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz17" offset="34" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz18" offset="36" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz19" offset="38" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz20" offset="40" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00142.xml
+++ b/smdx/smdx_00142.xml
@@ -2,63 +2,63 @@
   <!-- 142: HFRTC -->
   <model id="142" len="60" name="hfrtc" status="test">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Hz_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Pad" offset="9" access="r" type="pad" len="1" mandatory="false" />
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="Pad" offset="9" type="pad" len="1" />
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="Hz1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="Hz" sf="Hz_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="Hz1" offset="2" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz2" offset="4" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz3" offset="6" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz4" offset="8" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz5" offset="10" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz6" offset="12" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz7" offset="14" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz8" offset="16" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz9" offset="18" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz10" offset="20" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz11" offset="22" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz12" offset="24" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz13" offset="26" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz14" offset="28" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz15" offset="30" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz16" offset="32" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz17" offset="34" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz18" offset="36" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz19" offset="38" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz20" offset="40" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00143.xml
+++ b/smdx/smdx_00143.xml
@@ -2,65 +2,65 @@
   <!-- 143: LFRT Extended Curve-->
   <model id="143" len="60" name="lfrtx" status="test">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Hz_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="CrvType" offset="9" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="CrvType" offset="9" type="enum16" len="1" mandatory="true" >
         <symbol id="CEASE_TO_ENERGIZE">1</symbol>
       </point>
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="Hz1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="Hz" sf="Hz_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="Hz1" offset="2" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz2" offset="4" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz3" offset="6" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz4" offset="8" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz5" offset="10" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz6" offset="12" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz7" offset="14" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz8" offset="16" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz9" offset="18" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz10" offset="20" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz11" offset="22" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz12" offset="24" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz13" offset="26" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz14" offset="28" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz15" offset="30" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz16" offset="32" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz17" offset="34" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz18" offset="36" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz19" offset="38" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz20" offset="40" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00144.xml
+++ b/smdx/smdx_00144.xml
@@ -2,65 +2,65 @@
   <!-- 144: HFRT Extended Curve-->
   <model id="144" len="60" name="hfrtx" status="test">
     <block len="10" type="fixed">
-      <point id="ActCrv" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="ModEna" offset="1" access="rw" type="bitfield16" len="1" mandatory="true">
+      <point id="ActCrv" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="ModEna" offset="1" type="bitfield16" len="1" access="rw" mandatory="true" >
         <symbol id="ENABLED">0</symbol>
       </point>
-      <point id="WinTms" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RvrtTms" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="RmpTms" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Secs" />
-      <point id="NCrv" offset="5" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="NPt" offset="6" access="r" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms_SF" offset="7" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="Hz_SF" offset="8" access="r" type="sunssf" len="1" mandatory="true"  />
-      <point id="CrvType" offset="9" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="WinTms" offset="2" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RvrtTms" offset="3" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="RmpTms" offset="4" type="uint16" len="1" access="rw" units="Secs" />
+      <point id="NCrv" offset="5" type="uint16" len="1" mandatory="true" />
+      <point id="NPt" offset="6" type="uint16" len="1" mandatory="true" />
+      <point id="Tms_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="CrvType" offset="9" type="enum16" len="1" mandatory="true" >
         <symbol id="CEASE_TO_ENERGIZE">1</symbol>
       </point>
     </block>
     <block len="50" type="repeating" name="curve">
-      <point id="ActPt" offset="0" access="rw" type="uint16" len="1" mandatory="true"  />
-      <point id="Tms1" offset="1" access="rw" type="uint16" len="1" mandatory="true" units="Secs" sf="Tms_SF"/>
-      <point id="Hz1" offset="2" access="rw" type="uint16" len="1" mandatory="true" units="Hz" sf="Hz_SF"/>
-      <point id="Tms2" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz2" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms3" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz3" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms4" offset="7" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz4" offset="8" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms5" offset="9" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz5" offset="10" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms6" offset="11" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz6" offset="12" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms7" offset="13" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz7" offset="14" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms8" offset="15" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz8" offset="16" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms9" offset="17" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz9" offset="18" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms10" offset="19" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz10" offset="20" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms11" offset="21" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz11" offset="22" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms12" offset="23" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz12" offset="24" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms13" offset="25" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz13" offset="26" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms14" offset="27" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz14" offset="28" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms15" offset="29" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz15" offset="30" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms16" offset="31" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz16" offset="32" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms17" offset="33" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz17" offset="34" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms18" offset="35" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz18" offset="36" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms19" offset="37" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz19" offset="38" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="Tms20" offset="39" access="rw" type="uint16" len="1" mandatory="false" units="Secs" sf="Tms_SF"/>
-      <point id="Hz20" offset="40" access="rw" type="uint16" len="1" mandatory="false" units="Hz" sf="Hz_SF"/>
-      <point id="CrvNam" offset="41" access="rw" type="string" len="8" mandatory="false"  />
-      <point id="ReadOnly" offset="49" access="r" type="enum16" len="1" mandatory="true" >
+      <point id="ActPt" offset="0" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Tms1" offset="1" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" mandatory="true" />
+      <point id="Hz1" offset="2" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" mandatory="true" />
+      <point id="Tms2" offset="3" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz2" offset="4" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms3" offset="5" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz3" offset="6" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms4" offset="7" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz4" offset="8" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms5" offset="9" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz5" offset="10" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms6" offset="11" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz6" offset="12" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms7" offset="13" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz7" offset="14" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms8" offset="15" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz8" offset="16" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms9" offset="17" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz9" offset="18" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms10" offset="19" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz10" offset="20" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms11" offset="21" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz11" offset="22" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms12" offset="23" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz12" offset="24" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms13" offset="25" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz13" offset="26" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms14" offset="27" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz14" offset="28" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms15" offset="29" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz15" offset="30" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms16" offset="31" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz16" offset="32" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms17" offset="33" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz17" offset="34" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms18" offset="35" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz18" offset="36" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms19" offset="37" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz19" offset="38" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="Tms20" offset="39" type="uint16" len="1" sf="Tms_SF" access="rw" units="Secs" />
+      <point id="Hz20" offset="40" type="uint16" len="1" sf="Hz_SF" access="rw" units="Hz" />
+      <point id="CrvNam" offset="41" type="string" len="8" access="rw" />
+      <point id="ReadOnly" offset="49" type="enum16" len="1" mandatory="true" >
         <symbol id="READWRITE">0</symbol>
         <symbol id="READONLY">1</symbol>
       </point>

--- a/smdx/smdx_00145.xml
+++ b/smdx/smdx_00145.xml
@@ -2,14 +2,14 @@
   <!-- 145: Extended Inverter Controls Basic Settings  -->
   <model id="145" len="8" name="ext_settings" status="test">
     <block len="8" type="fixed">
-      <point id="NomRmpUpRte" offset="0" access="rw" type="uint16" len="1" mandatory="false" units="Pct" sf="Rmp_SF"/>
-      <point id="NomRmpDnRte" offset="1" access="rw" type="uint16" len="1" mandatory="false" units="Pct" sf="Rmp_SF"/>
-      <point id="EmgRmpUpRte" offset="2" access="rw" type="uint16" len="1" mandatory="false" units="Pct" sf="Rmp_SF"/>
-      <point id="EmgRmpDnRte" offset="3" access="rw" type="uint16" len="1" mandatory="false" units="Pct" sf="Rmp_SF"/>
-      <point id="ConnRmpUpRte" offset="4" access="rw" type="uint16" len="1" mandatory="false" units="Pct" sf="Rmp_SF"/>
-      <point id="ConnRmpDnRte" offset="5" access="rw" type="uint16" len="1" mandatory="false" units="Pct" sf="Rmp_SF"/>
-      <point id="AGra" offset="6" access="rw" type="uint16" len="1" mandatory="false" units="Pct" sf="Rmp_SF"/>
-      <point id="Rmp_SF" offset="7" access="r" type="sunssf" len="1" mandatory="false" />
+      <point id="NomRmpUpRte" offset="0" type="uint16" len="1" sf="Rmp_SF" access="rw" units="Pct" />
+      <point id="NomRmpDnRte" offset="1" type="uint16" len="1" sf="Rmp_SF" access="rw" units="Pct" />
+      <point id="EmgRmpUpRte" offset="2" type="uint16" len="1" sf="Rmp_SF" access="rw" units="Pct" />
+      <point id="EmgRmpDnRte" offset="3" type="uint16" len="1" sf="Rmp_SF" access="rw" units="Pct" />
+      <point id="ConnRmpUpRte" offset="4" type="uint16" len="1" sf="Rmp_SF" access="rw" units="Pct" />
+      <point id="ConnRmpDnRte" offset="5" type="uint16" len="1" sf="Rmp_SF" access="rw" units="Pct" />
+      <point id="AGra" offset="6" type="uint16" len="1" sf="Rmp_SF" access="rw" units="Pct" />
+      <point id="Rmp_SF" offset="7" type="sunssf" len="1" />
     </block>
   </model>
   <strings id="145" locale="en">

--- a/smdx/smdx_00145.xml
+++ b/smdx/smdx_00145.xml
@@ -16,47 +16,47 @@
     <model>
       <label>Extended Settings</label>
       <description>Inverter controls extended settings </description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="NomRmpUpRte">
       <label>Ramp Up Rate</label>
       <description>Ramp up rate as a percentage of max current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="NomRmpDnRte">
       <label>NomRmpDnRte</label>
       <description>Ramp down rate as a percentage of max current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EmgRmpUpRte">
       <label>Emergency Ramp Up Rate</label>
       <description>Emergency ramp up rate as a percentage of max current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EmgRmpDnRte">
       <label>Emergency Ramp Down Rate</label>
       <description>Emergency ramp down rate as a percentage of max current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ConnRmpUpRte">
       <label>Connect Ramp Up Rate</label>
       <description>Connect ramp up rate as a percentage of max current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ConnRmpDnRte">
       <label>Connect Ramp Down Rate</label>
       <description>Connect ramp down rate as a percentage of max current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AGra">
       <label>Default Ramp Rate</label>
       <description>Ramp rate specified in percent of max current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Rmp_SF">
       <label>Ramp Rate Scale Factor</label>
       <description>Ramp Rate Scale Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00160.xml
+++ b/smdx/smdx_00160.xml
@@ -86,372 +86,372 @@
   <strings id="160" locale="en">
     <model>
       <label>Multiple MPPT Inverter Extension Model</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="DCA_SF">
       <label>Current Scale Factor</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="DCV_SF">
       <label>Voltage Scale Factor</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="DCW_SF">
       <label>Power Scale Factor</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="DCWH_SF">
       <label>Energy Scale Factor</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Global Events</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="GROUND_FAULT">
         <label>Ground Fault</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="INPUT_OVER_VOLTAGE">
         <label>Input Over Voltage</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_DISCONNECT">
         <label>DC Disconnect</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CABINET_OPEN">
         <label>Cabinet Open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MANUAL_SHUTDOWN">
         <label>Manual Shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP">
         <label>Over Temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="BLOWN_FUSE">
         <label>Blown Fuse</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP">
         <label>Under Temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MEMORY_LOSS">
         <label>Memory Loss</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="ARC_DETECTION">
         <label>Arc Detection</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="TEST_FAILED">
         <label>Test Failed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="INPUT_UNDER_VOLTAGE">
         <label>Under Voltage</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="INPUT_OVER_CURRENT">
         <label>Over Current</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="N">
       <label>Number of Modules</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="ID">
       <label>Input ID</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="IDStr">
       <label>Input ID Sting</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="DCA">
       <label>DC Current</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="DCV">
       <label>DC Voltage</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="DCW">
       <label>DC Power</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="DCWH">
       <label>Lifetime Energy</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Tms">
       <label>Timestamp</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TmsPer">
       <label>Timestamp Period</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Tmp">
       <label>Temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="DCSt">
       <label>Operating State</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="OFF">
         <label>Off</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="SLEEPING">
         <label>Sleeping</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="STARTING">
         <label>Starting</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MPPT">
         <label>MPPT</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="THROTTLED">
         <label>Throttled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="SHUTTING_DOWN">
         <label>Shutting Down</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>Fault</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="STANDBY">
         <label>Standby</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="TEST">
         <label>Test</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="DCEvt">
       <label>Module Events</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="GROUND_FAULT">
         <label>Ground Fault</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="INPUT_OVER_VOLTAGE">
         <label>Input Over Voltage</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DC_DISCONNECT">
         <label>DC Disconnect</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CABINET_OPEN">
         <label>Cabinet Open</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MANUAL_SHUTDOWN">
         <label>Manual Shutdown</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP">
         <label>Over Temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="BLOWN_FUSE">
         <label>Blown Fuse</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP">
         <label>Under Temperature</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="MEMORY_LOSS">
         <label>Memory Loss</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="ARC_DETECTION">
         <label>Arc Detection</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="TEST_FAILED">
         <label>Test Failed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="INPUT_UNDER_VOLTAGE">
         <label>Under Voltage</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="INPUT_OVER_CURRENT">
         <label>Over Current</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00160.xml
+++ b/smdx/smdx_00160.xml
@@ -2,12 +2,12 @@
 
   <!-- 160: Multiple MPPT Inverter Extension Model -->
   <model id="160" len="28" name="mppt">
-    <block len="8">
-      <point id="DCA_SF" offset="0" type="sunssf" />
-      <point id="DCV_SF" offset="1" type="sunssf" />
-      <point id="DCW_SF" offset="2" type="sunssf" />
-      <point id="DCWH_SF" offset="3" type="sunssf" />
-      <point id="Evt" offset="4" type="bitfield32" >
+    <block len="8" type="fixed">
+      <point id="DCA_SF" offset="0" type="sunssf" len="1" />
+      <point id="DCV_SF" offset="1" type="sunssf" len="1" />
+      <point id="DCW_SF" offset="2" type="sunssf" len="1" />
+      <point id="DCWH_SF" offset="3" type="sunssf" len="1" />
+      <point id="Evt" offset="4" type="bitfield32" len="2" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="INPUT_OVER_VOLTAGE">1</symbol>
         <symbol id="RESERVED_2">2</symbol>
@@ -32,20 +32,19 @@
         <symbol id="INPUT_UNDER_VOLTAGE">21</symbol>
         <symbol id="INPUT_OVER_CURRENT">22</symbol>
       </point>
-      <point id="N" offset="6" type="count" />
-      <point id="TmsPer" offset="7" type="uint16" />
+      <point id="N" offset="6" type="count" len="1" />
+      <point id="TmsPer" offset="7" type="uint16" len="1" />
     </block>
-    <block type="repeating" len="20" name="module">
-      <point id="ID" offset="0" type="uint16" />
+    <block len="20" type="repeating" name="module">
+      <point id="ID" offset="0" type="uint16" len="1" />
       <point id="IDStr" offset="1" type="string" len="8" />
-      <point id="DCA" offset="9" type="uint16" sf="DCA_SF" units="A"/>
-      <point id="DCV" offset="10" type="uint16" sf="DCV_SF" units="V"/>
-      <point id="DCW" offset="11" type="uint16" sf="DCW_SF" units="W"/>
-      <point id="DCWH" offset="12" type="acc32" sf="DCWH_SF" units="Wh"/>
-      <point id="Tms" offset="14" type="uint32" units="Secs" />
-      <point id="Tmp" offset="16" type="int16" units="C"/>
-
-      <point id="DCSt" offset="17" type="enum16" >
+      <point id="DCA" offset="9" type="uint16" len="1" sf="DCA_SF" units="A" />
+      <point id="DCV" offset="10" type="uint16" len="1" sf="DCV_SF" units="V" />
+      <point id="DCW" offset="11" type="uint16" len="1" sf="DCW_SF" units="W" />
+      <point id="DCWH" offset="12" type="acc32" len="2" sf="DCWH_SF" units="Wh" />
+      <point id="Tms" offset="14" type="uint32" len="2" units="Secs" />
+      <point id="Tmp" offset="16" type="int16" len="1" units="C" />
+      <point id="DCSt" offset="17" type="enum16" len="1" >
         <symbol id="OFF">1</symbol>
         <symbol id="SLEEPING">2</symbol>
         <symbol id="STARTING">3</symbol>
@@ -57,7 +56,7 @@
         <symbol id="TEST">9</symbol>
         <symbol id="RESERVED_10">10</symbol>
       </point>
-      <point id="DCEvt" offset="18" type="bitfield32" >
+      <point id="DCEvt" offset="18" type="bitfield32" len="2" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="INPUT_OVER_VOLTAGE">1</symbol>
         <symbol id="RESERVED_2">2</symbol>

--- a/smdx/smdx_00201.xml
+++ b/smdx/smdx_00201.xml
@@ -1,79 +1,79 @@
 <sunSpecModels v="1">
   <!-- 201: ac_meter -->
   <model id="201" len="105" name="ac_meter">
-    <block len="105">
-      <point id="A" offset="0" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphA" offset="1" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphB" offset="2" type="int16" sf="A_SF" units="A" />
-      <point id="AphC" offset="3" type="int16" sf="A_SF" units="A" mandatory="false" />
-      <point id="A_SF" offset="4" type="sunssf" mandatory="true"/>
-      <point id="PhV" offset="5" type="int16" sf="V_SF" units="V" mandatory="false" />
-      <point id="PhVphA" offset="6" type="int16" sf="V_SF" units="V" mandatory="false" />
-      <point id="PhVphB" offset="7" type="int16" sf="V_SF" units="V" />
-      <point id="PhVphC" offset="8" type="int16" sf="V_SF" units="V" />
-      <point id="PPV" offset="9" type="int16" sf="V_SF" units="V" mandatory="false" />
-      <point id="PPVphAB" offset="10" type="int16" sf="V_SF" units="V" />
-      <point id="PPVphBC" offset="11" type="int16" sf="V_SF" units="V" />
-      <point id="PPVphCA" offset="12" type="int16" sf="V_SF" units="V" />
-      <point id="V_SF" offset="13" type="sunssf" mandatory="true" />
-      <point id="Hz" offset="14" type="int16" sf="Hz_SF" units="Hz" mandatory="true" />
-      <point id="Hz_SF" offset="15" type="sunssf" />
-      <point id="W" offset="16" type="int16" sf="W_SF" units="W" mandatory="true" />
-      <point id="WphA" offset="17" type="int16" sf="W_SF" units="W" />
-      <point id="WphB" offset="18" type="int16" sf="W_SF" units="W" />
-      <point id="WphC" offset="19" type="int16" sf="W_SF" units="W" />
-      <point id="W_SF" offset="20" type="sunssf" mandatory="true" />
-      <point id="VA" offset="21" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphA" offset="22" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphB" offset="23" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphC" offset="24" type="int16" sf="VA_SF" units="VA" />
-      <point id="VA_SF" offset="25" type="sunssf" />
-      <point id="VAR" offset="26" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphA" offset="27" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphB" offset="28" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphC" offset="29" type="int16" sf="VAR_SF" units="var" />
-      <point id="VAR_SF" offset="30" type="sunssf" />
-      <point id="PF" offset="31" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphA" offset="32" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphB" offset="33" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphC" offset="34" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PF_SF" offset="35" type="sunssf" />
-      <point id="TotWhExp" offset="36" type="acc32" sf="TotWh_SF" units="Wh" mandatory="true" />
-      <point id="TotWhExpPhA" offset="38" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhExpPhB" offset="40" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhExpPhC" offset="42" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImp" offset="44" type="acc32" sf="TotWh_SF" units="Wh" mandatory="true" />
-      <point id="TotWhImpPhA" offset="46" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImpPhB" offset="48" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImpPhC" offset="50" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWh_SF" offset="52" type="sunssf" mandatory="true" />
-      <point id="TotVAhExp" offset="53" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhA" offset="55" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhB" offset="57" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhC" offset="59" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImp" offset="61" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhA" offset="63" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhB" offset="65" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhC" offset="67" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAh_SF" offset="69" type="sunssf" />
-      <point id="TotVArhImpQ1" offset="70" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhA" offset="72" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhB" offset="74" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhC" offset="76" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2" offset="78" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhA" offset="80" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhB" offset="82" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhC" offset="84" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3" offset="86" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhA" offset="88" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhB" offset="90" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhC" offset="92" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4" offset="94" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhA" offset="96" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhB" offset="98" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhC" offset="100" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArh_SF" offset="102" type="sunssf" />
-      <point id="Evt" offset="103" type="bitfield32" mandatory="true" >
+    <block len="105" type="fixed">
+      <point id="A" offset="0" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphA" offset="1" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphB" offset="2" type="int16" len="1" sf="A_SF" units="A" />
+      <point id="AphC" offset="3" type="int16" len="1" sf="A_SF" units="A" />
+      <point id="A_SF" offset="4" type="sunssf" len="1" mandatory="true" />
+      <point id="PhV" offset="5" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PhVphA" offset="6" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PhVphB" offset="7" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PhVphC" offset="8" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PPV" offset="9" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PPVphAB" offset="10" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PPVphBC" offset="11" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PPVphCA" offset="12" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="V_SF" offset="13" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz" offset="14" type="int16" len="1" sf="Hz_SF" units="Hz" mandatory="true" />
+      <point id="Hz_SF" offset="15" type="sunssf" len="1" />
+      <point id="W" offset="16" type="int16" len="1" sf="W_SF" units="W" mandatory="true" />
+      <point id="WphA" offset="17" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="WphB" offset="18" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="WphC" offset="19" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="W_SF" offset="20" type="sunssf" len="1" mandatory="true" />
+      <point id="VA" offset="21" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphA" offset="22" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphB" offset="23" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphC" offset="24" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VA_SF" offset="25" type="sunssf" len="1" />
+      <point id="VAR" offset="26" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphA" offset="27" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphB" offset="28" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphC" offset="29" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VAR_SF" offset="30" type="sunssf" len="1" />
+      <point id="PF" offset="31" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphA" offset="32" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphB" offset="33" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphC" offset="34" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PF_SF" offset="35" type="sunssf" len="1" />
+      <point id="TotWhExp" offset="36" type="acc32" len="2" sf="TotWh_SF" units="Wh" mandatory="true" />
+      <point id="TotWhExpPhA" offset="38" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhExpPhB" offset="40" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhExpPhC" offset="42" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImp" offset="44" type="acc32" len="2" sf="TotWh_SF" units="Wh" mandatory="true" />
+      <point id="TotWhImpPhA" offset="46" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImpPhB" offset="48" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImpPhC" offset="50" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWh_SF" offset="52" type="sunssf" len="1" mandatory="true" />
+      <point id="TotVAhExp" offset="53" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhA" offset="55" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhB" offset="57" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhC" offset="59" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImp" offset="61" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhA" offset="63" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhB" offset="65" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhC" offset="67" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAh_SF" offset="69" type="sunssf" len="1" />
+      <point id="TotVArhImpQ1" offset="70" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhA" offset="72" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhB" offset="74" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhC" offset="76" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2" offset="78" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhA" offset="80" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhB" offset="82" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhC" offset="84" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3" offset="86" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhA" offset="88" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhB" offset="90" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhC" offset="92" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4" offset="94" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhA" offset="96" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhB" offset="98" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhC" offset="100" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArh_SF" offset="102" type="sunssf" len="1" />
+      <point id="Evt" offset="103" type="bitfield32" len="2" mandatory="true" >
         <symbol id="Power_Failure">2</symbol>
         <symbol id="Under_Voltage">3</symbol>
         <symbol id="Low_PF">4</symbol>

--- a/smdx/smdx_00201.xml
+++ b/smdx/smdx_00201.xml
@@ -102,27 +102,27 @@
     <model>
       <label>Meter (Single Phase)single phase (AN or AB) meter</label>
       <description>Include this model for single phase (AN or AB) metering</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>Total AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphA">
       <label>Amps PhaseA</label>
       <description>Phase A Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphB">
       <label>Amps PhaseB</label>
       <description>Phase B Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="A_SF"><description>Current scale factor</description></point>
     <point id="PhV">
@@ -138,17 +138,17 @@
     <point id="PPVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPV">
       <label>Voltage LL</label>
       <description>Line to Line AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
@@ -158,380 +158,380 @@
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="V_SF"><description>Voltage scale factor</description></point>
     <point id="Hz">
       <label>Hz</label>
       <description>Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz_SF"><description>Frequency scale factor</description></point>
     <point id="W">
       <label>Watts</label>
       <description>Total Real Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W_SF"><description>Real Power scale factor</description></point>
     <point id="WphA">
       <label>Watts phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphB">
       <label>Watts phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphC">
       <label>Watts phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VA_SF"><description>Apparent Power scale factor</description></point>
     <point id="VAphA">
       <label>VA phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphB">
       <label>VA phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphC">
       <label>VA phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAR">
       <label>VAR</label>
       <description>Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAR_SF"><description>Reactive Power scale factor</description></point>
     <point id="VARphA">
       <label>VAR phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphB">
       <label>VAR phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphC">
       <label>VAR phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PF_SF"><description>Power Factor scale factor</description></point>
     <point id="PFphA">
       <label>PF phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphB">
       <label>PF phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphC">
       <label>PF phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExp">
       <label>Total Watt-hours Exported</label>
       <description>Total Real Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWh_SF"><description>Real Energy scale factor</description></point>
     <point id="TotWhExpPhA">
       <label>Total Watt-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhB">
       <label>Total Watt-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhC">
       <label>Total Watt-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImp">
       <label>Total Watt-hours Imported</label>
       <description>Total Real Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhImpPhA">
       <label>Total Watt-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhB">
       <label>Total Watt-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhC">
       <label>Total Watt-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExp">
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAh_SF"><description>Apparent Energy scale factor</description></point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhB">
       <label>Total VA-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhC">
       <label>Total VA-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImp">
       <label>Total VA-hours Imported</label>
       <description>Total Apparent Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhImpPhA">
       <label>Total VA-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhB">
       <label>Total VA-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhC">
       <label>Total VA-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArh_SF"><description>Reactive Energy scale factor</description></point>
     <point id="TotVArhImpQ1">
       <label>Total VAR-hours Imported Q1</label>
       <description>Total Reactive Energy Imported Quadrant 1</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhA">
       <label>Total VAr-hours Imported Q1 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhB">
       <label>Total VAr-hours Imported Q1 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhC">
       <label>Total VAr-hours Imported Q1 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2">
       <label>Total VAr-hours Imported Q2</label>
       <description>Total Reactive Power Imported Quadrant 2</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhA">
       <label>Total VAr-hours Imported Q2 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhB">
       <label>Total VAr-hours Imported Q2 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhC">
       <label>Total VAr-hours Imported Q2 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3">
       <label>Total VAr-hours Exported Q3</label>
       <description>Total Reactive Power Exported Quadrant 3</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhA">
       <label>Total VAr-hours Exported Q3 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhB">
       <label>Total VAr-hours Exported Q3 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhC">
       <label>Total VAr-hours Exported Q3 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4">
       <label>Total VAr-hours Exported Q4</label>
       <description>Total Reactive Power Exported Quadrant 4</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhA">
       <label>Total VAr-hours Exported Q4 Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhB">
       <label>Total VAr-hours Exported Q4 Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhC">
       <label>Total VAr-hours Exported Q4 Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Events</label>
       <description>Meter Event Flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="Power_Failure">
         <label>Power Failure</label>
         <description>Loss of power or phase</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Under_Voltage">
         <label>Under Voltage</label>
         <description>Voltage below threshold (Phase Loss)</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Low_PF">
         <label>Low PF</label>
         <description>Power Factor below threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Current">
         <label>Over Current</label>
         <description>Current Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Voltage">
         <label>Over Voltage</label>
         <description>Voltage Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Missing_Sensor">
         <label>Missing Sensor</label>
         <description>Sensor not connected</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM01">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM02">
         <label>OEM02</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM03">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM04">
         <label>OEM04</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM05">
         <label>OEM05</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM06">
         <label>OEM06</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM07">
         <label>OEM07</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM08">
         <label>OEM08</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM09">
         <label>OEM09</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM10">
         <label>OEM10</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM11">
         <label>OEM11</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM12">
         <label>OEM12</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM13">
         <label>OEM13</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM14">
         <label>OEM14</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM15">
         <label>OEM15</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM16">
         <label>OEM16</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00202.xml
+++ b/smdx/smdx_00202.xml
@@ -109,437 +109,437 @@
   <strings id="202" locale="en">
     <model>
       <label>split single phase (ABN) meter</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>Total AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphA">
       <label>Amps PhaseA</label>
       <description>Phase A Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphB">
       <label>Amps PhaseB</label>
       <description>Phase B Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="A_SF"><description>Current scale factor</description></point>
     <point id="PhV">
       <label>Voltage LN</label>
       <description>Line to Neutral AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPV">
       <label>Voltage LL</label>
       <description>Line to Line AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="V_SF"><description>Voltage scale factor</description></point>
     <point id="Hz">
       <label>Hz</label>
       <description>Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz_SF"><description>Frequency scale factor</description></point>
     <point id="W">
       <label>Watts</label>
       <description>Total Real Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W_SF"><description>Real Power scale factor</description></point>
     <point id="WphA">
       <label>Watts phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphB">
       <label>Watts phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphC">
       <label>Watts phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VA_SF"><description>Apparent Power scale factor</description></point>
     <point id="VAphA">
       <label>VA phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphB">
       <label>VA phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphC">
       <label>VA phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAR">
       <label>VAR</label>
       <description>Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAR_SF"><description>Reactive Power scale factor</description></point>
     <point id="VARphA">
       <label>VAR phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphB">
       <label>VAR phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphC">
       <label>VAR phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PF_SF"><description>Power Factor scale factor</description></point>
     <point id="PFphA">
       <label>PF phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphB">
       <label>PF phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphC">
       <label>PF phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExp">
       <label>Total Watt-hours Exported</label>
       <description>Total Real Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWh_SF"><description>Real Energy scale factor</description></point>
     <point id="TotWhExpPhA">
       <label>Total Watt-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhB">
       <label>Total Watt-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhC">
       <label>Total Watt-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImp">
       <label>Total Watt-hours Imported</label>
       <description>Total Real Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhImpPhA">
       <label>Total Watt-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhB">
       <label>Total Watt-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhC">
       <label>Total Watt-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExp">
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAh_SF"><description>Apparent Energy scale factor</description></point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhB">
       <label>Total VA-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhC">
       <label>Total VA-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImp">
       <label>Total VA-hours Imported</label>
       <description>Total Apparent Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhImpPhA">
       <label>Total VA-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhB">
       <label>Total VA-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhC">
       <label>Total VA-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArh_SF"><description>Reactive Energy scale factor</description></point>
     <point id="TotVArhImpQ1">
       <label>Total VAR-hours Imported Q1</label>
       <description>Total Reactive Energy Imported Quadrant 1</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhA">
       <label>Total VAr-hours Imported Q1 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhB">
       <label>Total VAr-hours Imported Q1 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhC">
       <label>Total VAr-hours Imported Q1 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2">
       <label>Total VAr-hours Imported Q2</label>
       <description>Total Reactive Power Imported Quadrant 2</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhA">
       <label>Total VAr-hours Imported Q2 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhB">
       <label>Total VAr-hours Imported Q2 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhC">
       <label>Total VAr-hours Imported Q2 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3">
       <label>Total VAr-hours Exported Q3</label>
       <description>Total Reactive Power Exported Quadrant 3</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhA">
       <label>Total VAr-hours Exported Q3 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhB">
       <label>Total VAr-hours Exported Q3 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhC">
       <label>Total VAr-hours Exported Q3 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4">
       <label>Total VAr-hours Exported Q4</label>
       <description>Total Reactive Power Exported Quadrant 4</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhA">
       <label>Total VAr-hours Exported Q4 Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhB">
       <label>Total VAr-hours Exported Q4 Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhC">
       <label>Total VAr-hours Exported Q4 Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Events</label>
       <description>Meter Event Flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="Power_Failure">
         <label>Power Failure</label>
         <description>Loss of power or phase</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Under_Voltage">
         <label>Under Voltage</label>
         <description>Voltage below threshold (Phase Loss)</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Low_PF">
         <label>Low PF</label>
         <description>Power Factor below threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Current">
         <label>Over Current</label>
         <description>Current Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Voltage">
         <label>Over Voltage</label>
         <description>Voltage Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Missing_Sensor">
         <label>Missing Sensor</label>
         <description>Sensor not connected</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM01">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM02">
         <label>OEM02</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM03">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM04">
         <label>OEM04</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM05">
         <label>OEM05</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM06">
         <label>OEM06</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM07">
         <label>OEM07</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM08">
         <label>OEM08</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM09">
         <label>OEM09</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM10">
         <label>OEM10</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM11">
         <label>OEM11</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM12">
         <label>OEM12</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM13">
         <label>OEM13</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM14">
         <label>OEM14</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM15">
         <label>OEM15</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM16">
         <label>OEM16</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00202.xml
+++ b/smdx/smdx_00202.xml
@@ -1,79 +1,79 @@
 <sunSpecModels v="1">
   <!-- 202: ac_meter -->
   <model id="202" len="105" name="ac_meter">
-    <block len="105">
-      <point id="A" offset="0" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphA" offset="1" type="int16" sf="A_SF" units="A" mandatory="false" />
-      <point id="AphB" offset="2" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphC" offset="3" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="A_SF" offset="4" type="sunssf" mandatory="true" />
-      <point id="PhV" offset="5" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphA" offset="6" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphB" offset="7" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphC" offset="8" type="int16" sf="V_SF" units="V" />
-      <point id="PPV" offset="9" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphAB" offset="10" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphBC" offset="11" type="int16" sf="V_SF" units="V" />
-      <point id="PhVphCA" offset="12" type="int16" sf="V_SF" units="V" />
-      <point id="V_SF" offset="13" type="sunssf" mandatory="true" />
-      <point id="Hz" offset="14" type="int16" sf="Hz_SF" units="Hz" mandatory="true" />
-      <point id="Hz_SF" offset="15" type="sunssf" />
-      <point id="W" offset="16" type="int16" sf="W_SF" units="W" mandatory="true" />
-      <point id="WphA" offset="17" type="int16" sf="W_SF" units="W" />
-      <point id="WphB" offset="18" type="int16" sf="W_SF" units="W" />
-      <point id="WphC" offset="19" type="int16" sf="W_SF" units="W" />
-      <point id="W_SF" offset="20" type="sunssf" mandatory="true" />
-      <point id="VA" offset="21" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphA" offset="22" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphB" offset="23" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphC" offset="24" type="int16" sf="VA_SF" units="VA" />
-      <point id="VA_SF" offset="25" type="sunssf" />
-      <point id="VAR" offset="26" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphA" offset="27" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphB" offset="28" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphC" offset="29" type="int16" sf="VAR_SF" units="var" />
-      <point id="VAR_SF" offset="30" type="sunssf" />
-      <point id="PF" offset="31" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphA" offset="32" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphB" offset="33" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphC" offset="34" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PF_SF" offset="35" type="sunssf" />
-      <point id="TotWhExp" offset="36" type="acc32" sf="TotWh_SF" units="Wh" mandatory="true" />
-      <point id="TotWhExpPhA" offset="38" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhExpPhB" offset="40" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhExpPhC" offset="42" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImp" offset="44" type="acc32" sf="TotWh_SF" units="Wh" mandatory="true" />
-      <point id="TotWhImpPhA" offset="46" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImpPhB" offset="48" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImpPhC" offset="50" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWh_SF" offset="52" type="sunssf" mandatory="true" />
-      <point id="TotVAhExp" offset="53" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhA" offset="55" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhB" offset="57" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhC" offset="59" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImp" offset="61" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhA" offset="63" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhB" offset="65" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhC" offset="67" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAh_SF" offset="69" type="sunssf" />
-      <point id="TotVArhImpQ1" offset="70" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhA" offset="72" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhB" offset="74" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhC" offset="76" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2" offset="78" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhA" offset="80" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhB" offset="82" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhC" offset="84" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3" offset="86" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhA" offset="88" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhB" offset="90" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhC" offset="92" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4" offset="94" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhA" offset="96" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhB" offset="98" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhC" offset="100" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArh_SF" offset="102" type="sunssf" />
-      <point id="Evt" offset="103" type="bitfield32" mandatory="true" >
+    <block len="105" type="fixed">
+      <point id="A" offset="0" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphA" offset="1" type="int16" len="1" sf="A_SF" units="A" />
+      <point id="AphB" offset="2" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphC" offset="3" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="A_SF" offset="4" type="sunssf" len="1" mandatory="true" />
+      <point id="PhV" offset="5" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphA" offset="6" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphB" offset="7" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphC" offset="8" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PPV" offset="9" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphAB" offset="10" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphBC" offset="11" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PhVphCA" offset="12" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="V_SF" offset="13" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz" offset="14" type="int16" len="1" sf="Hz_SF" units="Hz" mandatory="true" />
+      <point id="Hz_SF" offset="15" type="sunssf" len="1" />
+      <point id="W" offset="16" type="int16" len="1" sf="W_SF" units="W" mandatory="true" />
+      <point id="WphA" offset="17" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="WphB" offset="18" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="WphC" offset="19" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="W_SF" offset="20" type="sunssf" len="1" mandatory="true" />
+      <point id="VA" offset="21" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphA" offset="22" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphB" offset="23" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphC" offset="24" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VA_SF" offset="25" type="sunssf" len="1" />
+      <point id="VAR" offset="26" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphA" offset="27" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphB" offset="28" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphC" offset="29" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VAR_SF" offset="30" type="sunssf" len="1" />
+      <point id="PF" offset="31" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphA" offset="32" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphB" offset="33" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphC" offset="34" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PF_SF" offset="35" type="sunssf" len="1" />
+      <point id="TotWhExp" offset="36" type="acc32" len="2" sf="TotWh_SF" units="Wh" mandatory="true" />
+      <point id="TotWhExpPhA" offset="38" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhExpPhB" offset="40" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhExpPhC" offset="42" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImp" offset="44" type="acc32" len="2" sf="TotWh_SF" units="Wh" mandatory="true" />
+      <point id="TotWhImpPhA" offset="46" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImpPhB" offset="48" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImpPhC" offset="50" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWh_SF" offset="52" type="sunssf" len="1" mandatory="true" />
+      <point id="TotVAhExp" offset="53" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhA" offset="55" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhB" offset="57" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhC" offset="59" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImp" offset="61" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhA" offset="63" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhB" offset="65" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhC" offset="67" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAh_SF" offset="69" type="sunssf" len="1" />
+      <point id="TotVArhImpQ1" offset="70" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhA" offset="72" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhB" offset="74" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhC" offset="76" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2" offset="78" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhA" offset="80" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhB" offset="82" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhC" offset="84" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3" offset="86" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhA" offset="88" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhB" offset="90" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhC" offset="92" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4" offset="94" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhA" offset="96" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhB" offset="98" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhC" offset="100" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArh_SF" offset="102" type="sunssf" len="1" />
+      <point id="Evt" offset="103" type="bitfield32" len="2" mandatory="true" >
         <symbol id="M_EVENT_Power_Failure">2</symbol>
         <symbol id="M_EVENT_Under_Voltage">3</symbol>
         <symbol id="M_EVENT_Low_PF">4</symbol>

--- a/smdx/smdx_00203.xml
+++ b/smdx/smdx_00203.xml
@@ -109,437 +109,437 @@
   <strings id="203" locale="en">
     <model>
       <label>wye-connect three phase (abcn) meter</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>Total AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphA">
       <label>Amps PhaseA</label>
       <description>Phase A Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphB">
       <label>Amps PhaseB</label>
       <description>Phase B Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="A_SF"><description>Current scale factor</description></point>
     <point id="PhV">
       <label>Voltage LN</label>
       <description>Line to Neutral AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPV">
       <label>Voltage LL</label>
       <description>Line to Line AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="V_SF"><description>Voltage scale factor</description></point>
     <point id="Hz">
       <label>Hz</label>
       <description>Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz_SF"><description>Frequency scale factor</description></point>
     <point id="W">
       <label>Watts</label>
       <description>Total Real Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W_SF"><description>Real Power scale factor</description></point>
     <point id="WphA">
       <label>Watts phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphB">
       <label>Watts phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphC">
       <label>Watts phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VA_SF"><description>Apparent Power scale factor</description></point>
     <point id="VAphA">
       <label>VA phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphB">
       <label>VA phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphC">
       <label>VA phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAR">
       <label>VAR</label>
       <description>Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAR_SF"><description>Reactive Power scale factor</description></point>
     <point id="VARphA">
       <label>VAR phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphB">
       <label>VAR phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphC">
       <label>VAR phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PF_SF"><description>Power Factor scale factor</description></point>
     <point id="PFphA">
       <label>PF phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphB">
       <label>PF phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphC">
       <label>PF phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExp">
       <label>Total Watt-hours Exported</label>
       <description>Total Real Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWh_SF"><description>Real Energy scale factor</description></point>
     <point id="TotWhExpPhA">
       <label>Total Watt-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhB">
       <label>Total Watt-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhC">
       <label>Total Watt-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImp">
       <label>Total Watt-hours Imported</label>
       <description>Total Real Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhImpPhA">
       <label>Total Watt-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhB">
       <label>Total Watt-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhC">
       <label>Total Watt-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExp">
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAh_SF"><description>Apparent Energy scale factor</description></point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhB">
       <label>Total VA-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhC">
       <label>Total VA-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImp">
       <label>Total VA-hours Imported</label>
       <description>Total Apparent Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhImpPhA">
       <label>Total VA-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhB">
       <label>Total VA-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhC">
       <label>Total VA-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArh_SF"><description>Reactive Energy scale factor</description></point>
     <point id="TotVArhImpQ1">
       <label>Total VAR-hours Imported Q1</label>
       <description>Total Reactive Energy Imported Quadrant 1</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhA">
       <label>Total VAr-hours Imported Q1 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhB">
       <label>Total VAr-hours Imported Q1 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhC">
       <label>Total VAr-hours Imported Q1 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2">
       <label>Total VAr-hours Imported Q2</label>
       <description>Total Reactive Power Imported Quadrant 2</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhA">
       <label>Total VAr-hours Imported Q2 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhB">
       <label>Total VAr-hours Imported Q2 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhC">
       <label>Total VAr-hours Imported Q2 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3">
       <label>Total VAr-hours Exported Q3</label>
       <description>Total Reactive Power Exported Quadrant 3</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhA">
       <label>Total VAr-hours Exported Q3 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhB">
       <label>Total VAr-hours Exported Q3 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhC">
       <label>Total VAr-hours Exported Q3 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4">
       <label>Total VAr-hours Exported Q4</label>
       <description>Total Reactive Power Exported Quadrant 4</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhA">
       <label>Total VAr-hours Exported Q4 Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhB">
       <label>Total VAr-hours Exported Q4 Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhC">
       <label>Total VAr-hours Exported Q4 Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Events</label>
       <description>Meter Event Flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="Power_Failure">
         <label>Power Failure</label>
         <description>Loss of power or phase</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Under_Voltage">
         <label>Under Voltage</label>
         <description>Voltage below threshold (Phase Loss)</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Low_PF">
         <label>Low PF</label>
         <description>Power Factor below threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Current">
         <label>Over Current</label>
         <description>Current Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Voltage">
         <label>Over Voltage</label>
         <description>Voltage Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Missing_Sensor">
         <label>Missing Sensor</label>
         <description>Sensor not connected</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM01">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM02">
         <label>OEM02</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM03">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM04">
         <label>OEM04</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM05">
         <label>OEM05</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM06">
         <label>OEM06</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM07">
         <label>OEM07</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM08">
         <label>OEM08</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM09">
         <label>OEM09</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM10">
         <label>OEM10</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM11">
         <label>OEM11</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM12">
         <label>OEM12</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM13">
         <label>OEM13</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM14">
         <label>OEM14</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM15">
         <label>OEM15</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM16">
         <label>OEM16</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00203.xml
+++ b/smdx/smdx_00203.xml
@@ -1,79 +1,79 @@
 <sunSpecModels v="1">
   <!-- 203: ac_meter -->
   <model id="203" len="105" name="ac_meter">
-    <block len="105">
-      <point id="A" offset="0" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphA" offset="1" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphB" offset="2" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphC" offset="3" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="A_SF" offset="4" type="sunssf" mandatory="true" />
-      <point id="PhV" offset="5" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphA" offset="6" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphB" offset="7" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphC" offset="8" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PPV" offset="9" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphAB" offset="10" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphBC" offset="11" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphCA" offset="12" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="V_SF" offset="13" type="sunssf" mandatory="true" />
-      <point id="Hz" offset="14" type="int16" sf="Hz_SF" units="Hz" mandatory="true" />
-      <point id="Hz_SF" offset="15" type="sunssf" />
-      <point id="W" offset="16" type="int16" sf="W_SF" units="W" mandatory="true" />
-      <point id="WphA" offset="17" type="int16" sf="W_SF" units="W" />
-      <point id="WphB" offset="18" type="int16" sf="W_SF" units="W" />
-      <point id="WphC" offset="19" type="int16" sf="W_SF" units="W" />
-      <point id="W_SF" offset="20" type="sunssf" mandatory="true" />
-      <point id="VA" offset="21" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphA" offset="22" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphB" offset="23" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphC" offset="24" type="int16" sf="VA_SF" units="VA" />
-      <point id="VA_SF" offset="25" type="sunssf" />
-      <point id="VAR" offset="26" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphA" offset="27" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphB" offset="28" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphC" offset="29" type="int16" sf="VAR_SF" units="var" />
-      <point id="VAR_SF" offset="30" type="sunssf" />
-      <point id="PF" offset="31" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphA" offset="32" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphB" offset="33" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphC" offset="34" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PF_SF" offset="35" type="sunssf" />
-      <point id="TotWhExp" offset="36" type="acc32" sf="TotWh_SF" units="Wh" mandatory="true" />
-      <point id="TotWhExpPhA" offset="38" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhExpPhB" offset="40" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhExpPhC" offset="42" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImp" offset="44" type="acc32" sf="TotWh_SF" units="Wh" mandatory="true" />
-      <point id="TotWhImpPhA" offset="46" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImpPhB" offset="48" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImpPhC" offset="50" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWh_SF" offset="52" type="sunssf" mandatory="true" />
-      <point id="TotVAhExp" offset="53" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhA" offset="55" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhB" offset="57" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhC" offset="59" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImp" offset="61" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhA" offset="63" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhB" offset="65" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhC" offset="67" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAh_SF" offset="69" type="sunssf" />
-      <point id="TotVArhImpQ1" offset="70" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhA" offset="72" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhB" offset="74" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhC" offset="76" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2" offset="78" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhA" offset="80" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhB" offset="82" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhC" offset="84" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3" offset="86" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhA" offset="88" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhB" offset="90" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhC" offset="92" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4" offset="94" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhA" offset="96" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhB" offset="98" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhC" offset="100" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArh_SF" offset="102" type="sunssf" />
-      <point id="Evt" offset="103" type="bitfield32" mandatory="true" >
+    <block len="105" type="fixed">
+      <point id="A" offset="0" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphA" offset="1" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphB" offset="2" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphC" offset="3" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="A_SF" offset="4" type="sunssf" len="1" mandatory="true" />
+      <point id="PhV" offset="5" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphA" offset="6" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphB" offset="7" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphC" offset="8" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PPV" offset="9" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphAB" offset="10" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphBC" offset="11" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphCA" offset="12" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="V_SF" offset="13" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz" offset="14" type="int16" len="1" sf="Hz_SF" units="Hz" mandatory="true" />
+      <point id="Hz_SF" offset="15" type="sunssf" len="1" />
+      <point id="W" offset="16" type="int16" len="1" sf="W_SF" units="W" mandatory="true" />
+      <point id="WphA" offset="17" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="WphB" offset="18" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="WphC" offset="19" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="W_SF" offset="20" type="sunssf" len="1" mandatory="true" />
+      <point id="VA" offset="21" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphA" offset="22" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphB" offset="23" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphC" offset="24" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VA_SF" offset="25" type="sunssf" len="1" />
+      <point id="VAR" offset="26" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphA" offset="27" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphB" offset="28" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphC" offset="29" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VAR_SF" offset="30" type="sunssf" len="1" />
+      <point id="PF" offset="31" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphA" offset="32" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphB" offset="33" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphC" offset="34" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PF_SF" offset="35" type="sunssf" len="1" />
+      <point id="TotWhExp" offset="36" type="acc32" len="2" sf="TotWh_SF" units="Wh" mandatory="true" />
+      <point id="TotWhExpPhA" offset="38" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhExpPhB" offset="40" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhExpPhC" offset="42" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImp" offset="44" type="acc32" len="2" sf="TotWh_SF" units="Wh" mandatory="true" />
+      <point id="TotWhImpPhA" offset="46" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImpPhB" offset="48" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImpPhC" offset="50" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWh_SF" offset="52" type="sunssf" len="1" mandatory="true" />
+      <point id="TotVAhExp" offset="53" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhA" offset="55" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhB" offset="57" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhC" offset="59" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImp" offset="61" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhA" offset="63" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhB" offset="65" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhC" offset="67" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAh_SF" offset="69" type="sunssf" len="1" />
+      <point id="TotVArhImpQ1" offset="70" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhA" offset="72" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhB" offset="74" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhC" offset="76" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2" offset="78" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhA" offset="80" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhB" offset="82" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhC" offset="84" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3" offset="86" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhA" offset="88" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhB" offset="90" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhC" offset="92" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4" offset="94" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhA" offset="96" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhB" offset="98" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhC" offset="100" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArh_SF" offset="102" type="sunssf" len="1" />
+      <point id="Evt" offset="103" type="bitfield32" len="2" mandatory="true" >
         <symbol id="M_EVENT_Power_Failure">2</symbol>
         <symbol id="M_EVENT_Under_Voltage">3</symbol>
         <symbol id="M_EVENT_Low_PF">4</symbol>

--- a/smdx/smdx_00204.xml
+++ b/smdx/smdx_00204.xml
@@ -1,79 +1,79 @@
 <sunSpecModels v="1">
   <!-- 204: ac_meter -->
   <model id="204" len="105" name="ac_meter">
-    <block len="105">
-      <point id="A" offset="0" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphA" offset="1" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphB" offset="2" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AphC" offset="3" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="A_SF" offset="4" type="sunssf" mandatory="true"/>
-      <point id="PhV" offset="5" type="int16" sf="V_SF" units="V" mandatory="false" />
-      <point id="PhVphA" offset="6" type="int16" sf="V_SF" units="V" />
-      <point id="PhVphB" offset="7" type="int16" sf="V_SF" units="V" />
-      <point id="PhVphC" offset="8" type="int16" sf="V_SF" units="V" />
-      <point id="PPV" offset="9" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphAB" offset="10" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphBC" offset="11" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="PhVphCA" offset="12" type="int16" sf="V_SF" units="V" mandatory="true" />
-      <point id="V_SF" offset="13" type="sunssf" mandatory="true" />
-      <point id="Hz" offset="14" type="int16" sf="Hz_SF" units="Hz" mandatory="true" />
-      <point id="Hz_SF" offset="15" type="sunssf" />
-      <point id="W" offset="16" type="int16" sf="W_SF" units="W" mandatory="true" />
-      <point id="WphA" offset="17" type="int16" sf="W_SF" units="W" />
-      <point id="WphB" offset="18" type="int16" sf="W_SF" units="W" />
-      <point id="WphC" offset="19" type="int16" sf="W_SF" units="W" />
-      <point id="W_SF" offset="20" type="sunssf" mandatory="true" />
-      <point id="VA" offset="21" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphA" offset="22" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphB" offset="23" type="int16" sf="VA_SF" units="VA" />
-      <point id="VAphC" offset="24" type="int16" sf="VA_SF" units="VA" />
-      <point id="VA_SF" offset="25" type="sunssf" />
-      <point id="VAR" offset="26" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphA" offset="27" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphB" offset="28" type="int16" sf="VAR_SF" units="var" />
-      <point id="VARphC" offset="29" type="int16" sf="VAR_SF" units="var" />
-      <point id="VAR_SF" offset="30" type="sunssf" />
-      <point id="PF" offset="31" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphA" offset="32" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphB" offset="33" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PFphC" offset="34" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PF_SF" offset="35" type="sunssf" />
-      <point id="TotWhExp" offset="36" type="acc32" sf="TotWh_SF" units="Wh" mandatory="true" />
-      <point id="TotWhExpPhA" offset="38" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhExpPhB" offset="40" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhExpPhC" offset="42" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImp" offset="44" type="acc32" sf="TotWh_SF" units="Wh" mandatory="true" />
-      <point id="TotWhImpPhA" offset="46" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImpPhB" offset="48" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWhImpPhC" offset="50" type="acc32" sf="TotWh_SF" units="Wh" />
-      <point id="TotWh_SF" offset="52" type="sunssf" mandatory="true" />
-      <point id="TotVAhExp" offset="53" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhA" offset="55" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhB" offset="57" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhExpPhC" offset="59" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImp" offset="61" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhA" offset="63" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhB" offset="65" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImpPhC" offset="67" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAh_SF" offset="69" type="sunssf" />
-      <point id="TotVArhImpQ1" offset="70" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhA" offset="72" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhB" offset="74" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ1PhC" offset="76" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2" offset="78" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhA" offset="80" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhB" offset="82" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2PhC" offset="84" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3" offset="86" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhA" offset="88" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhB" offset="90" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3PhC" offset="92" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4" offset="94" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhA" offset="96" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhB" offset="98" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4PhC" offset="100" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArh_SF" offset="102" type="sunssf" />
-      <point id="Evt" offset="103" type="bitfield32" mandatory="true" >
+    <block len="105" type="fixed">
+      <point id="A" offset="0" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphA" offset="1" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphB" offset="2" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AphC" offset="3" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="A_SF" offset="4" type="sunssf" len="1" mandatory="true" />
+      <point id="PhV" offset="5" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PhVphA" offset="6" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PhVphB" offset="7" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PhVphC" offset="8" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="PPV" offset="9" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphAB" offset="10" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphBC" offset="11" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="PhVphCA" offset="12" type="int16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="V_SF" offset="13" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz" offset="14" type="int16" len="1" sf="Hz_SF" units="Hz" mandatory="true" />
+      <point id="Hz_SF" offset="15" type="sunssf" len="1" />
+      <point id="W" offset="16" type="int16" len="1" sf="W_SF" units="W" mandatory="true" />
+      <point id="WphA" offset="17" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="WphB" offset="18" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="WphC" offset="19" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="W_SF" offset="20" type="sunssf" len="1" mandatory="true" />
+      <point id="VA" offset="21" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphA" offset="22" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphB" offset="23" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VAphC" offset="24" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VA_SF" offset="25" type="sunssf" len="1" />
+      <point id="VAR" offset="26" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphA" offset="27" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphB" offset="28" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VARphC" offset="29" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VAR_SF" offset="30" type="sunssf" len="1" />
+      <point id="PF" offset="31" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphA" offset="32" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphB" offset="33" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PFphC" offset="34" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PF_SF" offset="35" type="sunssf" len="1" />
+      <point id="TotWhExp" offset="36" type="acc32" len="2" sf="TotWh_SF" units="Wh" mandatory="true" />
+      <point id="TotWhExpPhA" offset="38" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhExpPhB" offset="40" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhExpPhC" offset="42" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImp" offset="44" type="acc32" len="2" sf="TotWh_SF" units="Wh" mandatory="true" />
+      <point id="TotWhImpPhA" offset="46" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImpPhB" offset="48" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWhImpPhC" offset="50" type="acc32" len="2" sf="TotWh_SF" units="Wh" />
+      <point id="TotWh_SF" offset="52" type="sunssf" len="1" mandatory="true" />
+      <point id="TotVAhExp" offset="53" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhA" offset="55" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhB" offset="57" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhExpPhC" offset="59" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImp" offset="61" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhA" offset="63" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhB" offset="65" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImpPhC" offset="67" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAh_SF" offset="69" type="sunssf" len="1" />
+      <point id="TotVArhImpQ1" offset="70" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhA" offset="72" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhB" offset="74" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ1PhC" offset="76" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2" offset="78" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhA" offset="80" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhB" offset="82" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2PhC" offset="84" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3" offset="86" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhA" offset="88" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhB" offset="90" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3PhC" offset="92" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4" offset="94" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhA" offset="96" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhB" offset="98" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4PhC" offset="100" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArh_SF" offset="102" type="sunssf" len="1" />
+      <point id="Evt" offset="103" type="bitfield32" len="2" mandatory="true" >
         <symbol id="M_EVENT_Power_Failure">2</symbol>
         <symbol id="M_EVENT_Under_Voltage">3</symbol>
         <symbol id="M_EVENT_Low_PF">4</symbol>

--- a/smdx/smdx_00204.xml
+++ b/smdx/smdx_00204.xml
@@ -109,437 +109,437 @@
   <strings id="204" locale="en">
     <model>
       <label>delta-connect three phase (abc) meter</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>Total AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphA">
       <label>Amps PhaseA</label>
       <description>Phase A Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphB">
       <label>Amps PhaseB</label>
       <description>Phase B Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="A_SF"><description>Current scale factor</description></point>
     <point id="PhV">
       <label>Voltage LN</label>
       <description>Line to Neutral AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPV">
       <label>Voltage LL</label>
       <description>Line to Line AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="V_SF"><description>Voltage scale factor</description></point>
     <point id="Hz">
       <label>Hz</label>
       <description>Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz_SF"><description>Frequency scale factor</description></point>
     <point id="W">
       <label>Watts</label>
       <description>Total Real Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W_SF"><description>Real Power scale factor</description></point>
     <point id="WphA">
       <label>Watts phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphB">
       <label>Watts phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphC">
       <label>Watts phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VA_SF"><description>Apparent Power scale factor</description></point>
     <point id="VAphA">
       <label>VA phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphB">
       <label>VA phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphC">
       <label>VA phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAR">
       <label>VAR</label>
       <description>Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAR_SF"><description>Reactive Power scale factor</description></point>
     <point id="VARphA">
       <label>VAR phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphB">
       <label>VAR phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphC">
       <label>VAR phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PF_SF"><description>Power Factor scale factor</description></point>
     <point id="PFphA">
       <label>PF phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphB">
       <label>PF phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphC">
       <label>PF phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExp">
       <label>Total Watt-hours Exported</label>
       <description>Total Real Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWh_SF"><description>Real Energy scale factor</description></point>
     <point id="TotWhExpPhA">
       <label>Total Watt-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhB">
       <label>Total Watt-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhC">
       <label>Total Watt-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImp">
       <label>Total Watt-hours Imported</label>
       <description>Total Real Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhImpPhA">
       <label>Total Watt-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhB">
       <label>Total Watt-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhC">
       <label>Total Watt-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExp">
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAh_SF"><description>Apparent Energy scale factor</description></point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhB">
       <label>Total VA-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhC">
       <label>Total VA-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImp">
       <label>Total VA-hours Imported</label>
       <description>Total Apparent Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhImpPhA">
       <label>Total VA-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhB">
       <label>Total VA-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhC">
       <label>Total VA-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArh_SF"><description>Reactive Energy scale factor</description></point>
     <point id="TotVArhImpQ1">
       <label>Total VAR-hours Imported Q1</label>
       <description>Total Reactive Energy Imported Quadrant 1</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhA">
       <label>Total VAr-hours Imported Q1 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhB">
       <label>Total VAr-hours Imported Q1 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1PhC">
       <label>Total VAr-hours Imported Q1 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2">
       <label>Total VAr-hours Imported Q2</label>
       <description>Total Reactive Power Imported Quadrant 2</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhA">
       <label>Total VAr-hours Imported Q2 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhB">
       <label>Total VAr-hours Imported Q2 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2PhC">
       <label>Total VAr-hours Imported Q2 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3">
       <label>Total VAr-hours Exported Q3</label>
       <description>Total Reactive Power Exported Quadrant 3</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhA">
       <label>Total VAr-hours Exported Q3 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhB">
       <label>Total VAr-hours Exported Q3 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3PhC">
       <label>Total VAr-hours Exported Q3 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4">
       <label>Total VAr-hours Exported Q4</label>
       <description>Total Reactive Power Exported Quadrant 4</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhA">
       <label>Total VAr-hours Exported Q4 Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhB">
       <label>Total VAr-hours Exported Q4 Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4PhC">
       <label>Total VAr-hours Exported Q4 Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Events</label>
       <description>Meter Event Flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="Power_Failure">
         <label>Power Failure</label>
         <description>Loss of power or phase</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Under_Voltage">
         <label>Under Voltage</label>
         <description>Voltage below threshold (Phase Loss)</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Low_PF">
         <label>Low PF</label>
         <description>Power Factor below threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Current">
         <label>Over Current</label>
         <description>Current Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Voltage">
         <label>Over Voltage</label>
         <description>Voltage Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Missing_Sensor">
         <label>Missing Sensor</label>
         <description>Sensor not connected</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM01">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM02">
         <label>OEM02</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM03">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM04">
         <label>OEM04</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM05">
         <label>OEM05</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM06">
         <label>OEM06</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM07">
         <label>OEM07</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM08">
         <label>OEM08</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM09">
         <label>OEM09</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM10">
         <label>OEM10</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM11">
         <label>OEM11</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM12">
         <label>OEM12</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM13">
         <label>OEM13</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM14">
         <label>OEM14</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM15">
         <label>OEM15</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM16">
         <label>OEM16</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00211.xml
+++ b/smdx/smdx_00211.xml
@@ -1,69 +1,69 @@
 <sunSpecModels v="1">
   <!-- 211: ac_meter_f -->
   <model id="211" len="124" name="ac_meter">
-    <block len="124">
-      <point id="A" offset="0" type="float32" units="A" mandatory="true" />
-      <point id="AphA" offset="2" type="float32" units="A" mandatory="true" />
-      <point id="AphB" offset="4" type="float32" units="A" />
-      <point id="AphC" offset="6" type="float32" units="A" />
-      <point id="PhV" offset="8" type="float32" units="V" />
-      <point id="PhVphA" offset="10" type="float32" units="V" />
-      <point id="PhVphB" offset="12" type="float32" units="V" />
-      <point id="PhVphC" offset="14" type="float32" units="V" />
-      <point id="PPV" offset="16" type="float32" units="V" />
-      <point id="PPVphAB" offset="18" type="float32" units="V" />
-      <point id="PPVphBC" offset="20" type="float32" units="V" />
-      <point id="PPVphCA" offset="22" type="float32" units="V" />
-      <point id="Hz" offset="24" type="float32" units="Hz" mandatory="true" />
-      <point id="W" offset="26" type="float32" units="W" mandatory="true" />
-      <point id="WphA" offset="28" type="float32" units="W" />
-      <point id="WphB" offset="30" type="float32" units="W" />
-      <point id="WphC" offset="32" type="float32" units="W" />
-      <point id="VA" offset="34" type="float32" units="VA" />
-      <point id="VAphA" offset="36" type="float32" units="VA" />
-      <point id="VAphB" offset="38" type="float32" units="VA" />
-      <point id="VAphC" offset="40" type="float32" units="VA" />
-      <point id="VAR" offset="42" type="float32" units="var" />
-      <point id="VARphA" offset="44" type="float32" units="var" />
-      <point id="VARphB" offset="46" type="float32" units="var" />
-      <point id="VARphC" offset="48" type="float32" units="var" />
-      <point id="PF" offset="50" type="float32" units="PF" />
-      <point id="PFphA" offset="52" type="float32" units="PF" />
-      <point id="PFphB" offset="54" type="float32" units="PF" />
-      <point id="PFphC" offset="56" type="float32" units="PF" />
-      <point id="TotWhExp" offset="58" type="float32" units="Wh" mandatory="true" />
-      <point id="TotWhExpPhA" offset="60" type="float32" units="Wh" />
-      <point id="TotWhExpPhB" offset="62" type="float32" units="Wh" />
-      <point id="TotWhExpPhC" offset="64" type="float32" units="Wh" />
-      <point id="TotWhImp" offset="66" type="float32" units="Wh" mandatory="true" />
-      <point id="TotWhImpPhA" offset="68" type="float32" units="Wh" />
-      <point id="TotWhImpPhB" offset="70" type="float32" units="Wh" />
-      <point id="TotWhImpPhC" offset="72" type="float32" units="Wh" />
-      <point id="TotVAhExp" offset="74" type="float32" units="VAh" />
-      <point id="TotVAhExpPhA" offset="76" type="float32" units="VAh" />
-      <point id="TotVAhExpPhB" offset="78" type="float32" units="VAh" />
-      <point id="TotVAhExpPhC" offset="80" type="float32" units="VAh" />
-      <point id="TotVAhImp" offset="82" type="float32" units="VAh" />
-      <point id="TotVAhImpPhA" offset="84" type="float32" units="VAh" />
-      <point id="TotVAhImpPhB" offset="86" type="float32" units="VAh" />
-      <point id="TotVAhImpPhC" offset="88" type="float32" units="VAh" />
-      <point id="TotVArhImpQ1" offset="90" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phA" offset="92" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phB" offset="94" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phC" offset="96" type="float32" units="varh" />
-      <point id="TotVArhImpQ2" offset="98" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phA" offset="100" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phB" offset="102" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phC" offset="104" type="float32" units="varh" />
-      <point id="TotVArhExpQ3" offset="106" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phA" offset="108" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phB" offset="110" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phC" offset="112" type="float32" units="varh" />
-      <point id="TotVArhExpQ4" offset="114" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phA" offset="116" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phB" offset="118" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phC" offset="120" type="float32" units="varh" />
-      <point id="Evt" offset="122" type="bitfield32" mandatory="true" >
+    <block len="124" type="fixed">
+      <point id="A" offset="0" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphA" offset="2" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphB" offset="4" type="float32" len="2" units="A" />
+      <point id="AphC" offset="6" type="float32" len="2" units="A" />
+      <point id="PhV" offset="8" type="float32" len="2" units="V" />
+      <point id="PhVphA" offset="10" type="float32" len="2" units="V" />
+      <point id="PhVphB" offset="12" type="float32" len="2" units="V" />
+      <point id="PhVphC" offset="14" type="float32" len="2" units="V" />
+      <point id="PPV" offset="16" type="float32" len="2" units="V" />
+      <point id="PPVphAB" offset="18" type="float32" len="2" units="V" />
+      <point id="PPVphBC" offset="20" type="float32" len="2" units="V" />
+      <point id="PPVphCA" offset="22" type="float32" len="2" units="V" />
+      <point id="Hz" offset="24" type="float32" len="2" units="Hz" mandatory="true" />
+      <point id="W" offset="26" type="float32" len="2" units="W" mandatory="true" />
+      <point id="WphA" offset="28" type="float32" len="2" units="W" />
+      <point id="WphB" offset="30" type="float32" len="2" units="W" />
+      <point id="WphC" offset="32" type="float32" len="2" units="W" />
+      <point id="VA" offset="34" type="float32" len="2" units="VA" />
+      <point id="VAphA" offset="36" type="float32" len="2" units="VA" />
+      <point id="VAphB" offset="38" type="float32" len="2" units="VA" />
+      <point id="VAphC" offset="40" type="float32" len="2" units="VA" />
+      <point id="VAR" offset="42" type="float32" len="2" units="var" />
+      <point id="VARphA" offset="44" type="float32" len="2" units="var" />
+      <point id="VARphB" offset="46" type="float32" len="2" units="var" />
+      <point id="VARphC" offset="48" type="float32" len="2" units="var" />
+      <point id="PF" offset="50" type="float32" len="2" units="PF" />
+      <point id="PFphA" offset="52" type="float32" len="2" units="PF" />
+      <point id="PFphB" offset="54" type="float32" len="2" units="PF" />
+      <point id="PFphC" offset="56" type="float32" len="2" units="PF" />
+      <point id="TotWhExp" offset="58" type="float32" len="2" units="Wh" mandatory="true" />
+      <point id="TotWhExpPhA" offset="60" type="float32" len="2" units="Wh" />
+      <point id="TotWhExpPhB" offset="62" type="float32" len="2" units="Wh" />
+      <point id="TotWhExpPhC" offset="64" type="float32" len="2" units="Wh" />
+      <point id="TotWhImp" offset="66" type="float32" len="2" units="Wh" mandatory="true" />
+      <point id="TotWhImpPhA" offset="68" type="float32" len="2" units="Wh" />
+      <point id="TotWhImpPhB" offset="70" type="float32" len="2" units="Wh" />
+      <point id="TotWhImpPhC" offset="72" type="float32" len="2" units="Wh" />
+      <point id="TotVAhExp" offset="74" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhA" offset="76" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhB" offset="78" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhC" offset="80" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImp" offset="82" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhA" offset="84" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhB" offset="86" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhC" offset="88" type="float32" len="2" units="VAh" />
+      <point id="TotVArhImpQ1" offset="90" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phA" offset="92" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phB" offset="94" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phC" offset="96" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2" offset="98" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phA" offset="100" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phB" offset="102" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phC" offset="104" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3" offset="106" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phA" offset="108" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phB" offset="110" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phC" offset="112" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4" offset="114" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phA" offset="116" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phB" offset="118" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phC" offset="120" type="float32" len="2" units="varh" />
+      <point id="Evt" offset="122" type="bitfield32" len="2" mandatory="true" >
         <symbol id="M_EVENT_Power_Failure">2</symbol>
         <symbol id="M_EVENT_Under_Voltage">3</symbol>
         <symbol id="M_EVENT_Low_PF">4</symbol>

--- a/smdx/smdx_00211.xml
+++ b/smdx/smdx_00211.xml
@@ -99,427 +99,427 @@
   <strings id="211" locale="en">
     <model>
       <label>single phase (AN or AB) meter</label>
-      <description></description>
+      <description/>
       <notes>Float</notes>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>Total AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphA">
       <label>Amps PhaseA</label>
       <description>Phase A Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphB">
       <label>Amps PhaseB</label>
       <description>Phase B Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhV">
       <label>Voltage LN</label>
       <description>Line to Neutral AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPV">
       <label>Voltage LL</label>
       <description>Line to Line AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz">
       <label>Hz</label>
       <description>Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W">
       <label>Watts</label>
       <description>Total Real Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WphA">
       <label>Watts phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphB">
       <label>Watts phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphC">
       <label>Watts phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAphA">
       <label>VA phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphB">
       <label>VA phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphC">
       <label>VA phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAR">
       <label>VAR</label>
       <description>Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VARphA">
       <label>VAR phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphB">
       <label>VAR phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphC">
       <label>VAR phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PFphA">
       <label>PF phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphB">
       <label>PF phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphC">
       <label>PF phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExp">
       <label>Total Watt-hours Exported</label>
       <description>Total Real Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhExpPhA">
       <label>Total Watt-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhB">
       <label>Total Watt-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhC">
       <label>Total Watt-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImp">
       <label>Total Watt-hours Imported</label>
       <description>Total Real Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhImpPhA">
       <label>Total Watt-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhB">
       <label>Total Watt-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhC">
       <label>Total Watt-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExp">
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhB">
       <label>Total VA-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhC">
       <label>Total VA-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImp">
       <label>Total VA-hours Imported</label>
       <description>Total Apparent Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhImpPhA">
       <label>Total VA-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhB">
       <label>Total VA-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhC">
       <label>Total VA-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1">
       <label>Total VAR-hours Imported Q1</label>
       <description>Total Reactive Energy Imported Quadrant 1</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phA">
       <label>Total VAr-hours Imported Q1 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phB">
       <label>Total VAr-hours Imported Q1 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phC">
       <label>Total VAr-hours Imported Q1 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2">
       <label>Total VAr-hours Imported Q2</label>
       <description>Total Reactive Power Imported Quadrant 2</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phA">
       <label>Total VAr-hours Imported Q2 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phB">
       <label>Total VAr-hours Imported Q2 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phC">
       <label>Total VAr-hours Imported Q2 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3">
       <label>Total VAr-hours Exported Q3</label>
       <description>Total Reactive Power Exported Quadrant 3</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phA">
       <label>Total VAr-hours Exported Q3 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phB">
       <label>Total VAr-hours Exported Q3 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phC">
       <label>Total VAr-hours Exported Q3 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4">
       <label>Total VAr-hours Exported Q4</label>
       <description>Total Reactive Power Exported Quadrant 4</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phA">
       <label>Total VAr-hours Exported Q4 Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phB">
       <label>Total VAr-hours Exported Q4 Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phC">
       <label>Total VAr-hours Exported Q4 Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Events</label>
       <description>Meter Event Flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="Power_Failure">
         <label>Power Failure</label>
         <description>Loss of power or phase</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Under_Voltage">
         <label>Under Voltage</label>
         <description>Voltage below threshold (Phase Loss)</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Low_PF">
         <label>Low PF</label>
         <description>Power Factor below threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Current">
         <label>Over Current</label>
         <description>Current Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Voltage">
         <label>Over Voltage</label>
         <description>Voltage Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Missing_Sensor">
         <label>Missing Sensor</label>
         <description>Sensor not connected</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM01">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM02">
         <label>OEM02</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM03">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM04">
         <label>OEM04</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM05">
         <label>OEM05</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM06">
         <label>OEM06</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM07">
         <label>OEM07</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM08">
         <label>OEM08</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM09">
         <label>OEM09</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM10">
         <label>OEM10</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM11">
         <label>OEM11</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM12">
         <label>OEM12</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM13">
         <label>OEM13</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM14">
         <label>OEM14</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM15">
         <label>OEM15</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM16">
         <label>OEM16</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00212.xml
+++ b/smdx/smdx_00212.xml
@@ -1,69 +1,69 @@
 <sunSpecModels v="1">
   <!-- 212: ac_meter_f -->
   <model id="212" len="124" name="ac_meter">
-    <block len="124">
-      <point id="A" offset="0" type="float32" units="A" mandatory="true" />
-      <point id="AphA" offset="2" type="float32" units="A" mandatory="true" />
-      <point id="AphB" offset="4" type="float32" units="A" mandatory="true" />
-      <point id="AphC" offset="6" type="float32" units="A" />
-      <point id="PhV" offset="8" type="float32" units="V" mandatory="true" />
-      <point id="PhVphA" offset="10" type="float32" units="V" mandatory="true" />
-      <point id="PhVphB" offset="12" type="float32" units="V" mandatory="true" />
-      <point id="PhVphC" offset="14" type="float32" units="V" />
-      <point id="PPV" offset="16" type="float32" units="V" mandatory="true" />
-      <point id="PPVphAB" offset="18" type="float32" units="V" mandatory="true" />
-      <point id="PPVphBC" offset="20" type="float32" units="V" />
-      <point id="PPVphCA" offset="22" type="float32" units="V" />
-      <point id="Hz" offset="24" type="float32" units="Hz" mandatory="true" />
-      <point id="W" offset="26" type="float32" units="W" mandatory="true" />
-      <point id="WphA" offset="28" type="float32" units="W" />
-      <point id="WphB" offset="30" type="float32" units="W" />
-      <point id="WphC" offset="32" type="float32" units="W" />
-      <point id="VA" offset="34" type="float32" units="VA" />
-      <point id="VAphA" offset="36" type="float32" units="VA" />
-      <point id="VAphB" offset="38" type="float32" units="VA" />
-      <point id="VAphC" offset="40" type="float32" units="VA" />
-      <point id="VAR" offset="42" type="float32" units="var" />
-      <point id="VARphA" offset="44" type="float32" units="var" />
-      <point id="VARphB" offset="46" type="float32" units="var" />
-      <point id="VARphC" offset="48" type="float32" units="var" />
-      <point id="PF" offset="50" type="float32" units="PF" />
-      <point id="PFphA" offset="52" type="float32" units="PF" />
-      <point id="PFphB" offset="54" type="float32" units="PF" />
-      <point id="PFphC" offset="56" type="float32" units="PF" />
-      <point id="TotWhExp" offset="58" type="float32" units="Wh" mandatory="true" />
-      <point id="TotWhExpPhA" offset="60" type="float32" units="Wh" />
-      <point id="TotWhExpPhB" offset="62" type="float32" units="Wh" />
-      <point id="TotWhExpPhC" offset="64" type="float32" units="Wh" />
-      <point id="TotWhImp" offset="66" type="float32" units="Wh" mandatory="true" />
-      <point id="TotWhImpPhA" offset="68" type="float32" units="Wh" />
-      <point id="TotWhImpPhB" offset="70" type="float32" units="Wh" />
-      <point id="TotWhImpPhC" offset="72" type="float32" units="Wh" />
-      <point id="TotVAhExp" offset="74" type="float32" units="VAh" />
-      <point id="TotVAhExpPhA" offset="76" type="float32" units="VAh" />
-      <point id="TotVAhExpPhB" offset="78" type="float32" units="VAh" />
-      <point id="TotVAhExpPhC" offset="80" type="float32" units="VAh" />
-      <point id="TotVAhImp" offset="82" type="float32" units="VAh" />
-      <point id="TotVAhImpPhA" offset="84" type="float32" units="VAh" />
-      <point id="TotVAhImpPhB" offset="86" type="float32" units="VAh" />
-      <point id="TotVAhImpPhC" offset="88" type="float32" units="VAh" />
-      <point id="TotVArhImpQ1" offset="90" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phA" offset="92" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phB" offset="94" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phC" offset="96" type="float32" units="varh" />
-      <point id="TotVArhImpQ2" offset="98" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phA" offset="100" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phB" offset="102" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phC" offset="104" type="float32" units="varh" />
-      <point id="TotVArhExpQ3" offset="106" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phA" offset="108" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phB" offset="110" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phC" offset="112" type="float32" units="varh" />
-      <point id="TotVArhExpQ4" offset="114" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phA" offset="116" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phB" offset="118" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phC" offset="120" type="float32" units="varh" />
-      <point id="Evt" offset="122" type="bitfield32" mandatory="true" >
+    <block len="124" type="fixed">
+      <point id="A" offset="0" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphA" offset="2" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphB" offset="4" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphC" offset="6" type="float32" len="2" units="A" />
+      <point id="PhV" offset="8" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PhVphA" offset="10" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PhVphB" offset="12" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PhVphC" offset="14" type="float32" len="2" units="V" />
+      <point id="PPV" offset="16" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PPVphAB" offset="18" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PPVphBC" offset="20" type="float32" len="2" units="V" />
+      <point id="PPVphCA" offset="22" type="float32" len="2" units="V" />
+      <point id="Hz" offset="24" type="float32" len="2" units="Hz" mandatory="true" />
+      <point id="W" offset="26" type="float32" len="2" units="W" mandatory="true" />
+      <point id="WphA" offset="28" type="float32" len="2" units="W" />
+      <point id="WphB" offset="30" type="float32" len="2" units="W" />
+      <point id="WphC" offset="32" type="float32" len="2" units="W" />
+      <point id="VA" offset="34" type="float32" len="2" units="VA" />
+      <point id="VAphA" offset="36" type="float32" len="2" units="VA" />
+      <point id="VAphB" offset="38" type="float32" len="2" units="VA" />
+      <point id="VAphC" offset="40" type="float32" len="2" units="VA" />
+      <point id="VAR" offset="42" type="float32" len="2" units="var" />
+      <point id="VARphA" offset="44" type="float32" len="2" units="var" />
+      <point id="VARphB" offset="46" type="float32" len="2" units="var" />
+      <point id="VARphC" offset="48" type="float32" len="2" units="var" />
+      <point id="PF" offset="50" type="float32" len="2" units="PF" />
+      <point id="PFphA" offset="52" type="float32" len="2" units="PF" />
+      <point id="PFphB" offset="54" type="float32" len="2" units="PF" />
+      <point id="PFphC" offset="56" type="float32" len="2" units="PF" />
+      <point id="TotWhExp" offset="58" type="float32" len="2" units="Wh" mandatory="true" />
+      <point id="TotWhExpPhA" offset="60" type="float32" len="2" units="Wh" />
+      <point id="TotWhExpPhB" offset="62" type="float32" len="2" units="Wh" />
+      <point id="TotWhExpPhC" offset="64" type="float32" len="2" units="Wh" />
+      <point id="TotWhImp" offset="66" type="float32" len="2" units="Wh" mandatory="true" />
+      <point id="TotWhImpPhA" offset="68" type="float32" len="2" units="Wh" />
+      <point id="TotWhImpPhB" offset="70" type="float32" len="2" units="Wh" />
+      <point id="TotWhImpPhC" offset="72" type="float32" len="2" units="Wh" />
+      <point id="TotVAhExp" offset="74" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhA" offset="76" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhB" offset="78" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhC" offset="80" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImp" offset="82" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhA" offset="84" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhB" offset="86" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhC" offset="88" type="float32" len="2" units="VAh" />
+      <point id="TotVArhImpQ1" offset="90" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phA" offset="92" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phB" offset="94" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phC" offset="96" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2" offset="98" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phA" offset="100" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phB" offset="102" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phC" offset="104" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3" offset="106" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phA" offset="108" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phB" offset="110" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phC" offset="112" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4" offset="114" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phA" offset="116" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phB" offset="118" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phC" offset="120" type="float32" len="2" units="varh" />
+      <point id="Evt" offset="122" type="bitfield32" len="2" mandatory="true" >
         <symbol id="M_EVENT_Power_Failure">2</symbol>
         <symbol id="M_EVENT_Under_Voltage">3</symbol>
         <symbol id="M_EVENT_Low_PF">4</symbol>

--- a/smdx/smdx_00212.xml
+++ b/smdx/smdx_00212.xml
@@ -99,427 +99,427 @@
   <strings id="212" locale="en">
     <model>
       <label>split single phase (ABN) meter</label>
-      <description></description>
+      <description/>
       <notes>Float</notes>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>Total AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphA">
       <label>Amps PhaseA</label>
       <description>Phase A Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphB">
       <label>Amps PhaseB</label>
       <description>Phase B Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhV">
       <label>Voltage LN</label>
       <description>Line to Neutral AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPV">
       <label>Voltage LL</label>
       <description>Line to Line AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz">
       <label>Hz</label>
       <description>Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W">
       <label>Watts</label>
       <description>Total Real Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WphA">
       <label>Watts phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphB">
       <label>Watts phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphC">
       <label>Watts phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAphA">
       <label>VA phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphB">
       <label>VA phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphC">
       <label>VA phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAR">
       <label>VAR</label>
       <description>Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VARphA">
       <label>VAR phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphB">
       <label>VAR phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphC">
       <label>VAR phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PFphA">
       <label>PF phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphB">
       <label>PF phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphC">
       <label>PF phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExp">
       <label>Total Watt-hours Exported</label>
       <description>Total Real Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhExpPhA">
       <label>Total Watt-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhB">
       <label>Total Watt-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhC">
       <label>Total Watt-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImp">
       <label>Total Watt-hours Imported</label>
       <description>Total Real Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhImpPhA">
       <label>Total Watt-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhB">
       <label>Total Watt-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhC">
       <label>Total Watt-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExp">
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhB">
       <label>Total VA-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhC">
       <label>Total VA-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImp">
       <label>Total VA-hours Imported</label>
       <description>Total Apparent Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhImpPhA">
       <label>Total VA-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhB">
       <label>Total VA-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhC">
       <label>Total VA-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1">
       <label>Total VAR-hours Imported Q1</label>
       <description>Total Reactive Energy Imported Quadrant 1</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phA">
       <label>Total VAr-hours Imported Q1 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phB">
       <label>Total VAr-hours Imported Q1 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phC">
       <label>Total VAr-hours Imported Q1 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2">
       <label>Total VAr-hours Imported Q2</label>
       <description>Total Reactive Power Imported Quadrant 2</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phA">
       <label>Total VAr-hours Imported Q2 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phB">
       <label>Total VAr-hours Imported Q2 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phC">
       <label>Total VAr-hours Imported Q2 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3">
       <label>Total VAr-hours Exported Q3</label>
       <description>Total Reactive Power Exported Quadrant 3</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phA">
       <label>Total VAr-hours Exported Q3 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phB">
       <label>Total VAr-hours Exported Q3 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phC">
       <label>Total VAr-hours Exported Q3 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4">
       <label>Total VAr-hours Exported Q4</label>
       <description>Total Reactive Power Exported Quadrant 4</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phA">
       <label>Total VAr-hours Exported Q4 Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phB">
       <label>Total VAr-hours Exported Q4 Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phC">
       <label>Total VAr-hours Exported Q4 Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Events</label>
       <description>Meter Event Flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="Power_Failure">
         <label>Power Failure</label>
         <description>Loss of power or phase</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Under_Voltage">
         <label>Under Voltage</label>
         <description>Voltage below threshold (Phase Loss)</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Low_PF">
         <label>Low PF</label>
         <description>Power Factor below threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Current">
         <label>Over Current</label>
         <description>Current Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Voltage">
         <label>Over Voltage</label>
         <description>Voltage Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Missing_Sensor">
         <label>Missing Sensor</label>
         <description>Sensor not connected</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM01">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM02">
         <label>OEM02</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM03">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM04">
         <label>OEM04</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM05">
         <label>OEM05</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM06">
         <label>OEM06</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM07">
         <label>OEM07</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM08">
         <label>OEM08</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM09">
         <label>OEM09</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM10">
         <label>OEM10</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM11">
         <label>OEM11</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM12">
         <label>OEM12</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM13">
         <label>OEM13</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM14">
         <label>OEM14</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM15">
         <label>OEM15</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM16">
         <label>OEM16</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00213.xml
+++ b/smdx/smdx_00213.xml
@@ -99,427 +99,427 @@
   <strings id="213" locale="en">
     <model>
       <label>wye-connect three phase (abcn) meter</label>
-      <description></description>
+      <description/>
       <notes>Float</notes>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>Total AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphA">
       <label>Amps PhaseA</label>
       <description>Phase A Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphB">
       <label>Amps PhaseB</label>
       <description>Phase B Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhV">
       <label>Voltage LN</label>
       <description>Line to Neutral AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPV">
       <label>Voltage LL</label>
       <description>Line to Line AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz">
       <label>Hz</label>
       <description>Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W">
       <label>Watts</label>
       <description>Total Real Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WphA">
       <label>Watts phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphB">
       <label>Watts phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphC">
       <label>Watts phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAphA">
       <label>VA phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphB">
       <label>VA phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphC">
       <label>VA phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAR">
       <label>VAR</label>
       <description>Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VARphA">
       <label>VAR phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphB">
       <label>VAR phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphC">
       <label>VAR phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PFphA">
       <label>PF phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphB">
       <label>PF phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphC">
       <label>PF phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExp">
       <label>Total Watt-hours Exported</label>
       <description>Total Real Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhExpPhA">
       <label>Total Watt-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhB">
       <label>Total Watt-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhC">
       <label>Total Watt-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImp">
       <label>Total Watt-hours Imported</label>
       <description>Total Real Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhImpPhA">
       <label>Total Watt-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhB">
       <label>Total Watt-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhC">
       <label>Total Watt-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExp">
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhB">
       <label>Total VA-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhC">
       <label>Total VA-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImp">
       <label>Total VA-hours Imported</label>
       <description>Total Apparent Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhImpPhA">
       <label>Total VA-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhB">
       <label>Total VA-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhC">
       <label>Total VA-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1">
       <label>Total VAR-hours Imported Q1</label>
       <description>Total Reactive Energy Imported Quadrant 1</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phA">
       <label>Total VAr-hours Imported Q1 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phB">
       <label>Total VAr-hours Imported Q1 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phC">
       <label>Total VAr-hours Imported Q1 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2">
       <label>Total VAr-hours Imported Q2</label>
       <description>Total Reactive Power Imported Quadrant 2</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phA">
       <label>Total VAr-hours Imported Q2 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phB">
       <label>Total VAr-hours Imported Q2 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phC">
       <label>Total VAr-hours Imported Q2 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3">
       <label>Total VAr-hours Exported Q3</label>
       <description>Total Reactive Power Exported Quadrant 3</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phA">
       <label>Total VAr-hours Exported Q3 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phB">
       <label>Total VAr-hours Exported Q3 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phC">
       <label>Total VAr-hours Exported Q3 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4">
       <label>Total VAr-hours Exported Q4</label>
       <description>Total Reactive Power Exported Quadrant 4</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phA">
       <label>Total VAr-hours Exported Q4 Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phB">
       <label>Total VAr-hours Exported Q4 Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phC">
       <label>Total VAr-hours Exported Q4 Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Events</label>
       <description>Meter Event Flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="Power_Failure">
         <label>Power Failure</label>
         <description>Loss of power or phase</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Under_Voltage">
         <label>Under Voltage</label>
         <description>Voltage below threshold (Phase Loss)</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Low_PF">
         <label>Low PF</label>
         <description>Power Factor below threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Current">
         <label>Over Current</label>
         <description>Current Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Voltage">
         <label>Over Voltage</label>
         <description>Voltage Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Missing_Sensor">
         <label>Missing Sensor</label>
         <description>Sensor not connected</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM01">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM02">
         <label>OEM02</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM03">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM04">
         <label>OEM04</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM05">
         <label>OEM05</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM06">
         <label>OEM06</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM07">
         <label>OEM07</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM08">
         <label>OEM08</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM09">
         <label>OEM09</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM10">
         <label>OEM10</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM11">
         <label>OEM11</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM12">
         <label>OEM12</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM13">
         <label>OEM13</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM14">
         <label>OEM14</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM15">
         <label>OEM15</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM16">
         <label>OEM16</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00213.xml
+++ b/smdx/smdx_00213.xml
@@ -1,69 +1,69 @@
 <sunSpecModels v="1">
   <!-- 213: ac_meter_f -->
   <model id="213" len="124" name="ac_meter">
-    <block len="124">
-      <point id="A" offset="0" type="float32" units="A" mandatory="true" />
-      <point id="AphA" offset="2" type="float32" units="A" mandatory="true" />
-      <point id="AphB" offset="4" type="float32" units="A" mandatory="true" />
-      <point id="AphC" offset="6" type="float32" units="A" mandatory="true" />
-      <point id="PhV" offset="8" type="float32" units="V" mandatory="true" />
-      <point id="PhVphA" offset="10" type="float32" units="V" mandatory="true" />
-      <point id="PhVphB" offset="12" type="float32" units="V" mandatory="true" />
-      <point id="PhVphC" offset="14" type="float32" units="V" mandatory="true" />
-      <point id="PPV" offset="16" type="float32" units="V" mandatory="true" />
-      <point id="PPVphAB" offset="18" type="float32" units="V" mandatory="true" />
-      <point id="PPVphBC" offset="20" type="float32" units="V" mandatory="true" />
-      <point id="PPVphCA" offset="22" type="float32" units="V" mandatory="true" />
-      <point id="Hz" offset="24" type="float32" units="Hz" mandatory="true" />
-      <point id="W" offset="26" type="float32" units="W" mandatory="true" />
-      <point id="WphA" offset="28" type="float32" units="W" />
-      <point id="WphB" offset="30" type="float32" units="W" />
-      <point id="WphC" offset="32" type="float32" units="W" />
-      <point id="VA" offset="34" type="float32" units="VA" />
-      <point id="VAphA" offset="36" type="float32" units="VA" />
-      <point id="VAphB" offset="38" type="float32" units="VA" />
-      <point id="VAphC" offset="40" type="float32" units="VA" />
-      <point id="VAR" offset="42" type="float32" units="var" />
-      <point id="VARphA" offset="44" type="float32" units="var" />
-      <point id="VARphB" offset="46" type="float32" units="var" />
-      <point id="VARphC" offset="48" type="float32" units="var" />
-      <point id="PF" offset="50" type="float32" units="PF" />
-      <point id="PFphA" offset="52" type="float32" units="PF" />
-      <point id="PFphB" offset="54" type="float32" units="PF" />
-      <point id="PFphC" offset="56" type="float32" units="PF" />
-      <point id="TotWhExp" offset="58" type="float32" units="Wh" mandatory="true" />
-      <point id="TotWhExpPhA" offset="60" type="float32" units="Wh" />
-      <point id="TotWhExpPhB" offset="62" type="float32" units="Wh" />
-      <point id="TotWhExpPhC" offset="64" type="float32" units="Wh" />
-      <point id="TotWhImp" offset="66" type="float32" units="Wh" mandatory="true" />
-      <point id="TotWhImpPhA" offset="68" type="float32" units="Wh" />
-      <point id="TotWhImpPhB" offset="70" type="float32" units="Wh" />
-      <point id="TotWhImpPhC" offset="72" type="float32" units="Wh" />
-      <point id="TotVAhExp" offset="74" type="float32" units="VAh" />
-      <point id="TotVAhExpPhA" offset="76" type="float32" units="VAh" />
-      <point id="TotVAhExpPhB" offset="78" type="float32" units="VAh" />
-      <point id="TotVAhExpPhC" offset="80" type="float32" units="VAh" />
-      <point id="TotVAhImp" offset="82" type="float32" units="VAh" />
-      <point id="TotVAhImpPhA" offset="84" type="float32" units="VAh" />
-      <point id="TotVAhImpPhB" offset="86" type="float32" units="VAh" />
-      <point id="TotVAhImpPhC" offset="88" type="float32" units="VAh" />
-      <point id="TotVArhImpQ1" offset="90" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phA" offset="92" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phB" offset="94" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phC" offset="96" type="float32" units="varh" />
-      <point id="TotVArhImpQ2" offset="98" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phA" offset="100" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phB" offset="102" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phC" offset="104" type="float32" units="varh" />
-      <point id="TotVArhExpQ3" offset="106" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phA" offset="108" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phB" offset="110" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phC" offset="112" type="float32" units="varh" />
-      <point id="TotVArhExpQ4" offset="114" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phA" offset="116" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phB" offset="118" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phC" offset="120" type="float32" units="varh" />
-      <point id="Evt" offset="122" type="bitfield32" mandatory="true" >
+    <block len="124" type="fixed">
+      <point id="A" offset="0" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphA" offset="2" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphB" offset="4" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphC" offset="6" type="float32" len="2" units="A" mandatory="true" />
+      <point id="PhV" offset="8" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PhVphA" offset="10" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PhVphB" offset="12" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PhVphC" offset="14" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PPV" offset="16" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PPVphAB" offset="18" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PPVphBC" offset="20" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PPVphCA" offset="22" type="float32" len="2" units="V" mandatory="true" />
+      <point id="Hz" offset="24" type="float32" len="2" units="Hz" mandatory="true" />
+      <point id="W" offset="26" type="float32" len="2" units="W" mandatory="true" />
+      <point id="WphA" offset="28" type="float32" len="2" units="W" />
+      <point id="WphB" offset="30" type="float32" len="2" units="W" />
+      <point id="WphC" offset="32" type="float32" len="2" units="W" />
+      <point id="VA" offset="34" type="float32" len="2" units="VA" />
+      <point id="VAphA" offset="36" type="float32" len="2" units="VA" />
+      <point id="VAphB" offset="38" type="float32" len="2" units="VA" />
+      <point id="VAphC" offset="40" type="float32" len="2" units="VA" />
+      <point id="VAR" offset="42" type="float32" len="2" units="var" />
+      <point id="VARphA" offset="44" type="float32" len="2" units="var" />
+      <point id="VARphB" offset="46" type="float32" len="2" units="var" />
+      <point id="VARphC" offset="48" type="float32" len="2" units="var" />
+      <point id="PF" offset="50" type="float32" len="2" units="PF" />
+      <point id="PFphA" offset="52" type="float32" len="2" units="PF" />
+      <point id="PFphB" offset="54" type="float32" len="2" units="PF" />
+      <point id="PFphC" offset="56" type="float32" len="2" units="PF" />
+      <point id="TotWhExp" offset="58" type="float32" len="2" units="Wh" mandatory="true" />
+      <point id="TotWhExpPhA" offset="60" type="float32" len="2" units="Wh" />
+      <point id="TotWhExpPhB" offset="62" type="float32" len="2" units="Wh" />
+      <point id="TotWhExpPhC" offset="64" type="float32" len="2" units="Wh" />
+      <point id="TotWhImp" offset="66" type="float32" len="2" units="Wh" mandatory="true" />
+      <point id="TotWhImpPhA" offset="68" type="float32" len="2" units="Wh" />
+      <point id="TotWhImpPhB" offset="70" type="float32" len="2" units="Wh" />
+      <point id="TotWhImpPhC" offset="72" type="float32" len="2" units="Wh" />
+      <point id="TotVAhExp" offset="74" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhA" offset="76" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhB" offset="78" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhC" offset="80" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImp" offset="82" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhA" offset="84" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhB" offset="86" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhC" offset="88" type="float32" len="2" units="VAh" />
+      <point id="TotVArhImpQ1" offset="90" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phA" offset="92" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phB" offset="94" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phC" offset="96" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2" offset="98" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phA" offset="100" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phB" offset="102" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phC" offset="104" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3" offset="106" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phA" offset="108" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phB" offset="110" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phC" offset="112" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4" offset="114" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phA" offset="116" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phB" offset="118" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phC" offset="120" type="float32" len="2" units="varh" />
+      <point id="Evt" offset="122" type="bitfield32" len="2" mandatory="true" >
         <symbol id="M_EVENT_Power_Failure">2</symbol>
         <symbol id="M_EVENT_Under_Voltage">3</symbol>
         <symbol id="M_EVENT_Low_PF">4</symbol>

--- a/smdx/smdx_00214.xml
+++ b/smdx/smdx_00214.xml
@@ -1,69 +1,69 @@
 <sunSpecModels v="1">
   <!-- 214: ac_meter_f -->
   <model id="214" len="124" name="ac_meter">
-    <block len="124">
-      <point id="A" offset="0" type="float32" units="A" mandatory="true" />
-      <point id="AphA" offset="2" type="float32" units="A" mandatory="true" />
-      <point id="AphB" offset="4" type="float32" units="A" mandatory="true" />
-      <point id="AphC" offset="6" type="float32" units="A" mandatory="true" />
-      <point id="PhV" offset="8" type="float32" units="V" />
-      <point id="PhVphA" offset="10" type="float32" units="V" />
-      <point id="PhVphB" offset="12" type="float32" units="V" />
-      <point id="PhVphC" offset="14" type="float32" units="V" />
-      <point id="PPV" offset="16" type="float32" units="V" mandatory="true" />
-      <point id="PPVphAB" offset="18" type="float32" units="V" mandatory="true" />
-      <point id="PPVphBC" offset="20" type="float32" units="V" mandatory="true" />
-      <point id="PPVphCA" offset="22" type="float32" units="V" mandatory="true" />
-      <point id="Hz" offset="24" type="float32" units="Hz" mandatory="true" />
-      <point id="W" offset="26" type="float32" units="W" mandatory="true" />
-      <point id="WphA" offset="28" type="float32" units="W" />
-      <point id="WphB" offset="30" type="float32" units="W" />
-      <point id="WphC" offset="32" type="float32" units="W" />
-      <point id="VA" offset="34" type="float32" units="VA" />
-      <point id="VAphA" offset="36" type="float32" units="VA" />
-      <point id="VAphB" offset="38" type="float32" units="VA" />
-      <point id="VAphC" offset="40" type="float32" units="VA" />
-      <point id="VAR" offset="42" type="float32" units="var" />
-      <point id="VARphA" offset="44" type="float32" units="var" />
-      <point id="VARphB" offset="46" type="float32" units="var" />
-      <point id="VARphC" offset="48" type="float32" units="var" />
-      <point id="PF" offset="50" type="float32" units="PF" />
-      <point id="PFphA" offset="52" type="float32" units="PF" />
-      <point id="PFphB" offset="54" type="float32" units="PF" />
-      <point id="PFphC" offset="56" type="float32" units="PF" />
-      <point id="TotWhExp" offset="58" type="float32" units="Wh" mandatory="true" />
-      <point id="TotWhExpPhA" offset="60" type="float32" units="Wh" />
-      <point id="TotWhExpPhB" offset="62" type="float32" units="Wh" />
-      <point id="TotWhExpPhC" offset="64" type="float32" units="Wh" />
-      <point id="TotWhImp" offset="66" type="float32" units="Wh" mandatory="true" />
-      <point id="TotWhImpPhA" offset="68" type="float32" units="Wh" />
-      <point id="TotWhImpPhB" offset="70" type="float32" units="Wh" />
-      <point id="TotWhImpPhC" offset="72" type="float32" units="Wh" />
-      <point id="TotVAhExp" offset="74" type="float32" units="VAh" />
-      <point id="TotVAhExpPhA" offset="76" type="float32" units="VAh" />
-      <point id="TotVAhExpPhB" offset="78" type="float32" units="VAh" />
-      <point id="TotVAhExpPhC" offset="80" type="float32" units="VAh" />
-      <point id="TotVAhImp" offset="82" type="float32" units="VAh" />
-      <point id="TotVAhImpPhA" offset="84" type="float32" units="VAh" />
-      <point id="TotVAhImpPhB" offset="86" type="float32" units="VAh" />
-      <point id="TotVAhImpPhC" offset="88" type="float32" units="VAh" />
-      <point id="TotVArhImpQ1" offset="90" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phA" offset="92" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phB" offset="94" type="float32" units="varh" />
-      <point id="TotVArhImpQ1phC" offset="96" type="float32" units="varh" />
-      <point id="TotVArhImpQ2" offset="98" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phA" offset="100" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phB" offset="102" type="float32" units="varh" />
-      <point id="TotVArhImpQ2phC" offset="104" type="float32" units="varh" />
-      <point id="TotVArhExpQ3" offset="106" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phA" offset="108" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phB" offset="110" type="float32" units="varh" />
-      <point id="TotVArhExpQ3phC" offset="112" type="float32" units="varh" />
-      <point id="TotVArhExpQ4" offset="114" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phA" offset="116" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phB" offset="118" type="float32" units="varh" />
-      <point id="TotVArhExpQ4phC" offset="120" type="float32" units="varh" />
-      <point id="Evt" offset="122" type="bitfield32" mandatory="true" >
+    <block len="124" type="fixed">
+      <point id="A" offset="0" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphA" offset="2" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphB" offset="4" type="float32" len="2" units="A" mandatory="true" />
+      <point id="AphC" offset="6" type="float32" len="2" units="A" mandatory="true" />
+      <point id="PhV" offset="8" type="float32" len="2" units="V" />
+      <point id="PhVphA" offset="10" type="float32" len="2" units="V" />
+      <point id="PhVphB" offset="12" type="float32" len="2" units="V" />
+      <point id="PhVphC" offset="14" type="float32" len="2" units="V" />
+      <point id="PPV" offset="16" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PPVphAB" offset="18" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PPVphBC" offset="20" type="float32" len="2" units="V" mandatory="true" />
+      <point id="PPVphCA" offset="22" type="float32" len="2" units="V" mandatory="true" />
+      <point id="Hz" offset="24" type="float32" len="2" units="Hz" mandatory="true" />
+      <point id="W" offset="26" type="float32" len="2" units="W" mandatory="true" />
+      <point id="WphA" offset="28" type="float32" len="2" units="W" />
+      <point id="WphB" offset="30" type="float32" len="2" units="W" />
+      <point id="WphC" offset="32" type="float32" len="2" units="W" />
+      <point id="VA" offset="34" type="float32" len="2" units="VA" />
+      <point id="VAphA" offset="36" type="float32" len="2" units="VA" />
+      <point id="VAphB" offset="38" type="float32" len="2" units="VA" />
+      <point id="VAphC" offset="40" type="float32" len="2" units="VA" />
+      <point id="VAR" offset="42" type="float32" len="2" units="var" />
+      <point id="VARphA" offset="44" type="float32" len="2" units="var" />
+      <point id="VARphB" offset="46" type="float32" len="2" units="var" />
+      <point id="VARphC" offset="48" type="float32" len="2" units="var" />
+      <point id="PF" offset="50" type="float32" len="2" units="PF" />
+      <point id="PFphA" offset="52" type="float32" len="2" units="PF" />
+      <point id="PFphB" offset="54" type="float32" len="2" units="PF" />
+      <point id="PFphC" offset="56" type="float32" len="2" units="PF" />
+      <point id="TotWhExp" offset="58" type="float32" len="2" units="Wh" mandatory="true" />
+      <point id="TotWhExpPhA" offset="60" type="float32" len="2" units="Wh" />
+      <point id="TotWhExpPhB" offset="62" type="float32" len="2" units="Wh" />
+      <point id="TotWhExpPhC" offset="64" type="float32" len="2" units="Wh" />
+      <point id="TotWhImp" offset="66" type="float32" len="2" units="Wh" mandatory="true" />
+      <point id="TotWhImpPhA" offset="68" type="float32" len="2" units="Wh" />
+      <point id="TotWhImpPhB" offset="70" type="float32" len="2" units="Wh" />
+      <point id="TotWhImpPhC" offset="72" type="float32" len="2" units="Wh" />
+      <point id="TotVAhExp" offset="74" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhA" offset="76" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhB" offset="78" type="float32" len="2" units="VAh" />
+      <point id="TotVAhExpPhC" offset="80" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImp" offset="82" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhA" offset="84" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhB" offset="86" type="float32" len="2" units="VAh" />
+      <point id="TotVAhImpPhC" offset="88" type="float32" len="2" units="VAh" />
+      <point id="TotVArhImpQ1" offset="90" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phA" offset="92" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phB" offset="94" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ1phC" offset="96" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2" offset="98" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phA" offset="100" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phB" offset="102" type="float32" len="2" units="varh" />
+      <point id="TotVArhImpQ2phC" offset="104" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3" offset="106" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phA" offset="108" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phB" offset="110" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ3phC" offset="112" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4" offset="114" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phA" offset="116" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phB" offset="118" type="float32" len="2" units="varh" />
+      <point id="TotVArhExpQ4phC" offset="120" type="float32" len="2" units="varh" />
+      <point id="Evt" offset="122" type="bitfield32" len="2" mandatory="true" >
         <symbol id="M_EVENT_Power_Failure">2</symbol>
         <symbol id="M_EVENT_Under_Voltage">3</symbol>
         <symbol id="M_EVENT_Low_PF">4</symbol>

--- a/smdx/smdx_00214.xml
+++ b/smdx/smdx_00214.xml
@@ -99,427 +99,427 @@
   <strings id="214" locale="en">
     <model>
       <label>delta-connect three phase (abc) meter</label>
-      <description></description>
+      <description/>
       <notes>Float</notes>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>Total AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphA">
       <label>Amps PhaseA</label>
       <description>Phase A Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphB">
       <label>Amps PhaseB</label>
       <description>Phase B Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AphC">
       <label>Amps PhaseC</label>
       <description>Phase C Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhV">
       <label>Voltage LN</label>
       <description>Line to Neutral AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphAB">
       <label>Phase Voltage AB</label>
       <description>Phase Voltage AB</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphBC">
       <label>Phase Voltage BC</label>
       <description>Phase Voltage BC</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPVphCA">
       <label>Phase Voltage CA</label>
       <description>Phase Voltage CA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PPV">
       <label>Voltage LL</label>
       <description>Line to Line AC Voltage (average of active phases)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphA">
       <label>Phase Voltage AN</label>
       <description>Phase Voltage AN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphB">
       <label>Phase Voltage BN</label>
       <description>Phase Voltage BN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PhVphC">
       <label>Phase Voltage CN</label>
       <description>Phase Voltage CN</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz">
       <label>Hz</label>
       <description>Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W">
       <label>Watts</label>
       <description>Total Real Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WphA">
       <label>Watts phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphB">
       <label>Watts phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WphC">
       <label>Watts phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAphA">
       <label>VA phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphB">
       <label>VA phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAphC">
       <label>VA phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VAR">
       <label>VAR</label>
       <description>Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VARphA">
       <label>VAR phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphB">
       <label>VAR phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VARphC">
       <label>VAR phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PF">
       <label>PF</label>
       <description>Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PFphA">
       <label>PF phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphB">
       <label>PF phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PFphC">
       <label>PF phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExp">
       <label>Total Watt-hours Exported</label>
       <description>Total Real Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhExpPhA">
       <label>Total Watt-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhB">
       <label>Total Watt-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhExpPhC">
       <label>Total Watt-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImp">
       <label>Total Watt-hours Imported</label>
       <description>Total Real Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWhImpPhA">
       <label>Total Watt-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhB">
       <label>Total Watt-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotWhImpPhC">
       <label>Total Watt-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExp">
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhExpPhA">
       <label>Total VA-hours Exported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhB">
       <label>Total VA-hours Exported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhExpPhC">
       <label>Total VA-hours Exported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImp">
       <label>Total VA-hours Imported</label>
       <description>Total Apparent Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhImpPhA">
       <label>Total VA-hours Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhB">
       <label>Total VA-hours Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVAhImpPhC">
       <label>Total VA-hours Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1">
       <label>Total VAR-hours Imported Q1</label>
       <description>Total Reactive Energy Imported Quadrant 1</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phA">
       <label>Total VAr-hours Imported Q1 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phB">
       <label>Total VAr-hours Imported Q1 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ1phC">
       <label>Total VAr-hours Imported Q1 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2">
       <label>Total VAr-hours Imported Q2</label>
       <description>Total Reactive Power Imported Quadrant 2</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phA">
       <label>Total VAr-hours Imported Q2 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phB">
       <label>Total VAr-hours Imported Q2 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2phC">
       <label>Total VAr-hours Imported Q2 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3">
       <label>Total VAr-hours Exported Q3</label>
       <description>Total Reactive Power Exported Quadrant 3</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phA">
       <label>Total VAr-hours Exported Q3 phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phB">
       <label>Total VAr-hours Exported Q3 phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3phC">
       <label>Total VAr-hours Exported Q3 phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4">
       <label>Total VAr-hours Exported Q4</label>
       <description>Total Reactive Power Exported Quadrant 4</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phA">
       <label>Total VAr-hours Exported Q4 Imported phase A</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phB">
       <label>Total VAr-hours Exported Q4 Imported phase B</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4phC">
       <label>Total VAr-hours Exported Q4 Imported phase C</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Events</label>
       <description>Meter Event Flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="Power_Failure">
         <label>Power Failure</label>
         <description>Loss of power or phase</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Under_Voltage">
         <label>Under Voltage</label>
         <description>Voltage below threshold (Phase Loss)</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Low_PF">
         <label>Low PF</label>
         <description>Power Factor below threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Current">
         <label>Over Current</label>
         <description>Current Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Voltage">
         <label>Over Voltage</label>
         <description>Voltage Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Missing_Sensor">
         <label>Missing Sensor</label>
         <description>Sensor not connected</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM01">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM02">
         <label>OEM02</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM03">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM04">
         <label>OEM04</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM05">
         <label>OEM05</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM06">
         <label>OEM06</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM07">
         <label>OEM07</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM08">
         <label>OEM08</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM09">
         <label>OEM09</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM10">
         <label>OEM10</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM11">
         <label>OEM11</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM12">
         <label>OEM12</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM13">
         <label>OEM13</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM14">
         <label>OEM14</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM15">
         <label>OEM15</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM16">
         <label>OEM16</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
   </strings>

--- a/smdx/smdx_00220.xml
+++ b/smdx/smdx_00220.xml
@@ -1,33 +1,33 @@
 <sunSpecModels v="1">
   <!-- 220: secure ac_meter -->
   <model id="220" len="43" name="ac_meter">
-    <block len="42">
-      <point id="A" offset="0" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="A_SF" offset="1" type="sunssf" mandatory="true"/>
-      <point id="PhV" offset="2" type="int16" sf="V_SF" units="V" mandatory="false" />
-      <point id="V_SF" offset="3" type="sunssf" mandatory="true" />
-      <point id="Hz" offset="4" type="int16" sf="Hz_SF" units="Hz" mandatory="true" />
-      <point id="Hz_SF" offset="5" type="sunssf" />
-      <point id="W" offset="6" type="int16" sf="W_SF" units="W" mandatory="true" />
-      <point id="W_SF" offset="7" type="sunssf" mandatory="true" />
-      <point id="VA" offset="8" type="int16" sf="VA_SF" units="VA" />
-      <point id="VA_SF" offset="9" type="sunssf" />
-      <point id="VAR" offset="10" type="int16" sf="VAR_SF" units="var" />
-      <point id="VAR_SF" offset="11" type="sunssf" />
-      <point id="PF" offset="12" type="int16" sf="PF_SF" units="Pct" />
-      <point id="PF_SF" offset="13" type="sunssf" />
-      <point id="TotWhExp" offset="14" type="acc32" sf="TotWh_SF" units="Wh" mandatory="true" />
-      <point id="TotWhImp" offset="16" type="acc32" sf="TotWh_SF" units="Wh" mandatory="true" />
-      <point id="TotWh_SF" offset="18" type="sunssf" mandatory="true" />
-      <point id="TotVAhExp" offset="19" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAhImp" offset="21" type="acc32" sf="TotVAh_SF" units="VAh" />
-      <point id="TotVAh_SF" offset="23" type="sunssf" />
-      <point id="TotVArhImpQ1" offset="24" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhImpQ2" offset="26" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ3" offset="28" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArhExpQ4" offset="30" type="acc32" sf="TotVArh_SF" units="varh" />
-      <point id="TotVArh_SF" offset="32" type="sunssf" />
-      <point id="Evt" offset="33" type="bitfield32" mandatory="true" >
+    <block len="42" type="fixed">
+      <point id="A" offset="0" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="A_SF" offset="1" type="sunssf" len="1" mandatory="true" />
+      <point id="PhV" offset="2" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="V_SF" offset="3" type="sunssf" len="1" mandatory="true" />
+      <point id="Hz" offset="4" type="int16" len="1" sf="Hz_SF" units="Hz" mandatory="true" />
+      <point id="Hz_SF" offset="5" type="sunssf" len="1" />
+      <point id="W" offset="6" type="int16" len="1" sf="W_SF" units="W" mandatory="true" />
+      <point id="W_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="VA" offset="8" type="int16" len="1" sf="VA_SF" units="VA" />
+      <point id="VA_SF" offset="9" type="sunssf" len="1" />
+      <point id="VAR" offset="10" type="int16" len="1" sf="VAR_SF" units="var" />
+      <point id="VAR_SF" offset="11" type="sunssf" len="1" />
+      <point id="PF" offset="12" type="int16" len="1" sf="PF_SF" units="Pct" />
+      <point id="PF_SF" offset="13" type="sunssf" len="1" />
+      <point id="TotWhExp" offset="14" type="acc32" len="2" sf="TotWh_SF" units="Wh" mandatory="true" />
+      <point id="TotWhImp" offset="16" type="acc32" len="2" sf="TotWh_SF" units="Wh" mandatory="true" />
+      <point id="TotWh_SF" offset="18" type="sunssf" len="1" mandatory="true" />
+      <point id="TotVAhExp" offset="19" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAhImp" offset="21" type="acc32" len="2" sf="TotVAh_SF" units="VAh" />
+      <point id="TotVAh_SF" offset="23" type="sunssf" len="1" />
+      <point id="TotVArhImpQ1" offset="24" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhImpQ2" offset="26" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ3" offset="28" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArhExpQ4" offset="30" type="acc32" len="2" sf="TotVArh_SF" units="varh" />
+      <point id="TotVArh_SF" offset="32" type="sunssf" len="1" />
+      <point id="Evt" offset="33" type="bitfield32" len="2" mandatory="true" >
         <symbol id="Power_Failure">2</symbol>
         <symbol id="Under_Voltage">3</symbol>
         <symbol id="Low_PF">4</symbol>
@@ -50,19 +50,19 @@
         <symbol id="OEM14">29</symbol>
         <symbol id="OEM15">30</symbol>
       </point>
-      <point id="Rsrvd"   offset="35" type="pad" access="r" mandatory="true" />
-      <point id="Ts"   offset="36" type="uint32" access="r" mandatory="true" />
-      <point id="Ms" offset="38" type="uint16" access="r" mandatory="true" />
-      <point id="Seq" offset="39" type="uint16" access="r" mandatory="true" />
-      <point id="Alg"   offset="40" type="enum16" access="r" mandatory="true">
+      <point id="Rsrvd" offset="35" type="pad" len="1" mandatory="true" />
+      <point id="Ts" offset="36" type="uint32" len="2" mandatory="true" />
+      <point id="Ms" offset="38" type="uint16" len="1" mandatory="true" />
+      <point id="Seq" offset="39" type="uint16" len="1" mandatory="true" />
+      <point id="Alg" offset="40" type="enum16" len="1" mandatory="true" >
         <symbol id="NONE">0</symbol>
         <symbol id="AES-GMAC-64">1</symbol>
         <symbol id="ECC-256">2</symbol>
       </point>
-      <point id="N" offset="41" type="uint16" access="r" mandatory="true" />
+      <point id="N" offset="41" type="uint16" len="1" mandatory="true" />
     </block>
-    <block type="repeating" len="1">
-      <point id="DS" offset="0" type="uint16" access="r" mandatory="true" />
+    <block len="1" type="repeating">
+      <point id="DS" offset="0" type="uint16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="220" locale="en">

--- a/smdx/smdx_00220.xml
+++ b/smdx/smdx_00220.xml
@@ -69,12 +69,12 @@
     <model>
       <label>Secure AC Meter Selected Readings</label>
       <description>Include this model for secure metering</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="A">
       <label>Amps</label>
       <description>Total AC Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="A_SF"><description>Current scale factor</description></point>
     <point id="PhV">
@@ -85,200 +85,200 @@
     <point id="Hz">
       <label>Hz</label>
       <description>Frequency</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Hz_SF"><description>Frequency scale factor</description></point>
     <point id="W">
       <label>Watts</label>
       <description>Total Real Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W_SF"><description>Real Power scale factor</description></point>
     <point id="VA">
       <label>VA</label>
       <description>AC Apparent Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VA_SF"><description>Apparent Power scale factor</description></point>
     <point id="VAR">
       <label>VAR</label>
       <description>Reactive Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="VAR_SF"><description>Reactive Power scale factor</description></point>
     <point id="PF">
       <label>PF</label>
       <description>Power Factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="PF_SF"><description>Power Factor scale factor</description></point>
     <point id="TotWhExp">
       <label>Total Watt-hours Exported</label>
       <description>Total Real Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotWh_SF"><description>Real Energy scale factor</description></point>
     <point id="TotWhImp">
       <label>Total Watt-hours Imported</label>
       <description>Total Real Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAhExp">
       <label>Total VA-hours Exported</label>
       <description>Total Apparent Energy Exported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVAh_SF"><description>Apparent Energy scale factor</description></point>
     <point id="TotVAhImp">
       <label>Total VA-hours Imported</label>
       <description>Total Apparent Energy Imported</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArh_SF"><description>Reactive Energy scale factor</description></point>
     <point id="TotVArhImpQ1">
       <label>Total VAR-hours Imported Q1</label>
       <description>Total Reactive Energy Imported Quadrant 1</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhImpQ2">
       <label>Total VAr-hours Imported Q2</label>
       <description>Total Reactive Power Imported Quadrant 2</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ3">
       <label>Total VAr-hours Exported Q3</label>
       <description>Total Reactive Power Exported Quadrant 3</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TotVArhExpQ4">
       <label>Total VAr-hours Exported Q4</label>
       <description>Total Reactive Power Exported Quadrant 4</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Events</label>
       <description>Meter Event Flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="Power_Failure">
         <label>Power Failure</label>
         <description>Loss of power or phase</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Under_Voltage">
         <label>Under Voltage</label>
         <description>Voltage below threshold (Phase Loss)</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Low_PF">
         <label>Low PF</label>
         <description>Power Factor below threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Current">
         <label>Over Current</label>
         <description>Current Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Over_Voltage">
         <label>Over Voltage</label>
         <description>Voltage Input over threshold</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="Missing_Sensor">
         <label>Missing Sensor</label>
         <description>Sensor not connected</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM01">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM02">
         <label>OEM02</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM03">
         <label>OEM01</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM04">
         <label>OEM04</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM05">
         <label>OEM05</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM06">
         <label>OEM06</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM07">
         <label>OEM07</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM08">
         <label>OEM08</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM09">
         <label>OEM09</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM10">
         <label>OEM10</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM11">
         <label>OEM11</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM12">
         <label>OEM12</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM13">
         <label>OEM13</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM14">
         <label>OEM14</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM15">
         <label>OEM15</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OEM16">
         <label>OEM16</label>
         <description>Reserved for OEM use</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Ts">
       <label>Timestamp</label>
       <description>Timestamp value is the number of seconds since January 1, 2000</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ms">
       <label>Milliseconds</label>
       <description>Millisecond counter 0-999</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Alg">
       <label>Algorithm</label>
@@ -292,12 +292,12 @@
       <symbol id="AES-GMAC-64">
         <label>AES-GMAC-64</label>
         <description>64 bit AES signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ECC-256">
         <label>ECC-256</label>
         <description>256 bit ECC signature algorithm is used</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="N">

--- a/smdx/smdx_00302.xml
+++ b/smdx/smdx_00302.xml
@@ -2,11 +2,11 @@
   <!-- 302: Irradiance Model -->
   <model id="302" len="5" name="irradiance">
     <block len="5" type="repeating">
-      <point id="GHI" offset="0" type="uint16" units="W/m2" mandatory="false"/>
-      <point id="POAI" offset="1" type="uint16" units="W/m2" mandatory="false"/>
-      <point id="DFI" offset="2" type="uint16" units="W/m2" mandatory="false"/>
-      <point id="DNI" offset="3" type="uint16" units="W/m2" mandatory="false"/>
-      <point id="OTI" offset="4" type="uint16" units="W/m2" mandatory="false"/>
+      <point id="GHI" offset="0" type="uint16" len="1" units="W/m2" />
+      <point id="POAI" offset="1" type="uint16" len="1" units="W/m2" />
+      <point id="DFI" offset="2" type="uint16" len="1" units="W/m2" />
+      <point id="DNI" offset="3" type="uint16" len="1" units="W/m2" />
+      <point id="OTI" offset="4" type="uint16" len="1" units="W/m2" />
     </block>
   </model>
   <strings id="302" locale="en">

--- a/smdx/smdx_00302.xml
+++ b/smdx/smdx_00302.xml
@@ -13,32 +13,32 @@
     <model>
       <label>Irradiance Model</label>
       <description>Include to support various irradiance measurements</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="GHI">
       <label>GHI</label>
       <description>Global Horizontal Irradiance</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="POAI">
       <label>POAI</label>
       <description>Plane-of-Array Irradiance</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DFI">
       <label>DFI</label>
       <description>Diffuse Irradiance</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DNI">
       <label>DNI</label>
       <description>Direct Normal Irradiance</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OTI">
       <label>OTI</label>
       <description>Other Irradiance</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00303.xml
+++ b/smdx/smdx_00303.xml
@@ -2,8 +2,8 @@
 
   <!-- 303: Back of Module Temperature Model -->
   <model id="303" len="1" name="bom_temp">
-    <block type="repeating" len="1" name="temp">
-      <point id="TmpBOM" offset="0" type="int16" units="C" sf="-1"  mandatory="true"/>
+    <block len="1" type="repeating" name="temp">
+      <point id="TmpBOM" offset="0" type="int16" len="1" sf="-1" units="C" mandatory="true" />
     </block>
   </model>
   <strings id="303" locale="en">

--- a/smdx/smdx_00303.xml
+++ b/smdx/smdx_00303.xml
@@ -10,12 +10,12 @@
     <model>
       <label>Back of Module Temperature Model</label>
       <description>Include to support variable number of  back of module temperature measurements</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="TmpBOM">
       <label>Temp</label>
       <description>Back of module temperature measurement</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00304.xml
+++ b/smdx/smdx_00304.xml
@@ -11,22 +11,22 @@
     <model>
       <label>Inclinometer Model</label>
       <description>Include to support orientation measurements</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Inclx">
       <label>X</label>
       <description>X-Axis inclination</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Incly">
       <label>Y</label>
       <description>Y-Axis inclination</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Inclz">
       <label>Z</label>
       <description>Z-Axis inclination</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00304.xml
+++ b/smdx/smdx_00304.xml
@@ -2,9 +2,9 @@
   <!-- 304: Inclinometer Model -->
   <model id="304" len="6" name="inclinometer">
     <block len="6" type="repeating" name="incl">
-      <point id="Inclx" offset="0" type="int32" sf="-2" units="Degrees" mandatory="true"/>
-      <point id="Incly" offset="2" type="int32" sf="-2" units="Degrees" mandatory="false"/>
-      <point id="Inclz" offset="4" type="int32" sf="-2" units="Degrees" mandatory="false"/>
+      <point id="Inclx" offset="0" type="int32" len="2" sf="-2" units="Degrees" mandatory="true" />
+      <point id="Incly" offset="2" type="int32" len="2" sf="-2" units="Degrees" />
+      <point id="Inclz" offset="4" type="int32" len="2" sf="-2" units="Degrees" />
     </block>
   </model>
   <strings id="304" locale="en">

--- a/smdx/smdx_00305.xml
+++ b/smdx/smdx_00305.xml
@@ -1,13 +1,13 @@
 <sunSpecModels v="1">
   <!-- 305: Location Model -->
   <model id="305" len="36" name="location">
-    <block len="36">
-      <point id="Tm" offset="0" type="string" len="6" units="hhmmss.sssZ" mandatory="false"/>
-      <point id="Date" offset="6" type="string" len="4" units="YYYYMMDD" mandatory="false"/>
-      <point id="Loc" offset="10" type="string" len="20" units="text" mandatory="false"/>
-      <point id="Lat" offset="30" type="int32" sf="-7" units="Degrees" mandatory="false"/>
-      <point id="Long" offset="32" type="int32" sf="-7" units="Degrees" mandatory="false"/>
-      <point id="Alt" offset="34" type="int32" units="meters" mandatory="false"/>
+    <block len="36" type="fixed">
+      <point id="Tm" offset="0" type="string" len="6" units="hhmmss.sssZ" />
+      <point id="Date" offset="6" type="string" len="4" units="YYYYMMDD" />
+      <point id="Loc" offset="10" type="string" len="20" units="text" />
+      <point id="Lat" offset="30" type="int32" len="2" sf="-7" units="Degrees" />
+      <point id="Long" offset="32" type="int32" len="2" sf="-7" units="Degrees" />
+      <point id="Alt" offset="34" type="int32" len="2" units="meters" />
     </block>
   </model>
   <strings id="305" locale="en">

--- a/smdx/smdx_00305.xml
+++ b/smdx/smdx_00305.xml
@@ -14,37 +14,37 @@
     <model>
       <label>GPS</label>
       <description>Include to support location measurements</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="Tm">
       <label>Tm</label>
       <description>UTC 24 hour time stamp to millisecond hhmmss.sssZ format</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Date">
       <label>Date</label>
       <description>UTC Date string YYYYMMDD format</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Loc">
       <label>Location</label>
       <description>Location string (40 chars max)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Lat">
       <label>Lat</label>
       <description>Latitude with seven degrees of precision</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Long">
       <label>Long</label>
       <description>Longitude with seven degrees of precision</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Alt">
       <label>Altitude</label>
       <description>Altitude measurement in meters</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00306.xml
+++ b/smdx/smdx_00306.xml
@@ -12,27 +12,27 @@
     <model>
       <label>Reference Point Model</label>
       <description>Include to support a standard reference point</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="GHI">
       <label>GHI</label>
       <description>Global Horizontal Irradiance</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="A">
       <label>Amps</label>
       <description>Current measurement at reference point</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="V">
       <label>Voltage</label>
       <description>Voltage  measurement at reference point</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Tmp">
       <label>Temperature</label>
       <description>Temperature measurement at reference point</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00306.xml
+++ b/smdx/smdx_00306.xml
@@ -1,11 +1,11 @@
 <sunSpecModels v="1">
   <!-- 302: Reference Point Model -->
   <model id="306" len="4" name="ref_point">
-    <block len="4">
-      <point id="GHI" offset="0" type="uint16" units="W/m2" mandatory="false"/>
-      <point id="A" offset="1" type="uint16" units="W/m2" mandatory="false"/>
-      <point id="V" offset="2" type="uint16" units="W/m2" mandatory="false"/>
-      <point id="Tmp" offset="3" type="uint16" units="W/m2" mandatory="false"/>
+    <block len="4" type="fixed">
+      <point id="GHI" offset="0" type="uint16" len="1" units="W/m2" />
+      <point id="A" offset="1" type="uint16" len="1" units="W/m2" />
+      <point id="V" offset="2" type="uint16" len="1" units="W/m2" />
+      <point id="Tmp" offset="3" type="uint16" len="1" units="W/m2" />
     </block>
   </model>
   <strings id="306" locale="en">

--- a/smdx/smdx_00307.xml
+++ b/smdx/smdx_00307.xml
@@ -23,58 +23,58 @@
     </model>
     <point id="TmpAmb">
       <label>Ambient Temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="RH">
       <label>Relative Humidity</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Pres">
       <label>Barometric Pressure</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WndSpd">
       <label>Wind Speed</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WndDir">
       <label>Wind Direction</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Rain">
       <label>Rainfall</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Snw">
       <label>Snow Depth</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="PPT">
       <label>Precipitation Type</label>
       <description> Precipitation Type (WMO 4680 SYNOP code reference)</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ElecFld">
       <label>Electric Field</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="SurWet">
       <label>Surface Wetness</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="SoilWet">
       <label>Soil Wetness</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00307.xml
+++ b/smdx/smdx_00307.xml
@@ -1,18 +1,18 @@
 <sunSpecModels v="1">
   <!-- 307: meteorological v1.1 -->
   <model id="307" len="11" name="base_met">
-    <block len="11">
-      <point id="TmpAmb" offset="0" type="int16" sf="-1" units="C" />
-      <point id="RH" offset="1" type="int16" units="Pct" />
-      <point id="Pres" offset="2" type="int16" units="HPa" />
-      <point id="WndSpd" offset="3" type="int16" units="mps" />
-      <point id="WndDir" offset="4" type="int16" units="deg" />
-      <point id="Rain" offset="5" type="int16" units="mm" />
-      <point id="Snw" offset="6" type="int16" units="mm" />
-      <point id="PPT" offset="7" type="int16" />
-      <point id="ElecFld" offset="8" type="int16" units="Vm" />
-      <point id="SurWet" offset="9" type="int16" units="kO" />
-      <point id="SoilWet" offset="10" type="int16" units="Pct" />
+    <block len="11" type="fixed">
+      <point id="TmpAmb" offset="0" type="int16" len="1" sf="-1" units="C" />
+      <point id="RH" offset="1" type="int16" len="1" units="Pct" />
+      <point id="Pres" offset="2" type="int16" len="1" units="HPa" />
+      <point id="WndSpd" offset="3" type="int16" len="1" units="mps" />
+      <point id="WndDir" offset="4" type="int16" len="1" units="deg" />
+      <point id="Rain" offset="5" type="int16" len="1" units="mm" />
+      <point id="Snw" offset="6" type="int16" len="1" units="mm" />
+      <point id="PPT" offset="7" type="int16" len="1" />
+      <point id="ElecFld" offset="8" type="int16" len="1" units="Vm" />
+      <point id="SurWet" offset="9" type="int16" len="1" units="kO" />
+      <point id="SoilWet" offset="10" type="int16" len="1" units="Pct" />
     </block>
   </model>
   <strings id="307" locale="en">

--- a/smdx/smdx_00308.xml
+++ b/smdx/smdx_00308.xml
@@ -13,27 +13,27 @@
     <model>
       <label>Mini Met Model</label>
       <description>Include to support a few basic measurements</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="GHI">
       <label>GHI</label>
       <description>Global Horizontal Irradiance</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpBOM">
       <label>Temp</label>
       <description>Back of module temperature measurement</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpAmb">
       <label>Ambient Temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WndSpd">
       <label>Wind Speed</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00308.xml
+++ b/smdx/smdx_00308.xml
@@ -2,11 +2,11 @@
 
   <!-- 308: Mini Met Model -->
   <model id="308" len="4" name="mini_met">
-    <block len="4">
-      <point id="GHI" offset="0" type="uint16" units="W/m2" mandatory="false"/>
-      <point id="TmpBOM" offset="1" type="int16" sf="-1" units="C" mandatory="false"/>
-      <point id="TmpAmb" offset="2" type="int16" sf="-1" units="C" mandatory="false"/>
-      <point id="WndSpd" offset="3" type="uint16" units="m/s" mandatory="false"/>
+    <block len="4" type="fixed">
+      <point id="GHI" offset="0" type="uint16" len="1" units="W/m2" />
+      <point id="TmpBOM" offset="1" type="int16" len="1" sf="-1" units="C" />
+      <point id="TmpAmb" offset="2" type="int16" len="1" sf="-1" units="C" />
+      <point id="WndSpd" offset="3" type="uint16" len="1" units="m/s" />
     </block>
   </model>
   <strings id="308" locale="en">

--- a/smdx/smdx_00401.xml
+++ b/smdx/smdx_00401.xml
@@ -1,13 +1,13 @@
 <sunSpecModels v="1">
   <!-- 401: string combiner -->
   <model id="401" len="22" name="string_combiner">
-    <block len="14">
-      <point id="DCA_SF" offset="0" type="sunssf" mandatory="true" />
-      <point id="DCAhr_SF" offset="1" type="sunssf" />
-      <point id="DCV_SF" offset="2" type="sunssf" />
-      <point id="DCAMax" offset="3" type="uint16" sf="DCA_SF" units="A" mandatory="true" />
-      <point id="N" offset="4" type="count" mandatory="true" />
-      <point id="Evt" offset="5" type="bitfield32" mandatory="true">
+    <block len="14" type="fixed">
+      <point id="DCA_SF" offset="0" type="sunssf" len="1" mandatory="true" />
+      <point id="DCAhr_SF" offset="1" type="sunssf" len="1" />
+      <point id="DCV_SF" offset="2" type="sunssf" len="1" />
+      <point id="DCAMax" offset="3" type="uint16" len="1" sf="DCA_SF" units="A" mandatory="true" />
+      <point id="N" offset="4" type="count" len="1" mandatory="true" />
+      <point id="Evt" offset="5" type="bitfield32" len="2" mandatory="true" >
         <symbol id="LOW_VOLTAGE">0</symbol>
         <symbol id="LOW_POWER">1</symbol>
         <symbol id="LOW_EFFICIENCY">2</symbol>
@@ -28,15 +28,15 @@
         <symbol id="THEFT">17</symbol>
         <symbol id="ARC_DETECTED">18</symbol>
       </point>
-      <point id="EvtVnd" offset="7" type="bitfield32" />
-      <point id="DCA" offset="9" type="int16" sf="DCA_SF" units="A" mandatory="true" />
-      <point id="DCAhr" offset="10" type="uint32" sf="DCAhr_SF" units="Ah" />
-      <point id="DCV" offset="12" type="uint16" sf="DCV_SF" units="V" />
-      <point id="Tmp" offset="13" type="int16" units="C" />
+      <point id="EvtVnd" offset="7" type="bitfield32" len="2" />
+      <point id="DCA" offset="9" type="int16" len="1" sf="DCA_SF" units="A" mandatory="true" />
+      <point id="DCAhr" offset="10" type="uint32" len="2" sf="DCAhr_SF" units="Ah" />
+      <point id="DCV" offset="12" type="uint16" len="1" sf="DCV_SF" units="V" />
+      <point id="Tmp" offset="13" type="int16" len="1" units="C" />
     </block>
-    <block type="repeating" len="8" name="string">
-      <point id="InID" offset="0" type="uint16" mandatory="true" />
-      <point id="InEvt" offset="1" type="bitfield32" mandatory="true">
+    <block len="8" type="repeating" name="string">
+      <point id="InID" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="InEvt" offset="1" type="bitfield32" len="2" mandatory="true" >
         <symbol id="LOW_VOLTAGE">0</symbol>
         <symbol id="LOW_POWER">1</symbol>
         <symbol id="LOW_EFFICIENCY">2</symbol>
@@ -57,9 +57,9 @@
         <symbol id="THEFT">17</symbol>
         <symbol id="ARC_DETECTED">18</symbol>
       </point>
-      <point id="InEvtVnd" offset="3" type="bitfield32" />
-      <point id="InDCA" offset="5" type="int16" sf="DCA_SF" units="A" mandatory="true" />
-      <point id="InDCAhr" offset="6" type="uint32" sf="DCAhr_SF" units="Ah" />
+      <point id="InEvtVnd" offset="3" type="bitfield32" len="2" />
+      <point id="InDCA" offset="5" type="int16" len="1" sf="DCA_SF" units="A" mandatory="true" />
+      <point id="InDCAhr" offset="6" type="uint32" len="2" sf="DCAhr_SF" units="Ah" />
     </block>
   </model>
   <strings id="401" locale="en">

--- a/smdx/smdx_00401.xml
+++ b/smdx/smdx_00401.xml
@@ -74,67 +74,67 @@
     <point id="DCAMax">
       <label>Rating</label>
       <description>Maximum DC Current Rating</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="N">
       <label>N</label>
       <description>Number of Inputs</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Event</label>
       <description>Bitmask value.  Events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd">
       <label>Vendor Event</label>
       <description>Bitmask value.  Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCA">
       <label>Amps</label>
       <description>Total measured current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCAhr">
       <label>Amp-hours</label>
       <description>Total metered Amp-hours</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCV">
       <label>Voltage</label>
       <description>Output Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Tmp">
       <label>Temp</label>
       <description>Internal operating temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InID">
       <label>ID</label>
       <description>Uniquely identifies this input set</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InEvt">
       <label>Input Event</label>
       <description>String Input Event Flags</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InEvtVnd">
       <label>Input Event Vendor</label>
       <description>String Input Vendor Event Flags</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCA">
       <label>Amps</label>
       <description>String Input Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCAhr">
       <label>Amp-hours</label>
       <description>String Input Amp-Hours</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00402.xml
+++ b/smdx/smdx_00402.xml
@@ -1,15 +1,15 @@
 <sunSpecModels v="1">
   <!-- 402: (SUPERSEDED by 404) String Combiner (Advanced) -->
   <model id="402" len="34" name="string_combiner">
-    <block len="20">
-      <point id="DCA_SF" offset="0" type="sunssf" mandatory="true" />
-      <point id="DCAhr_SF" offset="1" type="sunssf" />
-      <point id="DCV_SF" offset="2" type="sunssf" />
-      <point id="DCW_SF" offset="3" type="sunssf" />
-      <point id="DCWh_SF" offset="4" type="sunssf" mandatory="true" />
-      <point id="DCAMax" offset="5" type="uint16" units="A" />
-      <point id="N" offset="6" type="count" />
-      <point id="Evt" offset="7" type="bitfield32" mandatory="true">
+    <block len="20" type="fixed">
+      <point id="DCA_SF" offset="0" type="sunssf" len="1" mandatory="true" />
+      <point id="DCAhr_SF" offset="1" type="sunssf" len="1" />
+      <point id="DCV_SF" offset="2" type="sunssf" len="1" />
+      <point id="DCW_SF" offset="3" type="sunssf" len="1" />
+      <point id="DCWh_SF" offset="4" type="sunssf" len="1" mandatory="true" />
+      <point id="DCAMax" offset="5" type="uint16" len="1" units="A" />
+      <point id="N" offset="6" type="count" len="1" />
+      <point id="Evt" offset="7" type="bitfield32" len="2" mandatory="true" >
         <symbol id="LOW_VOLTAGE">0</symbol>
         <symbol id="LOW_POWER">1</symbol>
         <symbol id="LOW_EFFICIENCY">2</symbol>
@@ -30,18 +30,18 @@
         <symbol id="THEFT">17</symbol>
         <symbol id="ARC_DETECTED">18</symbol>
       </point>
-      <point id="EvtVnd" offset="9" type="bitfield32" />
-      <point id="DCA" offset="11" type="int16" sf="DCA_SF" mandatory="true" units="A" />
-      <point id="DCAhr" offset="12" type="uint32" sf="DCAhr_SF" units="Ah" />
-      <point id="DCV" offset="14" type="uint16" sf="DCV_SF" units="V" />
-      <point id="Tmp" offset="15" type="int16" units="C" />
-      <point id="DCW" offset="16" type="int16" sf="DCW_SF" units="W" />
-      <point id="DCPR" offset="17" type="uint16" units="Pct" />
-      <point id="DCWh" offset="18" type="uint32" sf="DCWh_SF" mandatory="true" units="Wh" />
+      <point id="EvtVnd" offset="9" type="bitfield32" len="2" />
+      <point id="DCA" offset="11" type="int16" len="1" sf="DCA_SF" units="A" mandatory="true" />
+      <point id="DCAhr" offset="12" type="uint32" len="2" sf="DCAhr_SF" units="Ah" />
+      <point id="DCV" offset="14" type="uint16" len="1" sf="DCV_SF" units="V" />
+      <point id="Tmp" offset="15" type="int16" len="1" units="C" />
+      <point id="DCW" offset="16" type="int16" len="1" sf="DCW_SF" units="W" />
+      <point id="DCPR" offset="17" type="uint16" len="1" units="Pct" />
+      <point id="DCWh" offset="18" type="uint32" len="2" sf="DCWh_SF" units="Wh" mandatory="true" />
     </block>
-    <block type="repeating" len="14" name="string">
-      <point id="InID" offset="0" type="uint16" mandatory="true" />
-      <point id="InEvt" offset="1" type="bitfield32" mandatory="true">
+    <block len="14" type="repeating" name="string">
+      <point id="InID" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="InEvt" offset="1" type="bitfield32" len="2" mandatory="true" >
         <symbol id="LOW_VOLTAGE">0</symbol>
         <symbol id="LOW_POWER">1</symbol>
         <symbol id="LOW_EFFICIENCY">2</symbol>
@@ -62,14 +62,14 @@
         <symbol id="THEFT">17</symbol>
         <symbol id="ARC_DETECTED">18</symbol>
       </point>
-      <point id="EvtVnd" offset="3" type="bitfield32" />
-      <point id="InDCA" offset="5" type="int16" sf="DCA_SF" units="A" mandatory="true" />
-      <point id="InDCAhr" offset="6" type="uint32" sf="DCAhr_SF" units="Ah" />
-      <point id="InDCV" offset="8" type="uint16" sf="DCV_SF" units="V" />
-      <point id="InDCW" offset="9" type="int16" sf="DCWh_SF" units="W" />
-      <point id="InDCWh" offset="10" type="uint32" units="Wh" />
-      <point id="InDCPR" offset="12" type="uint16" units="Pct" />
-      <point id="InN" offset="13" type="uint16"/>
+      <point id="EvtVnd" offset="3" type="bitfield32" len="2" />
+      <point id="InDCA" offset="5" type="int16" len="1" sf="DCA_SF" units="A" mandatory="true" />
+      <point id="InDCAhr" offset="6" type="uint32" len="2" sf="DCAhr_SF" units="Ah" />
+      <point id="InDCV" offset="8" type="uint16" len="1" sf="DCV_SF" units="V" />
+      <point id="InDCW" offset="9" type="int16" len="1" sf="DCWh_SF" units="W" />
+      <point id="InDCWh" offset="10" type="uint32" len="2" units="Wh" />
+      <point id="InDCPR" offset="12" type="uint16" len="1" units="Pct" />
+      <point id="InN" offset="13" type="uint16" len="1" />
     </block>
   </model>
   <strings id="402" locale="en">

--- a/smdx/smdx_00402.xml
+++ b/smdx/smdx_00402.xml
@@ -86,97 +86,97 @@
     <point id="DCAMax">
       <label>Rating</label>
       <description>Maximum DC Current Rating</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="N">
       <label>N</label>
       <description>Number of Inputs</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Event</label>
       <description>Bitmask value.  Events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd">
       <label>Vendor Event</label>
       <description>Bitmask value.  Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCA">
       <label>Amps</label>
       <description>Total measured current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCAhr">
       <label>Amp-hours</label>
       <description>Total metered Amp-hours</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCV">
       <label>Voltage</label>
       <description>Output Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Tmp">
       <label>Temp</label>
       <description>Internal operating temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCW">
       <label>Watts</label>
       <description>Output power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCWh">
       <label>Watt-hours</label>
       <description>Output energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCPR">
       <label>PR</label>
       <description>DC Performance ratio value</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InID">
       <label>ID</label>
       <description>Uniquely identifies this input set</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InEvt">
       <label>Input Event</label>
       <description>String Input Event Flags</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCA">
       <label>Amps</label>
       <description>String Input Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCAhr">
       <label>Amp-hours</label>
       <description>String Input Amp-Hours</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCV">
       <label>Voltage</label>
       <description>String Input Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCW">
       <label>Watts</label>
       <description>String Input Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCWh">
       <label>Watt-hours</label>
       <description>String Input Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCPR">
       <label>PR</label>
       <description>String Performance Ratio</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InN">
       <label>N</label>

--- a/smdx/smdx_00403.xml
+++ b/smdx/smdx_00403.xml
@@ -1,13 +1,13 @@
 <sunSpecModels v="1">
   <!-- 403: string combiner -->
   <model id="403" len="24" name="string_combiner">
-    <block len="16">
-      <point id="DCA_SF" offset="0" type="sunssf" mandatory="true" />
-      <point id="DCAhr_SF" offset="1" type="sunssf" />
-      <point id="DCV_SF" offset="2" type="sunssf" />
-      <point id="DCAMax" offset="3" type="uint16" sf="DCA_SF" units="A" mandatory="true" />
-      <point id="N" offset="4" type="count" mandatory="true" />
-      <point id="Evt" offset="5" type="bitfield32" mandatory="true">
+    <block len="16" type="fixed">
+      <point id="DCA_SF" offset="0" type="sunssf" len="1" mandatory="true" />
+      <point id="DCAhr_SF" offset="1" type="sunssf" len="1" />
+      <point id="DCV_SF" offset="2" type="sunssf" len="1" />
+      <point id="DCAMax" offset="3" type="uint16" len="1" sf="DCA_SF" units="A" mandatory="true" />
+      <point id="N" offset="4" type="count" len="1" mandatory="true" />
+      <point id="Evt" offset="5" type="bitfield32" len="2" mandatory="true" >
         <symbol id="LOW_VOLTAGE">0</symbol>
         <symbol id="LOW_POWER">1</symbol>
         <symbol id="LOW_EFFICIENCY">2</symbol>
@@ -28,17 +28,17 @@
         <symbol id="THEFT">17</symbol>
         <symbol id="ARC_DETECTED">18</symbol>
       </point>
-      <point id="EvtVnd" offset="7" type="bitfield32" />
-      <point id="DCA" offset="9" type="int16" sf="DCA_SF" units="A" mandatory="true" />
-      <point id="DCAhr" offset="10" type="acc32" sf="DCAhr_SF" units="Ah" />
-      <point id="DCV" offset="12" type="int16" sf="DCV_SF" units="V" />
-      <point id="Tmp" offset="13" type="int16" units="C" />
-      <point id="InDCA_SF" offset="14" type="sunssf" />
-      <point id="InDCAhr_SF" offset="15" type="sunssf" />
+      <point id="EvtVnd" offset="7" type="bitfield32" len="2" />
+      <point id="DCA" offset="9" type="int16" len="1" sf="DCA_SF" units="A" mandatory="true" />
+      <point id="DCAhr" offset="10" type="acc32" len="2" sf="DCAhr_SF" units="Ah" />
+      <point id="DCV" offset="12" type="int16" len="1" sf="DCV_SF" units="V" />
+      <point id="Tmp" offset="13" type="int16" len="1" units="C" />
+      <point id="InDCA_SF" offset="14" type="sunssf" len="1" />
+      <point id="InDCAhr_SF" offset="15" type="sunssf" len="1" />
     </block>
-    <block type="repeating" len="8" name="string">
-      <point id="InID" offset="0" type="uint16" mandatory="true" />
-      <point id="InEvt" offset="1" type="bitfield32" mandatory="true">
+    <block len="8" type="repeating" name="string">
+      <point id="InID" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="InEvt" offset="1" type="bitfield32" len="2" mandatory="true" >
         <symbol id="LOW_VOLTAGE">0</symbol>
         <symbol id="LOW_POWER">1</symbol>
         <symbol id="LOW_EFFICIENCY">2</symbol>
@@ -59,9 +59,9 @@
         <symbol id="THEFT">17</symbol>
         <symbol id="ARC_DETECTED">18</symbol>
       </point>
-      <point id="InEvtVnd" offset="3" type="bitfield32" />
-      <point id="InDCA" offset="5" type="int16" sf="InDCA_SF" units="A" mandatory="true" />
-      <point id="InDCAhr" offset="6" type="acc32" sf="InDCAhr_SF" units="Ah" />
+      <point id="InEvtVnd" offset="3" type="bitfield32" len="2" />
+      <point id="InDCA" offset="5" type="int16" len="1" sf="InDCA_SF" units="A" mandatory="true" />
+      <point id="InDCAhr" offset="6" type="acc32" len="2" sf="InDCAhr_SF" units="Ah" />
     </block>
   </model>
   <strings id="403" locale="en">

--- a/smdx/smdx_00403.xml
+++ b/smdx/smdx_00403.xml
@@ -78,67 +78,67 @@
     <point id="DCAMax">
       <label>Rating</label>
       <description>Maximum DC Current Rating</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="N">
       <label>N</label>
       <description>Number of Inputs</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Event</label>
       <description>Bitmask value.  Events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd">
       <label>Vendor Event</label>
       <description>Bitmask value.  Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCA">
       <label>Amps</label>
       <description>Total measured current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCAhr">
       <label>Amp-hours</label>
       <description>Total metered Amp-hours</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCV">
       <label>Voltage</label>
       <description>Output Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Tmp">
       <label>Temp</label>
       <description>Internal operating temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InID">
       <label>ID</label>
       <description>Uniquely identifies this input set</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InEvt">
       <label>Input Event</label>
       <description>String Input Event Flags</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InEvtVnd">
       <label>Input Event Vendor</label>
       <description>String Input Vendor Event Flags</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCA">
       <label>Amps</label>
       <description>String Input Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCAhr">
       <label>Amp-hours</label>
       <description>String Input Amp-Hours</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00404.xml
+++ b/smdx/smdx_00404.xml
@@ -1,15 +1,15 @@
 <sunSpecModels v="1">
   <!-- 404: advanced string combiner -->
   <model id="404" len="39" name="string_combiner">
-    <block len="25">
-      <point id="DCA_SF" offset="0" type="sunssf" mandatory="true" />
-      <point id="DCAhr_SF" offset="1" type="sunssf" />
-      <point id="DCV_SF" offset="2" type="sunssf" />
-      <point id="DCW_SF" offset="3" type="sunssf" />
-      <point id="DCWh_SF" offset="4" type="sunssf" />
-      <point id="DCAMax" offset="5" type="uint16" sf="DCA_SF" units="A" mandatory="true" />
-      <point id="N" offset="6" type="count" mandatory="true" />
-      <point id="Evt" offset="7" type="bitfield32" mandatory="true">
+    <block len="25" type="fixed">
+      <point id="DCA_SF" offset="0" type="sunssf" len="1" mandatory="true" />
+      <point id="DCAhr_SF" offset="1" type="sunssf" len="1" />
+      <point id="DCV_SF" offset="2" type="sunssf" len="1" />
+      <point id="DCW_SF" offset="3" type="sunssf" len="1" />
+      <point id="DCWh_SF" offset="4" type="sunssf" len="1" />
+      <point id="DCAMax" offset="5" type="uint16" len="1" sf="DCA_SF" units="A" mandatory="true" />
+      <point id="N" offset="6" type="count" len="1" mandatory="true" />
+      <point id="Evt" offset="7" type="bitfield32" len="2" mandatory="true" >
         <symbol id="LOW_VOLTAGE">0</symbol>
         <symbol id="LOW_POWER">1</symbol>
         <symbol id="LOW_EFFICIENCY">2</symbol>
@@ -30,23 +30,23 @@
         <symbol id="THEFT">17</symbol>
         <symbol id="ARC_DETECTED">18</symbol>
       </point>
-      <point id="EvtVnd" offset="9" type="bitfield32" />
-      <point id="DCA" offset="11" type="int16" sf="DCA_SF" units="A" mandatory="true" />
-      <point id="DCAhr" offset="12" type="acc32" sf="DCAhr_SF" units="Ah" />
-      <point id="DCV" offset="14" type="int16" sf="DCV_SF" units="V" />
-      <point id="Tmp" offset="15" type="int16" units="C" />
-      <point id="DCW" offset="16" type="int16" sf="DCW_SF" units="W" />
-      <point id="DCPR" offset="17" type="int16" units="Pct" />
-      <point id="DCWh" offset="18" type="acc32" sf="DCWh_SF" units="Wh" />
-      <point id="InDCA_SF" offset="20" type="sunssf" />
-      <point id="InDCAhr_SF" offset="21" type="sunssf" />
-      <point id="InDCV_SF" offset="22" type="sunssf" />
-      <point id="InDCW_SF" offset="23" type="sunssf" />
-      <point id="InDCWh_SF" offset="24" type="sunssf" />
+      <point id="EvtVnd" offset="9" type="bitfield32" len="2" />
+      <point id="DCA" offset="11" type="int16" len="1" sf="DCA_SF" units="A" mandatory="true" />
+      <point id="DCAhr" offset="12" type="acc32" len="2" sf="DCAhr_SF" units="Ah" />
+      <point id="DCV" offset="14" type="int16" len="1" sf="DCV_SF" units="V" />
+      <point id="Tmp" offset="15" type="int16" len="1" units="C" />
+      <point id="DCW" offset="16" type="int16" len="1" sf="DCW_SF" units="W" />
+      <point id="DCPR" offset="17" type="int16" len="1" units="Pct" />
+      <point id="DCWh" offset="18" type="acc32" len="2" sf="DCWh_SF" units="Wh" />
+      <point id="InDCA_SF" offset="20" type="sunssf" len="1" />
+      <point id="InDCAhr_SF" offset="21" type="sunssf" len="1" />
+      <point id="InDCV_SF" offset="22" type="sunssf" len="1" />
+      <point id="InDCW_SF" offset="23" type="sunssf" len="1" />
+      <point id="InDCWh_SF" offset="24" type="sunssf" len="1" />
     </block>
-    <block type="repeating" len="14" name="string">
-      <point id="InID" offset="0" type="uint16" mandatory="true" />
-      <point id="InEvt" offset="1" type="bitfield32" mandatory="true">
+    <block len="14" type="repeating" name="string">
+      <point id="InID" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="InEvt" offset="1" type="bitfield32" len="2" mandatory="true" >
         <symbol id="LOW_VOLTAGE">0</symbol>
         <symbol id="LOW_POWER">1</symbol>
         <symbol id="LOW_EFFICIENCY">2</symbol>
@@ -67,14 +67,14 @@
         <symbol id="THEFT">17</symbol>
         <symbol id="ARC_DETECTED">18</symbol>
       </point>
-      <point id="InEvtVnd" offset="3" type="bitfield32" />
-      <point id="InDCA" offset="5" type="int16" sf="InDCA_SF" units="A" mandatory="true" />
-      <point id="InDCAhr" offset="6" type="acc32" sf="InDCAhr_SF" units="Ah" />
-      <point id="InDCV" offset="8" type="int16" sf="InDCV_SF" units="V" />
-      <point id="InDCW" offset="9" type="int16" sf="InDCW_SF" units="W" />
-      <point id="InDCWh" offset="10" type="acc32" sf="InDCWh_SF" units="Wh" />
-      <point id="InDCPR" offset="12" type="uint16" units="Pct" />
-      <point id="InN" offset="13" type="uint16" />
+      <point id="InEvtVnd" offset="3" type="bitfield32" len="2" />
+      <point id="InDCA" offset="5" type="int16" len="1" sf="InDCA_SF" units="A" mandatory="true" />
+      <point id="InDCAhr" offset="6" type="acc32" len="2" sf="InDCAhr_SF" units="Ah" />
+      <point id="InDCV" offset="8" type="int16" len="1" sf="InDCV_SF" units="V" />
+      <point id="InDCW" offset="9" type="int16" len="1" sf="InDCW_SF" units="W" />
+      <point id="InDCWh" offset="10" type="acc32" len="2" sf="InDCWh_SF" units="Wh" />
+      <point id="InDCPR" offset="12" type="uint16" len="1" units="Pct" />
+      <point id="InN" offset="13" type="uint16" len="1" />
     </block>
   </model>
   <strings id="404" locale="en">

--- a/smdx/smdx_00404.xml
+++ b/smdx/smdx_00404.xml
@@ -96,102 +96,102 @@
     <point id="DCAMax">
       <label>Rating</label>
       <description>Maximum DC Current Rating</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="N">
       <label>N</label>
       <description>Number of Inputs</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Event</label>
       <description>Bitmask value.  Events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd">
       <label>Vendor Event</label>
       <description>Bitmask value.  Vendor defined events</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCA">
       <label>Amps</label>
       <description>Total measured current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCAhr">
       <label>Amp-hours</label>
       <description>Total metered Amp-hours</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCV">
       <label>Voltage</label>
       <description>Output Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Tmp">
       <label>Temp</label>
       <description>Internal operating temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCW">
       <label>Watts</label>
       <description>Output power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCWh">
       <label>Watt-hours</label>
       <description>Output energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DCPR">
       <label>PR</label>
       <description>DC Performance ratio value</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InID">
       <label>ID</label>
       <description>Uniquely identifies this input set</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InEvt">
       <label>Input Event</label>
       <description>String Input Event Flags</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InEvtVnd">
       <label>Input Event Vendor</label>
       <description>String Input Vendor Event Flags</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCA">
       <label>Amps</label>
       <description>String Input Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCAhr">
       <label>Amp-hours</label>
       <description>String Input Amp-Hours</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCV">
       <label>Voltage</label>
       <description>String Input Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCW">
       <label>Watts</label>
       <description>String Input Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCWh">
       <label>Watt-hours</label>
       <description>String Input Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InDCPR">
       <label>PR</label>
       <description>String Performance Ratio</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InN">
       <label>N</label>

--- a/smdx/smdx_00501.xml
+++ b/smdx/smdx_00501.xml
@@ -63,76 +63,76 @@
     <point id="Stat">
       <label>Status</label>
       <description>Enumerated value.  Module Status Code</description>
-      <notes></notes>
+      <notes/>
       <symbol id="OFF">
         <label>Off</label>
         <description>Module is in the OFF state</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SLEEPING">
         <label>SLEEPING</label>
         <description>Sleeping (auto-shutdown) or panel is at low/safe output power/voltage</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STARTING">
         <label>STARTING</label>
         <description>Starting up or ON but not producing power; panel might have high voltage but is not producing power</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MPPT">
         <label>MPPT</label>
         <description>Tracking MPPT power point</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="THROTTLED">
         <label>THROTTLED</label>
         <description>Forced power reduction / power de-rating</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SHUTTING_DOWN">
         <label>SHUTTING_DOWN</label>
         <description>Shutting down</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>FAULT</label>
         <description>One or more faults exist</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STANDBY">
         <label>STANDBY</label>
         <description>Standby (service or unit) - unlike SLEEPING in this mode the module might be at a high (unsafe) output voltage or power</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TEST">
         <label>TEST</label>
         <description>Test mode</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OTHER">
         <label>OTHER</label>
         <description>As defined in vendor specific status</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StatVend">
       <label>Vendor Status</label>
       <description>Module Vendor Status Code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Events</label>
       <description>Bitmask value.  Module Event Flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="GROUND_FAULT">
         <label>Ground Fault</label>
         <description>Ground Fault</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="INPUT_OVER_VOLTAGE">
         <label>Over Voltage</label>
         <description>DC input over-voltage</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
@@ -142,7 +142,7 @@
       <symbol id="DC_DISCONNECT">
         <label>Disconnect</label>
         <description>DC disconnect open</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
@@ -157,12 +157,12 @@
       <symbol id="MANUAL_SHUTDOWN">
         <label>Manual shutdown</label>
         <description>Manual shutdown</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMPERATURE">
         <label>Over Temperature</label>
         <description>Over Temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
@@ -187,118 +187,118 @@
       <symbol id="BLOWN_FUSE">
         <label>Blown Fuse</label>
         <description>Input fuse is blown</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMPERATURE">
         <label>Under Temperature</label>
         <description>Under Temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MEMORY_LOSS">
         <label>Memory Loss</label>
         <description>Generic Memory or Communication Error</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ARC_DETECTION">
         <label>Arc Detection</label>
         <description>Arc Detection</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="THEFT_DETECTION">
         <label>Theft Detection</label>
         <description>Theft Detection</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OUTPUT_OVER_CURRENT">
         <label>Over Current</label>
         <description>Output Over Current</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OUTPUT_OVER_VOLTAGE">
         <label>Output Over Voltage</label>
         <description>DC Output Over Voltage</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OUTPUT_UNDER_VOLTAGE">
         <label>Output Under Voltage</label>
         <description>DC Output Under Voltage</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TEST_FAILED">
         <label>Test Failed</label>
         <description>Last Self Test failed; see vendor event for details</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="EvtVend">
       <label>Vendor Module Event Flags</label>
       <description>Vendor specific flags</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ctl">
       <label>Control</label>
       <description>Module Control</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CtlVend">
       <label>Vendor Control</label>
       <description>Vendor Module Control</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CtlVal">
       <label>Control Value</label>
       <description>Module Control Value</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Tms">
       <label>Timestamp</label>
       <description>Time in seconds since 2000 epoch</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutA">
       <label>Output Current</label>
       <description>Output Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutV">
       <label>Output Voltage</label>
       <description>Output Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutWh">
       <label>Output Energy</label>
       <description>Output Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutW">
       <label>Output Power</label>
       <description>Output Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Tmp">
       <label>Temp</label>
       <description>Module Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InA">
       <label>Input Current</label>
       <description>Input Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InV">
       <label>Input Voltage</label>
       <description>Input Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InWh">
       <label>Input Energy</label>
       <description>Input Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InW">
       <label>Input Power</label>
       <description>Input Power</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00501.xml
+++ b/smdx/smdx_00501.xml
@@ -1,8 +1,8 @@
 <sunSpecModels v="1">
   <!-- 501: panel module float -->
   <model id="501" len="31" name="solar_module">
-    <block len="31">
-      <point id="Stat" offset="0" type="enum16" mandatory="true" >
+    <block len="31" type="fixed">
+      <point id="Stat" offset="0" type="enum16" len="1" mandatory="true" >
         <symbol id="OFF">1</symbol>
         <symbol id="SLEEPING">2</symbol>
         <symbol id="STARTING">3</symbol>
@@ -14,8 +14,8 @@
         <symbol id="TEST">9</symbol>
         <symbol id="OTHER">10</symbol>
       </point>
-      <point id="StatVend" offset="1" type="enum16" />
-      <point id="Evt" offset="2" type="bitfield32" mandatory="true" >
+      <point id="StatVend" offset="1" type="enum16" len="1" />
+      <point id="Evt" offset="2" type="bitfield32" len="2" mandatory="true" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="INPUT_OVER_VOLTAGE">1</symbol>
         <symbol id="RESERVED_2">2</symbol>
@@ -38,20 +38,20 @@
         <symbol id="OUTPUT_UNDER_VOLTAGE">19</symbol>
         <symbol id="TEST_FAILED">20</symbol>
       </point>
-      <point id="EvtVend" offset="4" type="bitfield32" />
-      <point id="Ctl" offset="6" type="enum16" access="rw" />
-      <point id="CtlVend" offset="7" type="enum32" access="rw" />
-      <point id="CtlVal" offset="9" type="int32" access="rw" />
-      <point id="Tms" offset="11" type="uint32" units="Secs" />
-      <point id="OutA" offset="13" type="float32" units="A" />
-      <point id="OutV" offset="15" type="float32" units="V" />
-      <point id="OutWh" offset="17" type="float32" units="Wh" />
-      <point id="OutW" offset="19" type="float32" units="W" />
-      <point id="Tmp" offset="21" type="float32" units="C" />
-      <point id="InA" offset="23" type="float32" units="A" />
-      <point id="InV" offset="25" type="float32" units="V" />
-      <point id="InWh" offset="27" type="float32" units="Wh" />
-      <point id="InW" offset="29" type="float32" units="W" />
+      <point id="EvtVend" offset="4" type="bitfield32" len="2" />
+      <point id="Ctl" offset="6" type="enum16" len="1" access="rw" />
+      <point id="CtlVend" offset="7" type="enum32" len="2" access="rw" />
+      <point id="CtlVal" offset="9" type="int32" len="2" access="rw" />
+      <point id="Tms" offset="11" type="uint32" len="2" units="Secs" />
+      <point id="OutA" offset="13" type="float32" len="2" units="A" />
+      <point id="OutV" offset="15" type="float32" len="2" units="V" />
+      <point id="OutWh" offset="17" type="float32" len="2" units="Wh" />
+      <point id="OutW" offset="19" type="float32" len="2" units="W" />
+      <point id="Tmp" offset="21" type="float32" len="2" units="C" />
+      <point id="InA" offset="23" type="float32" len="2" units="A" />
+      <point id="InV" offset="25" type="float32" len="2" units="V" />
+      <point id="InWh" offset="27" type="float32" len="2" units="Wh" />
+      <point id="InW" offset="29" type="float32" len="2" units="W" />
     </block>
   </model>
   <strings id="501" locale="en">

--- a/smdx/smdx_00502.xml
+++ b/smdx/smdx_00502.xml
@@ -1,12 +1,12 @@
 <sunSpecModels v="1">
   <!-- 502: panel module integer -->
   <model id="502" len="28" name="solar_module">
-    <block len="28">
-      <point id="A_SF" offset="0" type="sunssf" />
-      <point id="V_SF" offset="1" type="sunssf" />
-      <point id="W_SF" offset="2" type="sunssf" />
-      <point id="Wh_SF" offset="3" type="sunssf" />
-      <point id="Stat" offset="4" type="enum16" mandatory="true">
+    <block len="28" type="fixed">
+      <point id="A_SF" offset="0" type="sunssf" len="1" />
+      <point id="V_SF" offset="1" type="sunssf" len="1" />
+      <point id="W_SF" offset="2" type="sunssf" len="1" />
+      <point id="Wh_SF" offset="3" type="sunssf" len="1" />
+      <point id="Stat" offset="4" type="enum16" len="1" mandatory="true" >
         <symbol id="OFF">1</symbol>
         <symbol id="SLEEPING">2</symbol>
         <symbol id="STARTING">3</symbol>
@@ -18,8 +18,8 @@
         <symbol id="TEST">9</symbol>
         <symbol id="OTHER">10</symbol>
       </point>
-      <point id="StatVend" offset="5" type="enum16" />
-      <point id="Evt" offset="6" type="bitfield32" mandatory="true">
+      <point id="StatVend" offset="5" type="enum16" len="1" />
+      <point id="Evt" offset="6" type="bitfield32" len="2" mandatory="true" >
         <symbol id="GROUND_FAULT">0</symbol>
         <symbol id="INPUT_OVER_VOLTAGE">1</symbol>
         <symbol id="RESERVED_2">2</symbol>
@@ -42,20 +42,20 @@
         <symbol id="OUTPUT_UNDER_VOLTAGE">19</symbol>
         <symbol id="TEST_FAILED">20</symbol>
       </point>
-      <point id="EvtVend" offset="8" type="bitfield32" />
-      <point id="Ctl" offset="10" type="enum16" access="rw" />
-      <point id="CtlVend" offset="11" type="enum32" access="rw" />
-      <point id="CtlVal" offset="13" type="int32" access="rw" />
-      <point id="Tms" offset="15" type="uint32" units="Secs" />
-      <point id="OutA" offset="17" type="int16" sf="A_SF" units="A" />
-      <point id="OutV" offset="18" type="int16" sf="V_SF" units="V" />
-      <point id="OutWh" offset="19" type="acc32" sf="Wh_SF" units="Wh" />
-      <point id="OutPw" offset="21" type="int16" sf="W_SF" units="W" />
-      <point id="Tmp" offset="22" type="int16" units="C" />
-      <point id="InA" offset="23" type="int16" sf="A_SF" units="A" />
-      <point id="InV" offset="24" type="int16" sf="V_SF" units="V" />
-      <point id="InWh" offset="25" type="acc32" sf="Wh_SF" units="Wh" />
-      <point id="InW" offset="27" type="int16" sf="W_SF" units="W" />
+      <point id="EvtVend" offset="8" type="bitfield32" len="2" />
+      <point id="Ctl" offset="10" type="enum16" len="1" access="rw" />
+      <point id="CtlVend" offset="11" type="enum32" len="2" access="rw" />
+      <point id="CtlVal" offset="13" type="int32" len="2" access="rw" />
+      <point id="Tms" offset="15" type="uint32" len="2" units="Secs" />
+      <point id="OutA" offset="17" type="int16" len="1" sf="A_SF" units="A" />
+      <point id="OutV" offset="18" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="OutWh" offset="19" type="acc32" len="2" sf="Wh_SF" units="Wh" />
+      <point id="OutPw" offset="21" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="Tmp" offset="22" type="int16" len="1" units="C" />
+      <point id="InA" offset="23" type="int16" len="1" sf="A_SF" units="A" />
+      <point id="InV" offset="24" type="int16" len="1" sf="V_SF" units="V" />
+      <point id="InWh" offset="25" type="acc32" len="2" sf="Wh_SF" units="Wh" />
+      <point id="InW" offset="27" type="int16" len="1" sf="W_SF" units="W" />
     </block>
   </model>
   <strings id="502" locale="en">

--- a/smdx/smdx_00502.xml
+++ b/smdx/smdx_00502.xml
@@ -67,76 +67,76 @@
     <point id="Stat">
       <label>Status</label>
       <description>Enumerated value.  Module Status Code</description>
-      <notes></notes>
+      <notes/>
       <symbol id="OFF">
         <label>Off</label>
         <description>Module is in the OFF state</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SLEEPING">
         <label>SLEEPING</label>
         <description>Sleeping (auto-shutdown) or panel is at low/safe output power/voltage</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STARTING">
         <label>STARTING</label>
         <description>Starting up or ON but not producing power; panel might have high voltage but is not producing power</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MPPT">
         <label>MPPT</label>
         <description>Tracking MPPT power point</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="THROTTLED">
         <label>THROTTLED</label>
         <description>Forced power reduction / power de-rating</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SHUTTING_DOWN">
         <label>SHUTTING_DOWN</label>
         <description>Shutting down</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>FAULT</label>
         <description>One or more faults exist</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STANDBY">
         <label>STANDBY</label>
         <description>Standby (service or unit) - unlike SLEEPING in this mode the module might be at a high (unsafe) output voltage or power</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TEST">
         <label>TEST</label>
         <description>Test mode</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OTHER">
         <label>OTHER</label>
         <description>As defined in vendor specific status</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StatVend">
       <label>Vendor Status</label>
       <description>Module Vendor Status Code</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Evt">
       <label>Events</label>
       <description>Bitmask value.  Module Event Flags</description>
-      <notes></notes>
+      <notes/>
       <symbol id="GROUND_FAULT">
         <label>Ground Fault</label>
         <description>Ground Fault</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="INPUT_OVER_VOLTAGE">
         <label>Over Voltage</label>
         <description>DC input over-voltage</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
@@ -146,7 +146,7 @@
       <symbol id="DC_DISCONNECT">
         <label>Disconnect</label>
         <description>DC disconnect open</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
@@ -161,12 +161,12 @@
       <symbol id="MANUAL_SHUTDOWN">
         <label>Manual shutdown</label>
         <description>Manual shutdown</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMPERATURE">
         <label>Over Temperature</label>
         <description>Over Temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED">
         <label>Reserved</label>
@@ -191,138 +191,138 @@
       <symbol id="BLOWN_FUSE">
         <label>Blown Fuse</label>
         <description>Input fuse is blown</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMPERATURE">
         <label>Under Temperature</label>
         <description>Under Temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MEMORY_LOSS">
         <label>Memory Loss</label>
         <description>Generic Memory or Communication Error</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ARC_DETECTION">
         <label>Arc Detection</label>
         <description>Arc Detection</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="THEFT_DETECTION">
         <label>Theft Detection</label>
         <description>Theft Detection</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OUTPUT_OVER_CURRENT">
         <label>Over Current</label>
         <description>Output Over Current</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OUTPUT_OVER_VOLTAGE">
         <label>Output Over Voltage</label>
         <description>DC Output Over Voltage</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OUTPUT_UNDER_VOLTAGE">
         <label>Output Under Voltage</label>
         <description>DC Output Under Voltage</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TEST_FAILED">
         <label>Test Failed</label>
         <description>Last Self Test failed; see vendor event for details</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="EvtVend">
       <label>Vendor Module Event Flags</label>
       <description>Vendor specific flags</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="A_SF">
-      <label></label>
+      <label/>
       <description>Current scale factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="V_SF">
-      <label></label>
+      <label/>
       <description>Voltage scale factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W_SF">
-      <label></label>
+      <label/>
       <description>Power scale factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Wh_SF">
-      <label></label>
+      <label/>
       <description>Energy scale factor</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Ctl">
       <label>Control</label>
       <description>Module Control</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CtlVend">
       <label>Vendor Control</label>
       <description>Vendor Module Control</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CtlVal">
       <label>Control Value</label>
       <description>Module Control Value</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Tms">
       <label>Timestamp</label>
       <description>Time in seconds since 2000 epoch</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutA">
       <label>Output Current</label>
       <description>Output Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutV">
       <label>Output Voltage</label>
       <description>Output Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutWh">
       <label>Output Energy</label>
       <description>Output Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OutPw">
       <label>Output Power</label>
       <description>Output Power</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Tmp">
       <label>Temp</label>
       <description>Module Temperature</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InA">
       <label>Input Current</label>
       <description>Input Current</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InV">
       <label>Input Voltage</label>
       <description>Input Voltage</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InWh">
       <label>Input Energy</label>
       <description>Input Energy</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="InW">
       <label>Input Power</label>
       <description>Input Power</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00601.xml
+++ b/smdx/smdx_00601.xml
@@ -1,9 +1,9 @@
 <sunSpecModels v="1">
   <!-- 601: Tracker Controller -->
   <model id="601" len="48" name="tracker_controller">
-    <block len="26">
-      <point id="Nam" offset="0" type="string" len="8"  mandatory="false" />
-      <point id="Typ" offset="8" type="enum16" mandatory="true" >
+    <block len="26" type="fixed">
+      <point id="Nam" offset="0" type="string" len="8" />
+      <point id="Typ" offset="8" type="enum16" len="1" mandatory="true" >
         <symbol id="Unknown">0</symbol>
         <symbol id="Fixed">1</symbol>
         <symbol id="Horizontal">2</symbol>
@@ -12,38 +12,38 @@
         <symbol id="Dual">5</symbol>
         <symbol id="Other">99</symbol>
       </point>
-      <point id="DtLoc" offset="9" type="string" len="5" units="YYYYMMDD" mandatory="false"/>
-      <point id="TmLoc" offset="14" type="string" len="3" units="hhmmss" mandatory="false" />
-      <point id="Day" offset="17" type="uint16" mandatory="false" />
-      <point id="GlblElCtl" offset="18" type="int32" units="Degrees" sf="Dgr_SF" access="rw" mandatory="false" />
-      <point id="GlblAzCtl" offset="20" type="int32" units="Degrees" sf="Dgr_SF" access="rw" mandatory="false" />
-      <point id="GlblCtl" offset="22" type="enum16" access="rw" mandatory="false" >
+      <point id="DtLoc" offset="9" type="string" len="5" units="YYYYMMDD" />
+      <point id="TmLoc" offset="14" type="string" len="3" units="hhmmss" />
+      <point id="Day" offset="17" type="uint16" len="1" />
+      <point id="GlblElCtl" offset="18" type="int32" len="2" sf="Dgr_SF" access="rw" units="Degrees" />
+      <point id="GlblAzCtl" offset="20" type="int32" len="2" sf="Dgr_SF" access="rw" units="Degrees" />
+      <point id="GlblCtl" offset="22" type="enum16" len="1" access="rw" >
         <symbol id="Automatic">0</symbol>
         <symbol id="Manual">1</symbol>
         <symbol id="Calibrate">2</symbol>
       </point>
-      <point id="GlblAlm" offset="23" type="bitfield16"  mandatory="false">
+      <point id="GlblAlm" offset="23" type="bitfield16" len="1" >
         <symbol id="SetPoint">0</symbol>
         <symbol id="ObsEl">1</symbol>
         <symbol id="ObsAz">2</symbol>
       </point>
-      <point id="Dgr_SF" offset="24" type="sunssf"  mandatory="true" />
-      <point id="N" offset="25" type="uint16" mandatory="true" />
+      <point id="Dgr_SF" offset="24" type="sunssf" len="1" mandatory="true" />
+      <point id="N" offset="25" type="uint16" len="1" mandatory="true" />
     </block>
     <block len="22" type="repeating" name="tracker">
-      <point id="Id" offset="0" type="string" len="8"  mandatory="false" />
-      <point id="ElTrgt" offset="8" type="int32" units="Degrees" sf="Dgr_SF" mandatory="false" />
-      <point id="AzTrgt" offset="10" type="int32" units="Degrees" sf="Dgr_SF" mandatory="false" />
-      <point id="ElPos" offset="12" type="int32" units="Degrees" sf="Dgr_SF" mandatory="false" />
-      <point id="AzPos" offset="14" type="int32" units="Degrees" sf="Dgr_SF" mandatory="false" />
-      <point id="ElCtl" offset="16" type="int32" units="Degrees" sf="Dgr_SF" access="rw" mandatory="false" />
-      <point id="AzCtl" offset="18" type="int32" units="Degrees" sf="Dgr_SF" access="rw" mandatory="false" />
-      <point id="Ctl" offset="20" type="enum16" access="rw" mandatory="false" >
+      <point id="Id" offset="0" type="string" len="8" />
+      <point id="ElTrgt" offset="8" type="int32" len="2" sf="Dgr_SF" units="Degrees" />
+      <point id="AzTrgt" offset="10" type="int32" len="2" sf="Dgr_SF" units="Degrees" />
+      <point id="ElPos" offset="12" type="int32" len="2" sf="Dgr_SF" units="Degrees" />
+      <point id="AzPos" offset="14" type="int32" len="2" sf="Dgr_SF" units="Degrees" />
+      <point id="ElCtl" offset="16" type="int32" len="2" sf="Dgr_SF" access="rw" units="Degrees" />
+      <point id="AzCtl" offset="18" type="int32" len="2" sf="Dgr_SF" access="rw" units="Degrees" />
+      <point id="Ctl" offset="20" type="enum16" len="1" access="rw" >
         <symbol id="Automatic">0</symbol>
         <symbol id="Manual">1</symbol>
         <symbol id="Calibrate">2</symbol>
       </point>
-      <point id="Alm" offset="21" type="bitfield16"  mandatory="false">
+      <point id="Alm" offset="21" type="bitfield16" len="1" >
         <symbol id="SetPoint">0</symbol>
         <symbol id="ObsEl">1</symbol>
         <symbol id="ObsAz">2</symbol>

--- a/smdx/smdx_00801.xml
+++ b/smdx/smdx_00801.xml
@@ -9,12 +9,12 @@
     <model>
       <label>Energy Storage Base Model (DEPRECATED)</label>
       <description>This model has been deprecated.</description>
-      <notes></notes>
+      <notes/>
     </model>
     <point id="DEPRECATED">
       <label>Deprecated Model</label>
       <description>This model has been deprecated.</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00801.xml
+++ b/smdx/smdx_00801.xml
@@ -1,8 +1,8 @@
 <sunSpecModels v="1">
   <!-- 801: Energy Storage Base Model (DEPRECATED) -->
   <model id="801" len="1" name="storage">
-    <block len="1">
-      <point id="DEPRECATED" offset="0" type="enum16" mandatory="true" />
+    <block len="1" type="fixed">
+      <point id="DEPRECATED" offset="0" type="enum16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="801" locale="en">

--- a/smdx/smdx_00802.xml
+++ b/smdx/smdx_00802.xml
@@ -137,53 +137,53 @@
   <strings id="802" locale="en">
     <model>
       <label>Battery Base Model</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="AHRtg">
       <label>Nameplate Charge Capacity</label>
       <description>Nameplate charge capacity in amp-hours.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WHRtg">
       <label>Nameplate Energy Capacity</label>
       <description>Nameplate energy capacity in DC watt-hours.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WChaRteMax">
       <label>Nameplate Max Charge Rate</label>
       <description>Maximum rate of energy transfer into the storage device in DC watts.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WDisChaRteMax">
       <label>Nameplate Max Discharge Rate</label>
       <description>Maximum rate of energy transfer out of the storage device in DC watts.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DisChaRte">
       <label>Self Discharge Rate</label>
       <description>Self discharge rate.  Percentage of capacity (WHRtg) discharged per day.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoCMax">
       <label>Nameplate Max SoC</label>
       <description>Manufacturer maximum state of charge, expressed as a percentage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoCMin">
       <label>Nameplate Min SoC</label>
       <description>Manufacturer minimum state of charge, expressed as a percentage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SocRsvMax">
       <label>Max Reserve Percent</label>
       <description>Setpoint for maximum reserve for storage as a percentage of the nominal maximum storage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoCRsvMin">
       <label>Min Reserve Percent</label>
       <description>Setpoint for maximum reserve for storage as a percentage of the nominal maximum storage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoC">
       <label>State of Charge</label>
@@ -198,41 +198,41 @@
     <point id="ChaSt">
       <label>Charge Status</label>
       <description>Charge status of storage device. Enumeration.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="OFF">
-        <label></label>
-        <description></description>
-        <notes></notes>
+        <label/>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="EMPTY">
-        <label></label>
-        <description></description>
-        <notes></notes>
+        <label/>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="DISCHARGING">
-        <label></label>
-        <description></description>
-        <notes></notes>
+        <label/>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CHARGING">
-        <label></label>
-        <description></description>
-        <notes></notes>
+        <label/>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="FULL">
-        <label></label>
-        <description></description>
-        <notes></notes>
+        <label/>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="HOLDING">
-        <label></label>
-        <description></description>
-        <notes></notes>
+        <label/>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="TESTING">
-        <label></label>
-        <description></description>
-        <notes></notes>
+        <label/>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="LocRemCtl">
@@ -253,12 +253,12 @@
     <point id="Hb">
       <label>Battery Heartbeat</label>
       <description>Value is incremented every second with periodic resets to zero.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CtrlHb">
       <label>Controller Heartbeat</label>
       <description>Value is incremented every second with periodic resets to zero.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AlmRst">
       <label>Alarm Reset</label>
@@ -272,62 +272,62 @@
       <symbol id="NOT APPLICABLE_UNKNOWN">
         <label>Not Applicable or Unknown</label>
         <description>Battery type is not applicable or unknown.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="LEAD_ACID">
         <label>Lead-Acid</label>
         <description>Lead-acid battery type.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="NICKEL_METAL_HYDRATE">
         <label>Nickel-Metal Hydrate</label>
         <description>Nickel-metal hydrate battery type.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="NICKEL_CADMIUM">
         <label>Nickel-Cadmium</label>
         <description>Nickel-cadmium battery type.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="LITHIUM_ION">
         <label>Lithium-Ion</label>
         <description>Lithium-ion battery type.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CARBON_ZINC">
         <label>Carbon-Zinc</label>
         <description>Carbon-zinc battery type.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ZINC_CHLORIDE">
         <label>Zinc Chloride</label>
         <description>Zinc chloride battery type.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="ALKALINE">
         <label>Alkaline</label>
         <description>Alkaline battery type.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RECHARGEABLE_ALKALINE">
         <label>Rechargeable Alkaline</label>
         <description>Rechargeable alkaline battery type.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SODIUM_SULFUR">
         <label>Sodium-Sulfur</label>
         <description>Sodium-sulfur battery type.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FLOW">
         <label>Flow</label>
         <description>Flow battery type.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OTHER">
         <label>Other</label>
         <description>Other battery type.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="State">
@@ -337,53 +337,53 @@
       <symbol id="DISCONNECTED">
         <label>Disconnected</label>
         <description>Battery bank is disconnected. All contactors are open.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="INITIALIZING">
         <label>Initializing</label>
         <description>Battery bank is initializing but not ready for operating. String balancing may occur.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONNECTED">
         <label>Connected</label>
         <description>Battery bank is ready for operation. All enabled contactors are closed.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STANDBY">
         <label>Standby</label>
         <description>Battery bank is connected and in standby/power saving mode.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SOC PROTECTION">
         <label>SoC Protection</label>
         <description>Battery bank is connected but SoC is too low. Battery should be considered "offline".</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="SUSPENDING">
         <label>Suspending</label>
         <description>Battery bank is suspending operation and will disconnect.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>Fault</label>
         <description>The battery has experienced a critical failure and may not be operated.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StateVnd">
       <label>Vendor Battery Bank State</label>
       <description>Vendor specific battery bank state.  Enumeration.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="NCyc">
       <label>Cycle Count</label>
       <description>Number of cycles executed in the battery.</description>
-      <notes></notes>
+      <notes/>
      </point>
     <point id="SoH">
       <label>State of Health</label>
       <description>Percentage of battery life remaining.</description>
-      <notes></notes>
+      <notes/>
      </point>
     <point id="WarrDt">
       <label>Warranty Date</label>
@@ -393,31 +393,31 @@
     <point id="Evt1">
       <label>Battery Event 1 Bitfield</label>
       <description>Alarms and warnings.  Bit flags.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="COMMUNICATION_ERROR">
         <label>Communication Error</label>
         <description>Unable to communicate with BMS or BMS is unable to communicate with battery strings.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP_ALARM">
         <label>Over Temperature Alarm</label>
         <description>Battery has exceeded maximum operating temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP_WARNING">
         <label>Over Temperature  Warning</label>
         <description>Battery is approaching maximum operating temperature.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP_ALARM">
         <label>Under Temperature Alarm</label>
         <description>Battery has exceeded minimum operating temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP_WARNING">
         <label>Under Temperature Warning</label>
         <description>Battery is approaching minimum operating temperature.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_CHARGE_CURRENT_ALARM">
         <label>Over Charge Current Alarm</label>
@@ -442,82 +442,82 @@
       <symbol id="OVER_VOLT_ALARM">
         <label>Over Voltage Alarm</label>
         <description>Battery voltage has exceeded maximum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_VOLT_WARNING">
         <label>Over Voltage Warning</label>
         <description>Battery voltage is approaching maximum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_VOLT_ALARM">
         <label>Under Voltage Alarm</label>
         <description>Battery voltage has exceeded minimum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_VOLT_WARNING">
         <label>Under Voltage Warning</label>
         <description>Battery voltage is approaching minimum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_SOC_MIN_ALARM">
         <label>Under State of Charge Min Alarm</label>
         <description>Battery state of charge has reached or exceeded SoCMin</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_SOC_MIN_WARNING">
         <label>Under State of Charge Min Warning</label>
         <description>Battery state of charge is approaching SoCMin</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_SOC_MAX_ALARM">
         <label>Over State of Charge Max Alarm</label>
         <description>Battery state of charge has reached or exceeded SoCMax</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_SOC_MAX_WARNING">
         <label>Over State of Charge Max Warning</label>
         <description>Battery state of charge is approaching SoCMax</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="VOLTAGE_IMBALANCE_WARNING">
         <label>Voltage Imbalance Warning</label>
         <description>A voltage imbalance exists between the strings in the battery bank.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TEMPERATURE_IMBALANCE_ALARM">
         <label>Temperature Imbalance Alarm</label>
         <description>A temperature imbalance exists between the strings in the battery bank.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TEMPERATURE_IMBALANCE_WARNING">
         <label>Temperature Imbalance Warning</label>
         <description>A temperature imbalance is developing between the strings in the battery bank.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_ERROR">
         <label>Contactor Error</label>
         <description>A contactor failed to open or close as requested.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAN_ERROR">
         <label>Fan Error</label>
         <description>One or more battery fans has failed.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="GROUND_FAULT">
         <label>Ground Fault Error</label>
         <description>Ground fault detected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OPEN_DOOR_ERROR">
         <label>Open Door Error</label>
         <description>One or more doors are open.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CURRENT_IMBALANCE_WARNING">
         <label>Current Imbalance Warning</label>
         <description>A current imbalance exists between the strings in the battery bank.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OTHER_ALARM">
         <label>Other Battery Alarm</label>
@@ -537,12 +537,12 @@
       <symbol id="CONFIGURATION_ALARM">
         <label>Configuration Alarm</label>
         <description>The battery bank has been configured incorrectly and will not operate.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONFIGURATION_WARNING">
         <label>Configuration Warning</label>
         <description>The battery bank has been configured incorrectly and may not operated as expected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Evt2">
@@ -553,12 +553,12 @@
     <point id="EvtVnd1">
       <label>Vendor Event Bitfield 1</label>
       <description>Vendor defined events.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd2">
       <label>Vendor Event Bitfield 2</label>
       <description>Vendor defined events.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="V">
       <label>External Battery Voltage</label>
@@ -583,12 +583,12 @@
     <point id="CellVMaxStr">
       <label>Max Cell Voltage String</label>
       <description>String containing the cell with maximum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVMaxMod">
       <label>Max Cell Voltage Module</label>
       <description>Module containing the cell with maximum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVMin">
       <label>Min Cell Voltage</label>
@@ -598,12 +598,12 @@
     <point id="CellVMinStr">
       <label>Min Cell Voltage String</label>
       <description>String containing the cell with minimum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVMinMod">
       <label>Min Cell Voltage Module</label>
       <description>Module containing the cell with minimum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVAvg">
       <label>Average Cell Voltage</label>
@@ -637,7 +637,7 @@
       <symbol id="NO REQUEST">
         <label>No Request</label>
         <description>Battery has no requests of the inverter.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="START">
         <label>Start Inverter</label>
@@ -658,16 +658,16 @@
     <point id="SetOp">
       <label>Set Operation</label>
       <description>Instruct the battery bank to perform an operation such as connecting.  Enumeration.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="CONNECT">
         <label>Connect the Battery Bank</label>
         <description>Initialize the battery bank and close contactors for all enabled strings.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DISCONNECT">
         <label>Disconnect the Battery Bank</label>
         <description>Open contactors for all strings.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="SetInvState">
@@ -676,79 +676,79 @@
       <notes>Information needed by battery for some operations.</notes>
       <symbol id="INVERTER_STOPPED">
         <label>Inverter is Stopped</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="INVERTER_STANDBY">
         <label>Inverter is in Standby</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="INVERTER_STARTED">
         <label>Inverter is Started</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="AHRtg_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for charge capacity.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WHRtg_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for energy capacity.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="WChaDisChaMax_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for maximum charge and discharge rate.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DisChaRte_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for self discharge rate.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoC_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for state of charge values.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DoD_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for depth of discharge.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoH_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for state of health.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="V_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for DC bus voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellV_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for cell voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="A_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for DC current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="AMax_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for instantaneous DC charge/discharge current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="W_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for AC power request.</description>
-      <notes></notes>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_00802.xml
+++ b/smdx/smdx_00802.xml
@@ -1,21 +1,21 @@
 <sunSpecModels v="1">
   <!-- 802: Battery Base Model -->
   <model id="802" len="62" name="battery">
-    <block len="62">
-      <point id="AHRtg" offset="0" type="uint16" sf="AHRtg_SF" units="Ah" mandatory="true" />
-      <point id="WHRtg" offset="1" type="uint16" sf="WHRtg_SF" units="Wh" mandatory="true" />
-      <point id="WChaRteMax" offset="2" type="uint16" sf="WChaDisChaMax_SF" units="W" mandatory="true" />
-      <point id="WDisChaRteMax" offset="3" type="uint16" sf="WChaDisChaMax_SF" units="W" mandatory="true" />
-      <point id="DisChaRte" offset="4" type="uint16" sf="DisChaRte_SF" units="%WHRtg" />
-      <point id="SoCMax" offset="5" type="uint16" sf="SoC_SF" units="%WHRtg" />
-      <point id="SoCMin" offset="6" type="uint16" sf="SoC_SF" units="%WHRtg" />
-      <point id="SocRsvMax" offset="7" access="rw" type="uint16" sf="SoC_SF" units="%WHRtg" />
-      <point id="SoCRsvMin" offset="8" access="rw" type="uint16" sf="SoC_SF" units="%WHRtg" />
-      <point id="SoC" offset="9" type="uint16" sf="SoC_SF" units="%WHRtg" mandatory="true" />
-      <point id="DoD" offset="10" type="uint16" sf="DoD_SF" units="%" />
-      <point id="SoH" offset="11" type="uint16" sf="SoH_SF" units="%" />
-      <point id="NCyc" offset="12" type="uint32" />
-      <point id="ChaSt" offset="14" type="enum16" >
+    <block len="62" type="fixed">
+      <point id="AHRtg" offset="0" type="uint16" len="1" sf="AHRtg_SF" units="Ah" mandatory="true" />
+      <point id="WHRtg" offset="1" type="uint16" len="1" sf="WHRtg_SF" units="Wh" mandatory="true" />
+      <point id="WChaRteMax" offset="2" type="uint16" len="1" sf="WChaDisChaMax_SF" units="W" mandatory="true" />
+      <point id="WDisChaRteMax" offset="3" type="uint16" len="1" sf="WChaDisChaMax_SF" units="W" mandatory="true" />
+      <point id="DisChaRte" offset="4" type="uint16" len="1" sf="DisChaRte_SF" units="%WHRtg" />
+      <point id="SoCMax" offset="5" type="uint16" len="1" sf="SoC_SF" units="%WHRtg" />
+      <point id="SoCMin" offset="6" type="uint16" len="1" sf="SoC_SF" units="%WHRtg" />
+      <point id="SocRsvMax" offset="7" type="uint16" len="1" sf="SoC_SF" access="rw" units="%WHRtg" />
+      <point id="SoCRsvMin" offset="8" type="uint16" len="1" sf="SoC_SF" access="rw" units="%WHRtg" />
+      <point id="SoC" offset="9" type="uint16" len="1" sf="SoC_SF" units="%WHRtg" mandatory="true" />
+      <point id="DoD" offset="10" type="uint16" len="1" sf="DoD_SF" units="%" />
+      <point id="SoH" offset="11" type="uint16" len="1" sf="SoH_SF" units="%" />
+      <point id="NCyc" offset="12" type="uint32" len="2" />
+      <point id="ChaSt" offset="14" type="enum16" len="1" >
         <symbol id="OFF">1</symbol>
         <symbol id="EMPTY">2</symbol>
         <symbol id="DISCHARGING">3</symbol>
@@ -24,14 +24,14 @@
         <symbol id="HOLDING">6</symbol>
         <symbol id="TESTING">7</symbol>
       </point>
-      <point id="LocRemCtl" offset="15" type="enum16" mandatory="true" >
+      <point id="LocRemCtl" offset="15" type="enum16" len="1" mandatory="true" >
         <symbol id="REMOTE">0</symbol>
         <symbol id="LOCAL">1</symbol>
       </point>
-      <point id="Hb" offset="16" type="uint16" />
-      <point id="CtrlHb" offset="17" access="rw" type="uint16" />
-      <point id="AlmRst" offset="18" access="rw" type="uint16" mandatory="true" />
-      <point id="Typ" offset="19" type="enum16" mandatory="true" >
+      <point id="Hb" offset="16" type="uint16" len="1" />
+      <point id="CtrlHb" offset="17" type="uint16" len="1" access="rw" />
+      <point id="AlmRst" offset="18" type="uint16" len="1" access="rw" mandatory="true" />
+      <point id="Typ" offset="19" type="enum16" len="1" mandatory="true" >
         <symbol id="NOT APPLICABLE_UNKNOWN">0</symbol>
         <symbol id="LEAD_ACID">1</symbol>
         <symbol id="NICKEL_METAL_HYDRATE">2</symbol>
@@ -45,7 +45,7 @@
         <symbol id="FLOW">10</symbol>
         <symbol id="OTHER">99</symbol>
       </point>
-      <point id="State" offset="20" type="enum16" mandatory="true" >
+      <point id="State" offset="20" type="enum16" len="1" mandatory="true" >
         <symbol id="DISCONNECTED">1</symbol>
         <symbol id="INITIALIZING">2</symbol>
         <symbol id="CONNECTED">3</symbol>
@@ -54,9 +54,9 @@
         <symbol id="SUSPENDING">6</symbol>
         <symbol id="FAULT">99</symbol>
       </point>
-      <point id="StateVnd" offset="21" type="enum16" mandatory="false" />
-      <point id="WarrDt" offset="22" type="uint32" />
-      <point id="Evt1" offset="24" type="bitfield32" mandatory="true" >
+      <point id="StateVnd" offset="21" type="enum16" len="1" />
+      <point id="WarrDt" offset="22" type="uint32" len="2" />
+      <point id="Evt1" offset="24" type="bitfield32" len="2" mandatory="true" >
         <symbol id="COMMUNICATION_ERROR">0</symbol>
         <symbol id="OVER_TEMP_ALARM">1</symbol>
         <symbol id="OVER_TEMP_WARNING">2</symbol>
@@ -88,51 +88,50 @@
         <symbol id="CONFIGURATION_ALARM">28</symbol>
         <symbol id="CONFIGURATION_WARNING">29</symbol>
       </point>
-      <point id="Evt2" offset="26" type="bitfield32" mandatory="true" />
-      <point id="EvtVnd1" offset="28" type="bitfield32" mandatory="true" />
-      <point id="EvtVnd2" offset="30" type="bitfield32" mandatory="true" />
-      <point id="V" offset="32" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="VMax" offset="33" type="uint16" sf="V_SF" units="V" />
-      <point id="VMin" offset="34" type="uint16" sf="V_SF" units="V" />
-
-      <point id="CellVMax" offset="35" type="uint16" sf="CellV_SF" units="V" />
-      <point id="CellVMaxStr" offset="36" type="uint16" />
-      <point id="CellVMaxMod" offset="37" type="uint16" />
-      <point id="CellVMin" offset="38" type="uint16" sf="CellV_SF" units="V" />
-      <point id="CellVMinStr" offset="39" type="uint16" />
-      <point id="CellVMinMod" offset="40" type="uint16" />
-      <point id="CellVAvg" offset="41" type="uint16" sf="CellV_SF" units="V" />
-      <point id="A" offset="42" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="AChaMax" offset="43" type="uint16" sf="AMax_SF" units="A" />
-      <point id="ADisChaMax" offset="44" type="uint16" sf="AMax_SF" units="A" />
-      <point id="W" offset="45" type="int16" sf="W_SF" units="W" mandatory="true" />
-      <point id="ReqInvState" offset="46" type="enum16" >
+      <point id="Evt2" offset="26" type="bitfield32" len="2" mandatory="true" />
+      <point id="EvtVnd1" offset="28" type="bitfield32" len="2" mandatory="true" />
+      <point id="EvtVnd2" offset="30" type="bitfield32" len="2" mandatory="true" />
+      <point id="V" offset="32" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="VMax" offset="33" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="VMin" offset="34" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="CellVMax" offset="35" type="uint16" len="1" sf="CellV_SF" units="V" />
+      <point id="CellVMaxStr" offset="36" type="uint16" len="1" />
+      <point id="CellVMaxMod" offset="37" type="uint16" len="1" />
+      <point id="CellVMin" offset="38" type="uint16" len="1" sf="CellV_SF" units="V" />
+      <point id="CellVMinStr" offset="39" type="uint16" len="1" />
+      <point id="CellVMinMod" offset="40" type="uint16" len="1" />
+      <point id="CellVAvg" offset="41" type="uint16" len="1" sf="CellV_SF" units="V" />
+      <point id="A" offset="42" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="AChaMax" offset="43" type="uint16" len="1" sf="AMax_SF" units="A" />
+      <point id="ADisChaMax" offset="44" type="uint16" len="1" sf="AMax_SF" units="A" />
+      <point id="W" offset="45" type="int16" len="1" sf="W_SF" units="W" mandatory="true" />
+      <point id="ReqInvState" offset="46" type="enum16" len="1" >
         <symbol id="NO REQUEST">0</symbol>
         <symbol id="START">1</symbol>
         <symbol id="STOP">2</symbol>
       </point>
-      <point id="ReqW" offset="47" type="int16" sf="W_SF" units="W" />
-      <point id="SetOp" offset="48" access="rw" type="enum16" mandatory="true" >
+      <point id="ReqW" offset="47" type="int16" len="1" sf="W_SF" units="W" />
+      <point id="SetOp" offset="48" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="CONNECT">1</symbol>
         <symbol id="DISCONNECT">2</symbol>
       </point>
-      <point id="SetInvState" offset="49" access="rw" type="enum16" mandatory="true" >
+      <point id="SetInvState" offset="49" type="enum16" len="1" access="rw" mandatory="true" >
         <symbol id="INVERTER_STOPPED">1</symbol>
         <symbol id="INVERTER_STANDBY">2</symbol>
         <symbol id="INVERTER_STARTED">3</symbol>
       </point>
-      <point id="AHRtg_SF" offset="50" type="sunssf" mandatory="true" />
-      <point id="WHRtg_SF" offset="51" type="sunssf" mandatory="true" />
-      <point id="WChaDisChaMax_SF" offset="52" type="sunssf"  mandatory="true" />
-      <point id="DisChaRte_SF" offset="53" type="sunssf" />
-      <point id="SoC_SF" offset="54" type="sunssf" mandatory="true" />
-      <point id="DoD_SF" offset="55" type="sunssf" />
-      <point id="SoH_SF" offset="56" type="sunssf" />
-      <point id="V_SF" offset="57" type="sunssf" mandatory="true" />
-      <point id="CellV_SF" offset="58" type="sunssf" mandatory="true" />
-      <point id="A_SF" offset="59" type="sunssf" mandatory="true" />
-      <point id="AMax_SF" offset="60" type="sunssf" mandatory="true" />
-      <point id="W_SF" offset="61" type="sunssf" />
+      <point id="AHRtg_SF" offset="50" type="sunssf" len="1" mandatory="true" />
+      <point id="WHRtg_SF" offset="51" type="sunssf" len="1" mandatory="true" />
+      <point id="WChaDisChaMax_SF" offset="52" type="sunssf" len="1" mandatory="true" />
+      <point id="DisChaRte_SF" offset="53" type="sunssf" len="1" />
+      <point id="SoC_SF" offset="54" type="sunssf" len="1" mandatory="true" />
+      <point id="DoD_SF" offset="55" type="sunssf" len="1" />
+      <point id="SoH_SF" offset="56" type="sunssf" len="1" />
+      <point id="V_SF" offset="57" type="sunssf" len="1" mandatory="true" />
+      <point id="CellV_SF" offset="58" type="sunssf" len="1" mandatory="true" />
+      <point id="A_SF" offset="59" type="sunssf" len="1" mandatory="true" />
+      <point id="AMax_SF" offset="60" type="sunssf" len="1" mandatory="true" />
+      <point id="W_SF" offset="61" type="sunssf" len="1" />
     </block>
   </model>
   <strings id="802" locale="en">

--- a/smdx/smdx_00803.xml
+++ b/smdx/smdx_00803.xml
@@ -150,18 +150,18 @@
   <strings id="803" locale="en">
     <model>
       <label>Lithium-Ion Battery Bank Model</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="NStr">
       <label>String Count</label>
       <description>Number of strings in the bank.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="NStrCon">
       <label>Connected String Count</label>
       <description>Number of strings with contactor closed.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModTmpMax">
       <label>Max Module Temperature</label>
@@ -171,12 +171,12 @@
     <point id="ModTmpMaxStr">
       <label>Max Module Temperature String</label>
       <description>String containing the module with maximum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModTmpMaxMod">
       <label>Max Module Temperature Module</label>
       <description>Module with maximum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModTmpMin">
       <label>Min Module Temperature</label>
@@ -186,12 +186,12 @@
     <point id="ModTmpMinStr">
       <label>Min Module Temperature String</label>
       <description>String containing the module with minimum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModTmpMinMod">
       <label>Min Module Temperature Module</label>
       <description>Module with minimum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModTmpAvg">
       <label>Average Module Temperature</label>
@@ -206,7 +206,7 @@
     <point id="StrVMaxStr">
       <label>Max String Voltage String</label>
       <description>String with maximum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrVMin">
       <label>Min String Voltage</label>
@@ -216,7 +216,7 @@
     <point id="StrVMinStr">
       <label>Min String Voltage String</label>
       <description>String with minimum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrVAvg">
       <label>Average String Voltage</label>
@@ -231,7 +231,7 @@
     <point id="StrAMaxStr">
       <label>Max String Current String</label>
       <description>String with the maximum current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrAMin">
       <label>Min String Current</label>
@@ -241,7 +241,7 @@
     <point id="StrAMinStr">
       <label>Min String Current String</label>
       <description>String with the minimum current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrAAvg">
       <label>Average String Current</label>
@@ -251,51 +251,51 @@
     <point id="NCellBal">
       <label>Battery Cell Balancing Count</label>
       <description>Total number of cells that are currently being balanced.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellV_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for cell voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModTmp_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for module temperatures.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="A_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for string currents.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoH_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for string state of health.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoC_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for string state of charge.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="V_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for string voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrNMod">
       <label>Module Count</label>
       <description>Count of modules in the string.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrSt">
       <label>String Status</label>
       <description>Current status of the string.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="STRING_ENABLED">
         <label>String Is Enabled</label>
         <description>String is enabled and will connect next time battery is asked to connect.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_STATUS">
         <label>Contactor Status</label>
@@ -326,7 +326,7 @@
     <point id="StrCellVMaxMod">
       <label>Max Cell Voltage Module</label>
       <description>Module containing the maximum cell voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrCellVMin">
       <label>Min Cell Voltage</label>
@@ -336,7 +336,7 @@
     <point id="StrCellVMinMod">
       <label>Min Cell Voltage Module</label>
       <description>Module containing the minimum cell voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrCellVAvg">
       <label>Average Cell Voltage</label>
@@ -351,7 +351,7 @@
     <point id="StrModTmpMaxMod">
       <label>Max Module Temperature Module</label>
       <description>Module with the maximum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrModTmpMin">
       <label>Min Module Temperature</label>
@@ -361,7 +361,7 @@
     <point id="StrModTmpMinMod">
       <label>Min Module Temperature Module</label>
       <description>Module with the minimum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrModTmpAvg">
       <label>Average Module Temperature</label>
@@ -371,221 +371,221 @@
     <point id="StrDisRsn">
       <label>Disabled Reason</label>
       <description>Reason why the string is currently disabled.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NONE">
         <label>No Reason</label>
         <description>No reason provided.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>Fault</label>
         <description>A fault has occurred which caused the string to be disabled.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MAINTENANCE">
         <label>Maintenance</label>
         <description>The string has been disabled for maintenance reasons.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="EXTERNAL">
         <label>External</label>
         <description>The string has been disabled by an external user or controller.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OTHER">
         <label>Other</label>
         <description>The string has been disabled for some other reason.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StrConSt">
       <label>Contactor Status</label>
       <description>Status of the contactor(s) for the string.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="CONTACTOR_0">
         <label>Contactor 0 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_1">
         <label>Contactor 1 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_2">
         <label>Contactor 2 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_3">
         <label>Contactor 3 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_4">
         <label>Contactor 4 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_5">
         <label>Contactor 5 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_6">
         <label>Contactor 6 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_7">
         <label>Contactor 7 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_8">
         <label>Contactor 8 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_9">
         <label>Contactor 9 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_10">
         <label>Contactor 10 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_11">
         <label>Contactor 11 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_12">
         <label>Contactor 12 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_13">
         <label>Contactor 13 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_14">
         <label>Contactor 14 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_15">
         <label>Contactor 15 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_16">
         <label>Contactor 16 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_17">
         <label>Contactor 17 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_18">
         <label>Contactor 18 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_19">
         <label>Contactor 19 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_20">
         <label>Contactor 20 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_21">
         <label>Contactor 21 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_22">
         <label>Contactor 22 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_23">
         <label>Contactor 23 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_24">
         <label>Contactor 24 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_25">
         <label>Contactor 25 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_26">
         <label>Contactor 26 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_27">
         <label>Contactor 27 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_28">
         <label>Contactor 28 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_29">
         <label>Contactor 29 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_30">
         <label>Contactor 30 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="StrEvt1">
       <label>String Event 1</label>
       <description>Alarms, warnings and status values.  Bit flags.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="COMMUNICATION_ERROR">
         <label>Communication Error</label>
         <description>String is unable to communicate with battery modules.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP_ALARM">
         <label>Over Temperature Alarm</label>
         <description>Battery string has exceeded maximum operating temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP_WARNING">
         <label>Over Temperature  Warning</label>
         <description>Battery string is approaching maximum operating temperature.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP_ALARM">
         <label>Under Temperature Alarm</label>
         <description>Battery string has exceeded minimum operating temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP_WARNING">
         <label>Under Temperature Warning</label>
         <description>Battery string is approaching minimum operating temperature.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_CHARGE_CURRENT_ALARM">
         <label>Over Charge Current Alarm</label>
@@ -610,77 +610,77 @@
       <symbol id="OVER_VOLT_ALARM">
         <label>Over Voltage Alarm</label>
         <description>Battery string voltage has exceeded maximum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_VOLT_WARNING">
         <label>Over Voltage Warning</label>
         <description>Battery string voltage is approaching maximum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_VOLT_ALARM">
         <label>Under Voltage Alarm</label>
         <description>Battery string voltage has exceeded minimum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_VOLT_WARNING">
         <label>Under Voltage Warning</label>
         <description>Battery string voltage is approaching minimum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_SOC_MIN_ALARM">
         <label>Under State of Charge Min Alarm</label>
         <description>Battery string state of charge has reached or exceeded SoCMin</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_SOC_MIN_WARNING">
         <label>Under State of Charge Min Warning</label>
         <description>Battery string state of charge is approaching SoCMin</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_SOC_MAX_ALARM">
         <label>Over State of Charge Max Alarm</label>
         <description>Battery string state of charge has reached or exceeded SoCMax</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_SOC_MAX_WARNING">
         <label>Over State of Charge Max Warning</label>
         <description>Battery string state of charge is approaching SoCMax</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="VOLTAGE_IMBALANCE_WARNING">
         <label>Voltage Imbalance Warning</label>
         <description>A voltage imbalance exists between the modules in the battery string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TEMPERATURE_IMBALANCE_ALARM">
         <label>Temperature Imbalance Alarm</label>
         <description>A temperature imbalance exists between the modules in the battery string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TEMPERATURE_IMBALANCE_WARNING">
         <label>Temperature Imbalance Warning</label>
         <description>A temperature imbalance is developing between the modules in the battery string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_ERROR">
         <label>Contactor Error</label>
         <description>A contactor failed to open or close as requested.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAN_ERROR">
         <label>Fan Error</label>
         <description>One or more battery fans has failed.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="GROUND_FAULT">
         <label>Ground Fault Error</label>
         <description>Ground fault detected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OPEN_DOOR_ERROR">
         <label>Open Door Error</label>
         <description>One or more doors are open.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED_1">
         <label>Reserved</label>
@@ -705,12 +705,12 @@
       <symbol id="CONFIGURATION_ALARM">
         <label>Configuration Alarm</label>
         <description>The battery string has been configured incorrectly and will not operate.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONFIGURATION_WARNING">
         <label>Configuration Warning</label>
         <description>The battery string has been configured incorrectly and may not operate as expected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StrEvt2">
@@ -721,56 +721,56 @@
     <point id="StrEvtVnd1">
       <label>Vendor String Event Bitfield 1</label>
       <description>Vendor defined events.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrEvtVnd2">
       <label>Vendor String Event Bitfield 2</label>
       <description>Vendor defined events.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="StrConFail">
       <label>Connection Failure Reason</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="NO_FAILURE">
         <label>No Failure</label>
         <description>Connect did not fail.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="BUTTON_PUSHED">
         <label>Button Pushed</label>
         <description>A button was pushed which prevented connection.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STR_GROUND_FAULT">
         <label>Ground Fault</label>
         <description>Ground fault during auto-connect.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OUTSIDE_VOLTAGE_RANGE">
         <label>Outside Voltage Range</label>
         <description>Outside voltage target window during auto-connect.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STRING_NOT_ENABLED">
         <label>String Not Enabled</label>
         <description>The string is not enabled.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FUSE_OPEN">
         <label>Fuse Open</label>
         <description>A fuse is open which prevents connection.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_FAILURE">
         <label>Contactor Failure</label>
         <description>A contactor failed to operate.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="PRECHARGE_FAILURE">
         <label>Precharge Failure</label>
         <description>A failure during precharge occurred.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STRING_FAULT">
         <label>String Fault</label>
@@ -785,12 +785,12 @@
       <symbol id="ENABLE_STRING">
         <label>Enable String</label>
         <description>Enable the string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DISABLE_STRING">
         <label>Disable String</label>
         <description>Disable the string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="StrSetCon">
@@ -800,12 +800,12 @@
       <symbol id="CONNECT_STRING">
         <label>Connect String</label>
         <description>Connect the string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DISCONNECT_STRING">
         <label>Disconnect String</label>
         <description>Disconnect the string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Pad1">

--- a/smdx/smdx_00803.xml
+++ b/smdx/smdx_00803.xml
@@ -2,41 +2,41 @@
 
   <!-- 803: Lithium-Ion Battery Model -->
   <model id="803" len="58" name="lithium_ion_bank">
-    <block len="26">
-      <point id="NStr" offset="0" type="uint16" mandatory="true" />
-      <point id="NStrCon" offset="1" type="uint16" mandatory="true" />
-      <point id="ModTmpMax" offset="2" type="int16" sf="ModTmp_SF" units="" mandatory="true" />
-      <point id="ModTmpMaxStr" offset="3" type="uint16" />
-      <point id="ModTmpMaxMod" offset="4" type="uint16" />
-      <point id="ModTmpMin" offset="5" type="int16" sf="ModTmp_SF" units="C" mandatory="true" />
-      <point id="ModTmpMinStr" offset="6" type="uint16" />
-      <point id="ModTmpMinMod" offset="7" type="uint16" />
-      <point id="ModTmpAvg" offset="8" type="int16" />
-      <point id="StrVMax" offset="9" type="uint16" sf="V_SF" units="V" />
-      <point id="StrVMaxStr" offset="10" type="uint16" />
-      <point id="StrVMin" offset="11" type="uint16" sf="V_SF" units="V" />
-      <point id="StrVMinStr" offset="12" type="uint16" />
-      <point id="StrVAvg" offset="13" type="uint16" sf="V_SF" units="V" />
-      <point id="StrAMax" offset="14" type="int16" sf="A_SF" units="A" />
-      <point id="StrAMaxStr" offset="15" type="uint16" />
-      <point id="StrAMin" offset="16" type="int16" sf="A_SF" units="A" />
-      <point id="StrAMinStr" offset="17" type="uint16" />
-      <point id="StrAAvg" offset="18" type="int16" sf="A_SF" units="A" />
-      <point id="NCellBal" offset="19" type="uint16" />
-      <point id="CellV_SF" offset="20" type="sunssf" mandatory="true" />
-      <point id="ModTmp_SF" offset="21" type="sunssf" mandatory="true" />
-      <point id="A_SF" offset="22" type="sunssf" mandatory="true" />
-      <point id="SoH_SF" offset="23" type="sunssf" />
-      <point id="SoC_SF" offset="24" type="sunssf" mandatory="true" />
-      <point id="V_SF" offset="25" type="sunssf" mandatory="false" />
+    <block len="26" type="fixed">
+      <point id="NStr" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="NStrCon" offset="1" type="uint16" len="1" mandatory="true" />
+      <point id="ModTmpMax" offset="2" type="int16" len="1" sf="ModTmp_SF" mandatory="true" />
+      <point id="ModTmpMaxStr" offset="3" type="uint16" len="1" />
+      <point id="ModTmpMaxMod" offset="4" type="uint16" len="1" />
+      <point id="ModTmpMin" offset="5" type="int16" len="1" sf="ModTmp_SF" units="C" mandatory="true" />
+      <point id="ModTmpMinStr" offset="6" type="uint16" len="1" />
+      <point id="ModTmpMinMod" offset="7" type="uint16" len="1" />
+      <point id="ModTmpAvg" offset="8" type="int16" len="1" />
+      <point id="StrVMax" offset="9" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="StrVMaxStr" offset="10" type="uint16" len="1" />
+      <point id="StrVMin" offset="11" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="StrVMinStr" offset="12" type="uint16" len="1" />
+      <point id="StrVAvg" offset="13" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="StrAMax" offset="14" type="int16" len="1" sf="A_SF" units="A" />
+      <point id="StrAMaxStr" offset="15" type="uint16" len="1" />
+      <point id="StrAMin" offset="16" type="int16" len="1" sf="A_SF" units="A" />
+      <point id="StrAMinStr" offset="17" type="uint16" len="1" />
+      <point id="StrAAvg" offset="18" type="int16" len="1" sf="A_SF" units="A" />
+      <point id="NCellBal" offset="19" type="uint16" len="1" />
+      <point id="CellV_SF" offset="20" type="sunssf" len="1" mandatory="true" />
+      <point id="ModTmp_SF" offset="21" type="sunssf" len="1" mandatory="true" />
+      <point id="A_SF" offset="22" type="sunssf" len="1" mandatory="true" />
+      <point id="SoH_SF" offset="23" type="sunssf" len="1" />
+      <point id="SoC_SF" offset="24" type="sunssf" len="1" mandatory="true" />
+      <point id="V_SF" offset="25" type="sunssf" len="1" />
     </block>
-    <block type="repeating" len="32" name="string">
-      <point id="StrNMod" offset="0" type="uint16" mandatory="true" />
-      <point id="StrSt" offset="1" type="bitfield32" mandatory="true">
+    <block len="32" type="repeating" name="string">
+      <point id="StrNMod" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="StrSt" offset="1" type="bitfield32" len="2" mandatory="true" >
         <symbol id="STRING_ENABLED">0</symbol>
         <symbol id="CONTACTOR_STATUS">1</symbol>
       </point>
-      <point id="StrConFail" offset="3" type="enum16" >
+      <point id="StrConFail" offset="3" type="enum16" len="1" >
         <symbol id="NO_FAILURE">0</symbol>
         <symbol id="BUTTON_PUSHED">1</symbol>
         <symbol id="STR_GROUND_FAULT">2</symbol>
@@ -47,27 +47,27 @@
         <symbol id="PRECHARGE_FAILURE">7</symbol>
         <symbol id="STRING_FAULT">8</symbol>
       </point>
-      <point id="StrSoC" offset="4" type="uint16" sf="SoC_SF" units="%" mandatory="true" />
-      <point id="StrSoH" offset="5" type="uint16" sf="SoH_SF" units="%" />
-      <point id="StrA" offset="6" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="StrCellVMax" offset="7" type="uint16" sf="CellV_SF" units="V" mandatory="true" />
-      <point id="StrCellVMaxMod" offset="8" type="uint16" />
-      <point id="StrCellVMin" offset="9" type="uint16" sf="CellV_SF" units="V" mandatory="true" />
-      <point id="StrCellVMinMod" offset="10" type="uint16" />
-      <point id="StrCellVAvg" offset="11" type="uint16" sf="CellV_SF" units="V" mandatory="true" />
-      <point id="StrModTmpMax" offset="12" type="int16" sf="ModTmp_SF" units="C" mandatory="true" />
-      <point id="StrModTmpMaxMod" offset="13" type="uint16" />
-      <point id="StrModTmpMin" offset="14" type="int16" sf="ModTmp_SF" units="C" mandatory="true" />
-      <point id="StrModTmpMinMod" offset="15" type="uint16" />
-      <point id="StrModTmpAvg" offset="16" type="int16" sf="ModTmp_SF" units="C" mandatory="true" />
-      <point id="StrDisRsn" offset="17" type="enum16" mandatory="false">
+      <point id="StrSoC" offset="4" type="uint16" len="1" sf="SoC_SF" units="%" mandatory="true" />
+      <point id="StrSoH" offset="5" type="uint16" len="1" sf="SoH_SF" units="%" />
+      <point id="StrA" offset="6" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="StrCellVMax" offset="7" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="StrCellVMaxMod" offset="8" type="uint16" len="1" />
+      <point id="StrCellVMin" offset="9" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="StrCellVMinMod" offset="10" type="uint16" len="1" />
+      <point id="StrCellVAvg" offset="11" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="StrModTmpMax" offset="12" type="int16" len="1" sf="ModTmp_SF" units="C" mandatory="true" />
+      <point id="StrModTmpMaxMod" offset="13" type="uint16" len="1" />
+      <point id="StrModTmpMin" offset="14" type="int16" len="1" sf="ModTmp_SF" units="C" mandatory="true" />
+      <point id="StrModTmpMinMod" offset="15" type="uint16" len="1" />
+      <point id="StrModTmpAvg" offset="16" type="int16" len="1" sf="ModTmp_SF" units="C" mandatory="true" />
+      <point id="StrDisRsn" offset="17" type="enum16" len="1" >
         <symbol id="NONE">0</symbol>
         <symbol id="FAULT">1</symbol>
         <symbol id="MAINTENANCE">2</symbol>
         <symbol id="EXTERNAL">3</symbol>
         <symbol id="OTHER">4</symbol>
       </point>
-      <point id="StrConSt" offset="18" type="bitfield32" units="" >
+      <point id="StrConSt" offset="18" type="bitfield32" len="2" >
         <symbol id="CONTACTOR_0">0</symbol>
         <symbol id="CONTACTOR_1">1</symbol>
         <symbol id="CONTACTOR_2">2</symbol>
@@ -100,7 +100,7 @@
         <symbol id="CONTACTOR_29">29</symbol>
         <symbol id="CONTACTOR_30">30</symbol>
       </point>
-      <point id="StrEvt1" offset="20" type="bitfield32" mandatory="true" >
+      <point id="StrEvt1" offset="20" type="bitfield32" len="2" mandatory="true" >
         <symbol id="COMMUNICATION_ERROR">0</symbol>
         <symbol id="OVER_TEMP_ALARM">1</symbol>
         <symbol id="OVER_TEMP_WARNING">2</symbol>
@@ -132,19 +132,19 @@
         <symbol id="CONFIGURATION_ALARM">28</symbol>
         <symbol id="CONFIGURATION_WARNING">29</symbol>
       </point>
-      <point id="StrEvt2" offset="22" type="bitfield32" />
-      <point id="StrEvtVnd1" offset="24" type="bitfield32" />
-      <point id="StrEvtVnd2" offset="26" type="bitfield32" />
-      <point id="StrSetEna" offset="28" access="rw" type="enum16">
+      <point id="StrEvt2" offset="22" type="bitfield32" len="2" />
+      <point id="StrEvtVnd1" offset="24" type="bitfield32" len="2" />
+      <point id="StrEvtVnd2" offset="26" type="bitfield32" len="2" />
+      <point id="StrSetEna" offset="28" type="enum16" len="1" access="rw" >
         <symbol id="ENABLE_STRING">1</symbol>
         <symbol id="DISABLE_STRING">2</symbol>
       </point>
-      <point id="StrSetCon" offset="29" access="rw" type="enum16">
+      <point id="StrSetCon" offset="29" type="enum16" len="1" access="rw" >
         <symbol id="CONNECT_STRING">1</symbol>
         <symbol id="DISCONNECT_STRING">2</symbol>
       </point>
-      <point id="Pad1" offset="30" type="pad" mandatory="true" />
-      <point id="Pad2" offset="31" type="pad" mandatory="true" />
+      <point id="Pad1" offset="30" type="pad" len="1" mandatory="true" />
+      <point id="Pad2" offset="31" type="pad" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="803" locale="en">
@@ -397,7 +397,7 @@
         <description>The string has been disabled for some other reason.</description>
         <notes></notes>
       </symbol>
-    </point>    
+    </point>
     <point id="StrConSt">
       <label>Contactor Status</label>
       <description>Status of the contactor(s) for the string.</description>
@@ -812,11 +812,11 @@
       <label>Pad</label>
       <description>Pad register.</description>
       <notes> </notes>
-    </point>    
+    </point>
     <point id="Pad2">
       <label>Pad</label>
       <description>Pad register.</description>
       <notes> </notes>
-    </point>    
+    </point>
    </strings>
 </sunSpecModels>

--- a/smdx/smdx_00804.xml
+++ b/smdx/smdx_00804.xml
@@ -146,8 +146,8 @@
 
     <model>
       <label>Lithium-Ion String Model</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
 
     <!-- Fixed Block Strings -->
@@ -160,16 +160,16 @@
     <point id="NMod">
       <label>Module Count</label>
       <description>Count of modules in the string.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="St">
       <label>String Status</label>
       <description>Current status of the string.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="STRING_ENABLED">
         <label>String Is Enabled</label>
         <description>String is enabled and will connect next time battery is asked to connect.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_STATUS">
         <label>Contactor Status</label>
@@ -210,7 +210,7 @@
     <point id="CellVMaxMod">
       <label>Max Cell Voltage Module</label>
       <description>Module containing the cell with maximum cell voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVMin">
       <label>Min Cell Voltage</label>
@@ -220,7 +220,7 @@
     <point id="CellVMinMod">
       <label>Min Cell Voltage Module</label>
       <description>Module containing the cell with minimum cell voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVAvg">
       <label>Average Cell Voltage</label>
@@ -235,7 +235,7 @@
     <point id="ModTmpMaxMod">
       <label>Max Module Temperature Module</label>
       <description>Module with the maximum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModTmpMin">
       <label>Min Module Temperature</label>
@@ -245,7 +245,7 @@
     <point id="ModTmpMinMod">
       <label>Min Module Temperature Module</label>
       <description>Module with the minimum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModTmpAvg">
       <label>Average Module Temperature</label>
@@ -255,196 +255,196 @@
     <point id="Pad1">
       <label>Pad</label>
       <description>Pad register.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ConSt">
       <label>Contactor Status</label>
       <description>Status of the contactor(s) for the string.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="CONTACTOR_0">
         <label>Contactor 0 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_1">
         <label>Contactor 1 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_2">
         <label>Contactor 2 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_3">
         <label>Contactor 3 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_4">
         <label>Contactor 4 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_5">
         <label>Contactor 5 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_6">
         <label>Contactor 6 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_7">
         <label>Contactor 7 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_8">
         <label>Contactor 8 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_9">
         <label>Contactor 9 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_10">
         <label>Contactor 10 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_11">
         <label>Contactor 11 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_12">
         <label>Contactor 12 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_13">
         <label>Contactor 13 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_14">
         <label>Contactor 14 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_15">
         <label>Contactor 15 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_16">
         <label>Contactor 16 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_17">
         <label>Contactor 17 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_18">
         <label>Contactor 18 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_19">
         <label>Contactor 19 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_20">
         <label>Contactor 20 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_21">
         <label>Contactor 21 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_22">
         <label>Contactor 22 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_23">
         <label>Contactor 23 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_24">
         <label>Contactor 24 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_25">
         <label>Contactor 25 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_26">
         <label>Contactor 26 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_27">
         <label>Contactor 27 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_28">
         <label>Contactor 28 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_29">
         <label>Contactor 29 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_30">
         <label>Contactor 30 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="Evt1">
       <label>String Event 1</label>
       <description>Alarms, warnings and status values.  Bit flags.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="COMMUNICATION_ERROR">
         <label>Communication Error</label>
         <description>String is unable to communicate with battery modules.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP_ALARM">
         <label>Over Temperature Alarm</label>
         <description>Battery string has exceeded maximum operating temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP_WARNING">
         <label>Over Temperature  Warning</label>
         <description>Battery string is approaching maximum operating temperature.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP_ALARM">
         <label>Under Temperature Alarm</label>
         <description>Battery string has exceeded minimum operating temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP_WARNING">
         <label>Under Temperature Warning</label>
         <description>Battery string is approaching minimum operating temperature.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_CHARGE_CURRENT_ALARM">
         <label>Over Charge Current Alarm</label>
@@ -469,77 +469,77 @@
       <symbol id="OVER_VOLT_ALARM">
         <label>Over Voltage Alarm</label>
         <description>Battery string voltage has exceeded maximum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_VOLT_WARNING">
         <label>Over Voltage Warning</label>
         <description>Battery string voltage is approaching maximum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_VOLT_ALARM">
         <label>Under Voltage Alarm</label>
         <description>Battery string voltage has exceeded minimum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_VOLT_WARNING">
         <label>Under Voltage Warning</label>
         <description>Battery string voltage is approaching minimum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_SOC_MIN_ALARM">
         <label>Under State of Charge Min Alarm</label>
         <description>Battery string state of charge has reached or exceeded SoCMin.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_SOC_MIN_WARNING">
         <label>Under State of Charge Min Warning</label>
         <description>Battery string state of charge is approaching SoCMin.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_SOC_MAX_ALARM">
         <label>Over State of Charge Max Alarm</label>
         <description>Battery string state of charge has reached or exceeded SoCMax.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_SOC_MAX_WARNING">
         <label>Over State of Charge Max Warning</label>
         <description>Battery string state of charge is approaching SoCMax.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="VOLTAGE_IMBALANCE_WARNING">
         <label>Voltage Imbalance Warning</label>
         <description>A voltage imbalance exists between the modules in the battery string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TEMPERATURE_IMBALANCE_ALARM">
         <label>Temperature Imbalance Alarm</label>
         <description>A temperature imbalance exists between the modules in the battery string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="TEMPERATURE_IMBALANCE_WARNING">
         <label>Temperature Imbalance Warning</label>
         <description>A temperature imbalance is developing between the modules in the battery string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_ERROR">
         <label>Contactor Error</label>
         <description>A contactor failed to open or close as requested.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAN_ERROR">
         <label>Fan Error</label>
         <description>One or more battery fans has failed.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="GROUND_FAULT">
         <label>Ground Fault Error</label>
         <description>Ground fault detected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OPEN_DOOR_ERROR">
         <label>Open Door Error</label>
         <description>One or more doors are open.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED_1">
         <label>Reserved</label>
@@ -564,12 +564,12 @@
       <symbol id="CONFIGURATION_ALARM">
         <label>Configuration Alarm</label>
         <description>The battery string has been configured incorrectly and will not operate as expected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONFIGURATION_WARNING">
         <label>Configuration Warning</label>
         <description>The battery string has been configured incorrectly and may not operate as expected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Evt2">
@@ -580,56 +580,56 @@
     <point id="EvtVnd1">
       <label>Vendor Event Bitfield 1</label>
       <description>Vendor defined events.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd2">
       <label>Vendor Event Bitfield 2</label>
       <description>Vendor defined events.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ConFail">
       <label>Connection Failure Reason</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="NO_FAILURE">
         <label>No Failure</label>
         <description>Connect did not fail.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="BUTTON_PUSHED">
         <label>Button Pushed</label>
         <description>A button was pushed which prevented connection.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STR_GROUND_FAULT">
         <label>Ground Fault</label>
         <description>Ground fault during auto-connect.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OUTSIDE_VOLTAGE_RANGE">
         <label>Outside Voltage Range</label>
         <description>Outside voltage target window during auto-connect.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STRING_NOT_ENABLED">
         <label>String Not Enabled</label>
         <description>The string is not enabled.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FUSE_OPEN">
         <label>Fuse Open</label>
         <description>A fuse is open which prevents connection.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_FAILURE">
         <label>Contactor Failure</label>
         <description>A contactor failed to operate.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="PRECHARGE_FAILURE">
         <label>Precharge Failure</label>
         <description>A precharge failure occurred.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="STRING_FAULT">
         <label>String Fault</label>
@@ -640,7 +640,7 @@
     <point id="SetEna">
       <label>Enable/Disable String</label>
       <description>Enables and disables the string.  Should reset to 0 upon completion.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SetCon">
       <label>Connect/Disconnect String</label>
@@ -649,73 +649,73 @@
       <symbol id="CONNECT_STRING">
         <label>Connect String</label>
         <description>Connect the string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DISCONNECT_STRING">
         <label>Disconnect String</label>
         <description>Disconnect the string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="NCellBal">
       <label>String Cell Balancing Count</label>
       <description>Number of cells currently being balanced in the string.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="NCyc">
       <label>String Cycle Count</label>
       <description>Number of discharge cycles executed upon the string.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoC_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for string state of charge.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoH_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for string state of health.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DoD_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for string depth of discharge.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="A_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for string current.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="V_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for string voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellV_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for cell voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModTmp_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for module temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pad2">
       <label>Pad</label>
       <description>Pad register.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pad3">
       <label>Pad</label>
       <description>Pad register.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pad4">
       <label>Pad</label>
       <description>Pad register.</description>
-      <notes></notes>
+      <notes/>
     </point>
 
     <!-- Repeating Block Strings -->
@@ -723,17 +723,17 @@
     <point id="ModNCell">
       <label>Module Cell Count</label>
       <description>Count of all cells in the module.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModSoC">
       <label>Module SoC</label>
       <description>Module state of charge, expressed as a percentage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModSoH">
       <label>Module SoH</label>
       <description>Module state of health, expressed as a percentage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModCellVMax">
       <label>Max Cell Voltage</label>
@@ -743,7 +743,7 @@
     <point id="ModCellVMaxCell">
       <label>Max Cell Voltage Cell</label>
       <description>Cell with maximum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModCellVMin">
       <label>Min Cell Voltage</label>
@@ -753,7 +753,7 @@
     <point id="ModCellVMinCell">
       <label>Min Cell Voltage Cell</label>
       <description>Cell with minimum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModCellVAvg">
       <label>Average Cell Voltage</label>
@@ -768,7 +768,7 @@
     <point id="ModCellTmpMaxCell">
       <label>Max Cell Temperature Cell</label>
       <description>Cell with maximum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModCellTmpMin">
       <label>Min Cell Temperature</label>
@@ -778,7 +778,7 @@
     <point id="ModCellTmpMinCell">
       <label>Min Cell Temperature Cell</label>
       <description>Cell with minimum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModCellTmpAvg">
       <label>Average Cell Temperature</label>
@@ -788,17 +788,17 @@
     <point id="Pad5">
       <label>Pad</label>
       <description>Pad register.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pad6">
       <label>Pad</label>
       <description>Pad register.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pad7">
       <label>Pad</label>
       <description>Pad register.</description>
-      <notes></notes>
+      <notes/>
     </point>
 
    </strings>

--- a/smdx/smdx_00804.xml
+++ b/smdx/smdx_00804.xml
@@ -2,14 +2,14 @@
 
   <!-- 804: Lithium-ion String Model -->
   <model id="804" len="62" name="lithium_ion_string">
-    <block len="46">
-      <point id="Idx" offset="0" type="uint16" mandatory="true" />
-      <point id="NMod" offset="1" type="uint16" mandatory="true" />
-      <point id="St" offset="2" type="bitfield32" mandatory="true">
+    <block len="46" type="fixed">
+      <point id="Idx" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="NMod" offset="1" type="uint16" len="1" mandatory="true" />
+      <point id="St" offset="2" type="bitfield32" len="2" mandatory="true" >
         <symbol id="STRING_ENABLED">0</symbol>
         <symbol id="CONTACTOR_STATUS">1</symbol>
       </point>
-      <point id="ConFail" offset="4" type="enum16">
+      <point id="ConFail" offset="4" type="enum16" len="1" >
         <symbol id="NO_FAILURE">0</symbol>
         <symbol id="BUTTON_PUSHED">1</symbol>
         <symbol id="STR_GROUND_FAULT">2</symbol>
@@ -20,25 +20,25 @@
         <symbol id="PRECHARGE_FAILURE">7</symbol>
         <symbol id="STRING_FAULT">8</symbol>
       </point>
-      <point id="NCellBal" offset="5" type="uint16" />
-      <point id="SoC" offset="6" type="uint16" sf="SoC_SF" units="%" mandatory="true" />
-      <point id="DoD" offset="7" type="uint16" sf="DoD_SF" units="%" />
-      <point id="NCyc" offset="8" type="uint32" />
-      <point id="SoH" offset="10" type="uint16" sf="SoH_SF" units="%" />
-      <point id="A" offset="11" type="int16" sf="A_SF" units="A" mandatory="true" />
-      <point id="V" offset="12" type="uint16" sf="V_SF" units="V" />
-      <point id="CellVMax" offset="13" type="uint16" sf="CellV_SF" units="V" mandatory="true" />
-      <point id="CellVMaxMod" offset="14" type="uint16" />
-      <point id="CellVMin" offset="15" type="uint16" sf="CellV_SF" units="V" mandatory="true" />
-      <point id="CellVMinMod" offset="16" type="uint16" />
-      <point id="CellVAvg" offset="17" type="uint16" sf="CellV_SF" units="V" mandatory="true" />
-      <point id="ModTmpMax" offset="18" type="int16" sf="ModTmp_SF" units="C" mandatory="true" />
-      <point id="ModTmpMaxMod" offset="19" type="uint16" mandatory="true" />
-      <point id="ModTmpMin" offset="20" type="int16" sf="ModTmp_SF" units="C" mandatory="true" />
-      <point id="ModTmpMinMod" offset="21" type="uint16" mandatory="true" />
-      <point id="ModTmpAvg" offset="22" type="int16" sf="ModTmp_SF" units="C" mandatory="true" />
-      <point id="Pad1" offset="23" type="pad" mandatory="true" />
-      <point id="ConSt" offset="24" type="bitfield32" units="" >
+      <point id="NCellBal" offset="5" type="uint16" len="1" />
+      <point id="SoC" offset="6" type="uint16" len="1" sf="SoC_SF" units="%" mandatory="true" />
+      <point id="DoD" offset="7" type="uint16" len="1" sf="DoD_SF" units="%" />
+      <point id="NCyc" offset="8" type="uint32" len="2" />
+      <point id="SoH" offset="10" type="uint16" len="1" sf="SoH_SF" units="%" />
+      <point id="A" offset="11" type="int16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="V" offset="12" type="uint16" len="1" sf="V_SF" units="V" />
+      <point id="CellVMax" offset="13" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="CellVMaxMod" offset="14" type="uint16" len="1" />
+      <point id="CellVMin" offset="15" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="CellVMinMod" offset="16" type="uint16" len="1" />
+      <point id="CellVAvg" offset="17" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="ModTmpMax" offset="18" type="int16" len="1" sf="ModTmp_SF" units="C" mandatory="true" />
+      <point id="ModTmpMaxMod" offset="19" type="uint16" len="1" mandatory="true" />
+      <point id="ModTmpMin" offset="20" type="int16" len="1" sf="ModTmp_SF" units="C" mandatory="true" />
+      <point id="ModTmpMinMod" offset="21" type="uint16" len="1" mandatory="true" />
+      <point id="ModTmpAvg" offset="22" type="int16" len="1" sf="ModTmp_SF" units="C" mandatory="true" />
+      <point id="Pad1" offset="23" type="pad" len="1" mandatory="true" />
+      <point id="ConSt" offset="24" type="bitfield32" len="2" >
         <symbol id="CONTACTOR_0">0</symbol>
         <symbol id="CONTACTOR_1">1</symbol>
         <symbol id="CONTACTOR_2">2</symbol>
@@ -71,7 +71,7 @@
         <symbol id="CONTACTOR_29">29</symbol>
         <symbol id="CONTACTOR_30">30</symbol>
       </point>
-      <point id="Evt1" offset="26" type="bitfield32" mandatory="true">
+      <point id="Evt1" offset="26" type="bitfield32" len="2" mandatory="true" >
         <symbol id="COMMUNICATION_ERROR">0</symbol>
         <symbol id="OVER_TEMP_ALARM">1</symbol>
         <symbol id="OVER_TEMP_WARNING">2</symbol>
@@ -103,42 +103,42 @@
         <symbol id="CONFIGURATION_ALARM">28</symbol>
         <symbol id="CONFIGURATION_WARNING">29</symbol>
       </point>
-      <point id="Evt2" offset="28" type="bitfield32" />
-      <point id="EvtVnd1" offset="30" type="bitfield32" />
-      <point id="EvtVnd2" offset="32" type="bitfield32" />
-      <point id="SetEna" offset="34" access="rw" type="enum16" />
-      <point id="SetCon" offset="35" access="rw" type="enum16">
+      <point id="Evt2" offset="28" type="bitfield32" len="2" />
+      <point id="EvtVnd1" offset="30" type="bitfield32" len="2" />
+      <point id="EvtVnd2" offset="32" type="bitfield32" len="2" />
+      <point id="SetEna" offset="34" type="enum16" len="1" access="rw" />
+      <point id="SetCon" offset="35" type="enum16" len="1" access="rw" >
         <symbol id="CONNECT_STRING">1</symbol>
         <symbol id="DISCONNECT_STRING">2</symbol>
       </point>
-      <point id="SoC_SF" offset="36" type="sunssf" mandatory="true" />
-      <point id="SoH_SF" offset="37" type="sunssf" />
-      <point id="DoD_SF" offset="38" type="sunssf" />
-      <point id="A_SF" offset="39" type="sunssf" mandatory="true" />
-      <point id="V_SF" offset="40" type="sunssf" />
-      <point id="CellV_SF" offset="41" type="sunssf" mandatory="true" />
-      <point id="ModTmp_SF" offset="42" type="sunssf" mandatory="true" />
-      <point id="Pad2" offset="43" type="pad" mandatory="true" />
-      <point id="Pad3" offset="44" type="pad" mandatory="true" />
-      <point id="Pad4" offset="45" type="pad" mandatory="true" />
+      <point id="SoC_SF" offset="36" type="sunssf" len="1" mandatory="true" />
+      <point id="SoH_SF" offset="37" type="sunssf" len="1" />
+      <point id="DoD_SF" offset="38" type="sunssf" len="1" />
+      <point id="A_SF" offset="39" type="sunssf" len="1" mandatory="true" />
+      <point id="V_SF" offset="40" type="sunssf" len="1" />
+      <point id="CellV_SF" offset="41" type="sunssf" len="1" mandatory="true" />
+      <point id="ModTmp_SF" offset="42" type="sunssf" len="1" mandatory="true" />
+      <point id="Pad2" offset="43" type="pad" len="1" mandatory="true" />
+      <point id="Pad3" offset="44" type="pad" len="1" mandatory="true" />
+      <point id="Pad4" offset="45" type="pad" len="1" mandatory="true" />
     </block>
-    <block type="repeating" len="16" name="lithium_ion_string_module">
-      <point id="ModNCell" offset="0" type="uint16" mandatory="true" />
-      <point id="ModSoC" offset="1" type="uint16" sf="SoC_SF" units="%" />
-      <point id="ModSoH" offset="2" type="uint16" sf="SoH_SF" units="%" />
-      <point id="ModCellVMax" offset="3" sf="CellV_SF" units="V" type="uint16" mandatory="true" />
-      <point id="ModCellVMaxCell" offset="4" type="uint16" />
-      <point id="ModCellVMin" offset="5" sf="CellV_SF" units="V" type="uint16" mandatory="true" />
-      <point id="ModCellVMinCell" offset="6" sf="CellV_SF" units="V" type="uint16" />
-      <point id="ModCellVAvg" offset="7" sf="CellV_SF" units="V" type="uint16" mandatory="true" />
-      <point id="ModCellTmpMax" offset="8" sf="ModTmp_SF" units="C" type="int16" mandatory="true" />
-      <point id="ModCellTmpMaxCell" offset="9" type="uint16" />
-      <point id="ModCellTmpMin" offset="10" sf="ModTmp_SF" units="C" type="int16" mandatory="true" />
-      <point id="ModCellTmpMinCell" offset="11" type="uint16" />
-      <point id="ModCellTmpAvg" offset="12" sf="ModTmp_SF" units="C" type="int16" mandatory="true" />
-      <point id="Pad5" offset="13" type="pad" mandatory="true" />
-      <point id="Pad6" offset="14" type="pad" mandatory="true" />
-      <point id="Pad7" offset="15" type="pad" mandatory="true" />
+    <block len="16" type="repeating" name="lithium_ion_string_module">
+      <point id="ModNCell" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="ModSoC" offset="1" type="uint16" len="1" sf="SoC_SF" units="%" />
+      <point id="ModSoH" offset="2" type="uint16" len="1" sf="SoH_SF" units="%" />
+      <point id="ModCellVMax" offset="3" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="ModCellVMaxCell" offset="4" type="uint16" len="1" />
+      <point id="ModCellVMin" offset="5" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="ModCellVMinCell" offset="6" type="uint16" len="1" sf="CellV_SF" units="V" />
+      <point id="ModCellVAvg" offset="7" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="ModCellTmpMax" offset="8" type="int16" len="1" sf="ModTmp_SF" units="C" mandatory="true" />
+      <point id="ModCellTmpMaxCell" offset="9" type="uint16" len="1" />
+      <point id="ModCellTmpMin" offset="10" type="int16" len="1" sf="ModTmp_SF" units="C" mandatory="true" />
+      <point id="ModCellTmpMinCell" offset="11" type="uint16" len="1" />
+      <point id="ModCellTmpAvg" offset="12" type="int16" len="1" sf="ModTmp_SF" units="C" mandatory="true" />
+      <point id="Pad5" offset="13" type="pad" len="1" mandatory="true" />
+      <point id="Pad6" offset="14" type="pad" len="1" mandatory="true" />
+      <point id="Pad7" offset="15" type="pad" len="1" mandatory="true" />
     </block>
   </model>
 
@@ -256,7 +256,7 @@
       <label>Pad</label>
       <description>Pad register.</description>
       <notes></notes>
-    </point>    
+    </point>
     <point id="ConSt">
       <label>Contactor Status</label>
       <description>Status of the contactor(s) for the string.</description>
@@ -706,17 +706,17 @@
       <label>Pad</label>
       <description>Pad register.</description>
       <notes></notes>
-    </point>    
+    </point>
     <point id="Pad3">
       <label>Pad</label>
       <description>Pad register.</description>
       <notes></notes>
-    </point>    
+    </point>
     <point id="Pad4">
       <label>Pad</label>
       <description>Pad register.</description>
       <notes></notes>
-    </point>    
+    </point>
 
     <!-- Repeating Block Strings -->
 
@@ -789,17 +789,17 @@
       <label>Pad</label>
       <description>Pad register.</description>
       <notes></notes>
-    </point>    
+    </point>
     <point id="Pad6">
       <label>Pad</label>
       <description>Pad register.</description>
       <notes></notes>
-    </point>    
+    </point>
     <point id="Pad7">
       <label>Pad</label>
       <description>Pad register.</description>
       <notes></notes>
-    </point>    
+    </point>
 
    </strings>
 </sunSpecModels>

--- a/smdx/smdx_00805.xml
+++ b/smdx/smdx_00805.xml
@@ -2,38 +2,38 @@
 
   <!-- 805: Lithium-Ion Module Model -->
   <model id="805" len="46" name="lithium-ion-module">
-    <block len="42">
-      <point id="StrIdx" offset="0" type="uint16" mandatory="true" />
-      <point id="ModIdx" offset="1" type="uint16" mandatory="true" />
-      <point id="NCell" offset="2" type="uint16" mandatory="true" />
-      <point id="SoC" offset="3" type="uint16" sf="SoC_SF" units="%" />
-      <point id="DoD" offset="4" type="uint16" sf="DoD_SF" units="%" />
-      <point id="SoH" offset="5" type="uint16" sf="SoH_SF" units="%" />
-      <point id="NCyc" offset="6" type="uint32" />
-      <point id="V" offset="8" sf="V_SF" units="V" type="uint16" mandatory="true" />
-      <point id="CellVMax" offset="9" sf="CellV_SF" units="V" type="uint16" mandatory="true" />
-      <point id="CellVMaxCell" offset="10" type="uint16" />
-      <point id="CellVMin" offset="11" sf="CellV_SF" units="V" type="uint16" mandatory="true" />
-      <point id="CellVMinCell" offset="12" type="uint16" />
-      <point id="CellVAvg" offset="13" sf="CellV_SF" units="V" type="uint16" mandatory="true" />
-      <point id="CellTmpMax" offset="14" sf="Tmp_SF" units="C" type="int16" mandatory="true" />
-      <point id="CellTmpMaxCell" offset="15" type="uint16" />
-      <point id="CellTmpMin" offset="16" sf="Tmp_SF" units="C" type="int16" mandatory="true" />
-      <point id="CellTmpMinCell" offset="17" type="uint16" />
-      <point id="CellTmpAvg" offset="18" sf="Tmp_SF" units="C" type="int16" mandatory="true" />
-      <point id="NCellBal" offset="19" type="uint16" />
-      <point id="SN" offset="20" len="16" type="string" />
-      <point id="SoC_SF" offset="36" type="sunssf" />
-      <point id="SoH_SF" offset="37" type="sunssf" />
-      <point id="DoD_SF" offset="38" type="sunssf" />
-      <point id="V_SF" offset="39" type="sunssf" mandatory="true" />
-      <point id="CellV_SF" offset="40" type="sunssf" mandatory="true" />
-      <point id="Tmp_SF" offset="41" type="sunssf" mandatory="true" />
+    <block len="42" type="fixed">
+      <point id="StrIdx" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="ModIdx" offset="1" type="uint16" len="1" mandatory="true" />
+      <point id="NCell" offset="2" type="uint16" len="1" mandatory="true" />
+      <point id="SoC" offset="3" type="uint16" len="1" sf="SoC_SF" units="%" />
+      <point id="DoD" offset="4" type="uint16" len="1" sf="DoD_SF" units="%" />
+      <point id="SoH" offset="5" type="uint16" len="1" sf="SoH_SF" units="%" />
+      <point id="NCyc" offset="6" type="uint32" len="2" />
+      <point id="V" offset="8" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CellVMax" offset="9" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="CellVMaxCell" offset="10" type="uint16" len="1" />
+      <point id="CellVMin" offset="11" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="CellVMinCell" offset="12" type="uint16" len="1" />
+      <point id="CellVAvg" offset="13" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="CellTmpMax" offset="14" type="int16" len="1" sf="Tmp_SF" units="C" mandatory="true" />
+      <point id="CellTmpMaxCell" offset="15" type="uint16" len="1" />
+      <point id="CellTmpMin" offset="16" type="int16" len="1" sf="Tmp_SF" units="C" mandatory="true" />
+      <point id="CellTmpMinCell" offset="17" type="uint16" len="1" />
+      <point id="CellTmpAvg" offset="18" type="int16" len="1" sf="Tmp_SF" units="C" mandatory="true" />
+      <point id="NCellBal" offset="19" type="uint16" len="1" />
+      <point id="SN" offset="20" type="string" len="16" />
+      <point id="SoC_SF" offset="36" type="sunssf" len="1" />
+      <point id="SoH_SF" offset="37" type="sunssf" len="1" />
+      <point id="DoD_SF" offset="38" type="sunssf" len="1" />
+      <point id="V_SF" offset="39" type="sunssf" len="1" mandatory="true" />
+      <point id="CellV_SF" offset="40" type="sunssf" len="1" mandatory="true" />
+      <point id="Tmp_SF" offset="41" type="sunssf" len="1" mandatory="true" />
     </block>
-    <block type="repeating" len="4" name="lithium-ion-module-cell">
-      <point id="CellV" offset="0" sf="CellV_SF" units="V" type="uint16" mandatory="true" />
-      <point id="CellTmp" offset="1" sf="Tmp_SF" units="C" type="int16" mandatory="true" />
-      <point id="CellSt" offset="2" type="bitfield32">
+    <block len="4" type="repeating" name="lithium-ion-module-cell">
+      <point id="CellV" offset="0" type="uint16" len="1" sf="CellV_SF" units="V" mandatory="true" />
+      <point id="CellTmp" offset="1" type="int16" len="1" sf="Tmp_SF" units="C" mandatory="true" />
+      <point id="CellSt" offset="2" type="bitfield32" len="2" >
         <symbol id="CELL_IS_BALANCING">0</symbol>
       </point>
     </block>

--- a/smdx/smdx_00805.xml
+++ b/smdx/smdx_00805.xml
@@ -43,8 +43,8 @@
 
     <model>
       <label>Lithium-Ion Module Model</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
 
     <!-- Fixed Block Strings -->
@@ -62,17 +62,17 @@
     <point id="NCell">
       <label>Module Cell Count</label>
       <description>Count of all cells in the module.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoC">
       <label>Module SoC</label>
       <description>Module state of charge, expressed as a percentage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoH">
       <label>Module SoH</label>
       <description>Module state of health, expressed as a percentage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="V">
       <label>Module Voltage</label>
@@ -92,7 +92,7 @@
     <point id="CellVMaxCell">
       <label>Max Cell Voltage Cell</label>
       <description>Cell with the maximum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVMin">
       <label>Min Cell Voltage</label>
@@ -102,7 +102,7 @@
     <point id="CellVMinCell">
       <label>Min Cell Voltage Cell</label>
       <description>Cell with the minimum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVAvg">
       <label>Average Cell Voltage</label>
@@ -117,7 +117,7 @@
     <point id="CellTmpMaxCell">
       <label>Max Cell Temperature Cell</label>
       <description>Cell with the maximum cell temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellTmpMin">
       <label>Min Cell Temperature</label>
@@ -127,7 +127,7 @@
     <point id="CellTmpMinCell">
       <label>Min Cell Temperature Cell</label>
       <description>Cell with the minimum cell temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellTmpAvg">
       <label>Average Cell Temperature</label>
@@ -147,34 +147,34 @@
       <description>Count of cycles executed.</description>
     </point>
     <point id="V_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for module voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoC_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for module state of charge.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoH_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for module state of health.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="DoD_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for module depth of discharge.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellV_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for cell voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Tmp_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for module temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
 
     <!-- Repeating Block Strings -->
@@ -192,11 +192,11 @@
     <point id="CellSt">
       <label>Cell Status</label>
       <description>Status of the cell.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="CELL_IS_BALANCING">
         <label>Cell Is Balancing</label>
         <description>Cell is currently being balanced.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
 

--- a/smdx/smdx_00806.xml
+++ b/smdx/smdx_00806.xml
@@ -12,18 +12,18 @@
   <strings id="806" locale="en">
     <model>
       <label>Flow Battery Model</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="BatTBD">
       <label>Battery Points To Be Determined</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="BatStTBD">
       <label>Battery String Points To Be Determined</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
 
    </strings>

--- a/smdx/smdx_00806.xml
+++ b/smdx/smdx_00806.xml
@@ -2,11 +2,11 @@
 
   <!-- 806: Flow Battery Model -->
   <model id="806" len="2" name="flow_battery">
-    <block len="1">
-      <point id="BatTBD" offset="0" type="uint16" mandatory="true" />
+    <block len="1" type="fixed">
+      <point id="BatTBD" offset="0" type="uint16" len="1" mandatory="true" />
     </block>
-    <block type="repeating" len="1" name="battery_string">
-      <point id="BatStTBD" offset="0" type="uint16" mandatory="true" />
+    <block len="1" type="repeating" name="battery_string">
+      <point id="BatStTBD" offset="0" type="uint16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="806" locale="en">

--- a/smdx/smdx_00807.xml
+++ b/smdx/smdx_00807.xml
@@ -193,8 +193,8 @@
   <strings id="807" locale="en">
     <model>
       <label>Flow Battery String Model</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="Idx">
       <label>String Index</label>
@@ -204,12 +204,12 @@
     <point id="NMod">
       <label>Module Count</label>
       <description>Number of modules in this string.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="NModCon">
       <label>Connected Module Count</label>
       <description>Number of electrically connected modules in this string.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModVMax">
       <label>Max Module Voltage</label>
@@ -219,7 +219,7 @@
     <point id="ModVMaxMod">
       <label>Max Module Voltage Module</label>
       <description>Module with the maximum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModVMin">
       <label>Min Module Voltage</label>
@@ -229,7 +229,7 @@
     <point id="ModVMinMod">
       <label>Min Module Voltage Module</label>
       <description>Module with the minimum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModVAvg">
       <label>Average Module Voltage</label>
@@ -244,12 +244,12 @@
     <point id="CellVMaxMod">
       <label>Max Cell Voltage Module</label>
       <description>Module containing the cell with the maximum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVMaxStk">
       <label>Max Cell Voltage Stack</label>
       <description>Stack containing the cell with the maximum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVMin">
       <label>Min Cell Voltage</label>
@@ -259,12 +259,12 @@
     <point id="CellVMinMod">
       <label>Min Cell Voltage Module</label>
       <description>Module containing the cell with the minimum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVMinStk">
       <label>Min Cell Voltage Stack</label>
       <description>Stack containing the cell with the minimum voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellVAvg">
       <label>Average Cell Voltage</label>
@@ -279,7 +279,7 @@
     <point id="TmpMaxMod">
       <label>Max Temperature Module</label>
       <description>Module with the maximum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpMin">
       <label>Min Temperature</label>
@@ -289,7 +289,7 @@
     <point id="TmpMinMod">
       <label>Min Temperature Module</label>
       <description>Module with the minimum temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="TmpAvg">
       <label>Average Temperature</label>
@@ -299,31 +299,31 @@
     <point id="Evt1">
       <label>String Event 1</label>
       <description>Alarms, warnings and status values.  Bit flags.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="COMMUNICATION_ERROR">
         <label>Communication Error</label>
         <description>BMS is unable to communicate with modules.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP_ALARM">
         <label>Over Temperature Alarm</label>
         <description>Battery string has exceeded maximum operating temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP_WARNING">
         <label>Over Temperature  Warning</label>
         <description>Battery string is approaching maximum operating temperature.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP_ALARM">
         <label>Under Temperature Alarm</label>
         <description>Battery string has exceeded minimum operating temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP_WARNING">
         <label>Under Temperature Warning</label>
         <description>Battery string is approaching minimum operating temperature.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_CHARGE_CURRENT_ALARM">
         <label>Over Charge Current Alarm</label>
@@ -348,47 +348,47 @@
       <symbol id="OVER_VOLT_ALARM">
         <label>Over Voltage Alarm</label>
         <description>Battery string voltage has exceeded maximum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_VOLT_WARNING">
         <label>Over Voltage Warning</label>
         <description>Battery string voltage is approaching maximum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_VOLT_ALARM">
         <label>Under Voltage Alarm</label>
         <description>Battery string voltage has exceeded minimum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_VOLT_WARNING">
         <label>Under Voltage Warning</label>
         <description>Battery string voltage is approaching minimum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_SOC_MIN_ALARM">
         <label>Under State of Charge Minimum Alarm</label>
         <description>Battery string state of charge has reached or exceeded SoCMin.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_SOC_MIN_WARNING">
         <label>Under State of Charge Minimum Warning</label>
         <description>Battery string state of charge is approaching SoCMin.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_SOC_MAX_ALARM">
         <label>Over State of Charge Maximum Alarm</label>
         <description>Battery string state of charge has reached or exceeded SoCMax.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_SOC_MAX_WARNING">
         <label>Over State of Charge Maximum Warning</label>
         <description>Battery string state of charge is approaching SoCMax</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="VOLTAGE_IMBALANCE_WARNING">
         <label>Voltage Imbalance Warning</label>
         <description>A voltage imbalance exists between the modules in the string.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED_1">
         <label>Reserved</label>
@@ -403,22 +403,22 @@
       <symbol id="CONTACTOR_ERROR">
         <label>Contactor Error</label>
         <description>A contactor failed to open or close as requested.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAN_ERROR">
         <label>Fan Error</label>
         <description>One or more battery string fans has failed.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="GROUND_FAULT">
         <label>Ground Fault Error</label>
         <description>Ground fault detected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OPEN_DOOR_ERROR">
         <label>Open Door Error</label>
         <description>One or more doors are open.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED_3">
         <label>Reserved</label>
@@ -438,83 +438,83 @@
       <symbol id="FIRE_ALARM">
         <label>Fire Alarm</label>
         <description>A fire has been detected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONFIGURATION_ALARM">
         <label>Configuration Alarm</label>
         <description>The battery string has been configured incorrectly and will not operate.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONFIGURATION_WARNING">
         <label>Configuration Warning</label>
         <description>The battery string has been configured incorrectly and may not operate as expected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="Evt2">
       <label>String Event 2</label>
       <description>Alarms, warnings and status values.  Bit flags.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="LEAK_ALARM">
         <label>Leak Alarm</label>
         <description>A leak has been detected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="PUMP_ALARM">
         <label>Pump Alarm</label>
         <description>A pump has experienced an alarm condition or some other error.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="HIGH_PRESSURE_ALARM">
         <label>High Pressure Alarm</label>
         <description>Pressure exceeds maximum value.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="HIGH_PRESSURE_WARNING">
         <label>High Pressure Warning</label>
         <description>Pressure approaching maximum value.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="LOW_FLOW_ALARM">
         <label>Low Flow Alarm</label>
         <description>Flow exceeds minimum value.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="LOW_FLOW_WARNING">
         <label>Low Flow Warning</label>
         <description>Flow approaching minimum value.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="EvtVnd1">
       <label>Vendor Event Bitfield 1</label>
       <description>Vendor defined events.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="EvtVnd2">
       <label>Vendor Event Bitfield 2</label>
       <description>Vendor defined events.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="CellV_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Tmp_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for temperature.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SoC_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for state of charge.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="OCV_SF">
-      <label></label>
+      <label/>
       <description>Scale factor for open circuit voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Pad1">
       <label>Pad</label>
@@ -532,16 +532,16 @@
     <point id="ModNStk">
       <label>Stack Count</label>
       <description>Number of stacks in this module.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModSt">
       <label>Module Status</label>
       <description>Current status of the module.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="MODULE_ENABLED">
         <label>Module Is Enabled</label>
         <description>Module is enabled and will connect next time battery is asked to connect.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_STATUS">
         <label>Contactor Status</label>
@@ -552,17 +552,17 @@
     <point id="ModSoC">
       <label>Module State of Charge</label>
       <description>State of charge for this module.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModOCV">
       <label>Open Circuit Voltage</label>
       <description>Open circuit voltage for this module.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModV">
       <label>External Voltage</label>
       <description>External voltage fo this module.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModCellVMax">
       <label>Maximum Cell Voltage</label>
@@ -572,7 +572,7 @@
     <point id="ModCellVMaxCell">
       <label>Max Cell Voltage Cell</label>
       <description>Cell with the maximum cell voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModCellVMin">
       <label>Minimum Cell Voltage</label>
@@ -582,7 +582,7 @@
     <point id="ModCellVMinCell">
       <label>Min Cell Voltage Cell</label>
       <description>Cell with the minimum cell voltage.</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="ModCellVAvg">
       <label>Average Cell Voltage</label>
@@ -591,202 +591,202 @@
     </point>
     <point id="ModAnoTmp">
       <label>Anolyte Temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="ModCatTmp">
       <label>Catholyte Temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="ModConSt">
       <label>Contactor Status</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="CONTACTOR_0">
         <label>Contactor 0 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_1">
         <label>Contactor 1 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_2">
         <label>Contactor 2 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_3">
         <label>Contactor 3 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_4">
         <label>Contactor 4 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_5">
         <label>Contactor 5 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_6">
         <label>Contactor 6 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_7">
         <label>Contactor 7 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_8">
         <label>Contactor 8 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_9">
         <label>Contactor 9 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_10">
         <label>Contactor 10 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_11">
         <label>Contactor 11 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_12">
         <label>Contactor 12 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_13">
         <label>Contactor 13 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_14">
         <label>Contactor 14 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_15">
         <label>Contactor 15 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_16">
         <label>Contactor 16 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_17">
         <label>Contactor 17 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_18">
         <label>Contactor 18 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_19">
         <label>Contactor 19 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_20">
         <label>Contactor 20 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_21">
         <label>Contactor 21 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_22">
         <label>Contactor 22 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_23">
         <label>Contactor 23 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_24">
         <label>Contactor 24 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_25">
         <label>Contactor 25 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_26">
         <label>Contactor 26 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_27">
         <label>Contactor 27 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_28">
         <label>Contactor 28 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_29">
         <label>Contactor 29 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_30">
         <label>Contactor 30 Closed</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="ModEvt1">
       <label>Module Event 1</label>
       <description>Alarms, warnings and status values.  Bit flags.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="COMMUNICATION_ERROR">
         <label>Communication Error</label>
         <description>Module is unable to communicate with the BMS or other components.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP_ALARM">
         <label>Over Temperature Alarm</label>
         <description>Module has exceeded maximum operating temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_TEMP_WARNING">
         <label>Over Temperature  Warning</label>
         <description>Module is approaching maximum operating temperature.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP_ALARM">
         <label>Under Temperature Alarm</label>
         <description>Module has exceeded minimum operating temperature</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_TEMP_WARNING">
         <label>Under Temperature Warning</label>
         <description>Module is approaching minimum operating temperature.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_CHARGE_CURRENT_ALARM">
         <label>Over Charge Current Alarm</label>
@@ -811,47 +811,47 @@
       <symbol id="OVER_VOLT_ALARM">
         <label>Over Voltage Alarm</label>
         <description>Module voltage has exceeded maximum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_VOLT_WARNING">
         <label>Over Voltage Warning</label>
         <description>Module voltage is approaching maximum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_VOLT_ALARM">
         <label>Under Voltage Alarm</label>
         <description>Module voltage has exceeded minimum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_VOLT_WARNING">
         <label>Under Voltage Warning</label>
         <description>Module voltage is approaching minimum limit.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_SOC_MIN_ALARM">
         <label>Under State of Charge Minimum Alarm</label>
         <description>Module state of charge has reached or exceeded SoCMin.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="UNDER_SOC_MIN_WARNING">
         <label>Under State of Charge Minimum Warning</label>
         <description>Module state of charge is approaching SoCMin.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_SOC_MAX_ALARM">
         <label>Over State of Charge Maximum Alarm</label>
         <description>Module state of charge has reached or exceeded SoCMax.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OVER_SOC_MAX_WARNING">
         <label>Over State of Charge Maximum Warning</label>
         <description>Module state of charge is approaching SoCMax.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="VOLTAGE_IMBALANCE_WARNING">
         <label>Voltage Imbalance Warning</label>
         <description>A voltage imbalance exists between the stacks in the module.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED_1">
         <label>Reserved</label>
@@ -866,22 +866,22 @@
       <symbol id="CONTACTOR_ERROR">
         <label>Contactor Error</label>
         <description>A contactor failed to open or close as requested.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAN_ERROR">
         <label>Fan Error</label>
         <description>One or more module fans has failed.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="GROUND_FAULT">
         <label>Ground Fault Error</label>
         <description>Ground fault detected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OPEN_DOOR_ERROR">
         <label>Open Door Error</label>
         <description>One or more doors are open.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="RESERVED_3">
         <label>Reserved</label>
@@ -901,97 +901,97 @@
       <symbol id="FIRE_ALARM">
         <label>Fire Alarm</label>
         <description>A fire has been detected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MODULE_CONFIGURATION_ALARM">
         <label>Configuration Alarm</label>
         <description>The battery module has been configured incorrectly and will not operate.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MODULE_CONFIGURATION_WARNING">
         <label>Configuration Warning</label>
         <description>The battery module has been configured incorrectly and may not operate as expected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="ModEvt2">
       <label>Module Event 2</label>
       <description>Alarms, warnings and status values.  Bit flags.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="LEAK_ALARM">
         <label>Leak Alarm</label>
         <description>A leak has been detected.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="PUMP_ALARM">
         <label>Pump Alarm</label>
         <description>A pump has experienced an alarm condition or some other error.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="HIGH_PRESSURE_ALARM">
         <label>High Pressure Alarm</label>
         <description>Pressure exceeds maximum value.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="HIGH_PRESSURE_WARNING">
         <label>High Pressure Warning</label>
         <description>Pressure approaching maximum value.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="LOW_FLOW_ALARM">
         <label>Low Flow Alarm</label>
         <description>Flow exceeds minimum value.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="LOW_FLOW_WARNING">
         <label>Low Flow Warning</label>
         <description>Flow approaching minimum value.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="ModConFail">
       <label>Connection Failure Reason</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="NO_FAILURE">
         <label>No Failure</label>
         <description>Connect did not fail.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="BUTTON_PUSHED">
         <label>Button Pushed</label>
         <description>A button was pushed which prevented connection.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MODULE_GROUND_FAULT">
         <label>Ground Fault</label>
         <description>Ground fault during auto-connect.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OUTSIDE_VOLTAGE_RANGE">
         <label>Outside Voltage Range</label>
         <description>Outside voltage target window during auto-connect.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MODULE_NOT_ENABLED">
         <label>Module  Not Enabled</label>
         <description>The module is not enabled.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FUSE_OPEN">
         <label>Fuse Open</label>
         <description>A fuse is open which prevents connection.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="CONTACTOR_FAILURE">
         <label>Contactor Failure</label>
         <description>A contactor failed to operate.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="PRECHARGE_FAILURE">
         <label>Precharge Failure</label>
         <description>A failure during precharge occurred.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MODULE_FAULT">
         <label>Module Fault</label>
@@ -1006,12 +1006,12 @@
       <symbol id="ENABLE_MODULE">
         <label>Enable Module</label>
         <description>Enable the module.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DISABLE_MODULE">
         <label>Disable Module</label>
         <description>Disable the module.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="ModSetCon">
@@ -1021,42 +1021,42 @@
       <symbol id="CONNECT_MODULE">
         <label>Connect Module</label>
         <description>Connect the module.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="DISCONNECT_MODULE">
         <label>Disconnect Module</label>
         <description>Disconnect the module.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
     <point id="ModDisRsn">
       <label>Disabled Reason</label>
       <description>Reason why the module is currently disabled.</description>
-      <notes></notes>
+      <notes/>
       <symbol id="NONE">
         <label>No Reason</label>
         <description>No reason provided.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="FAULT">
         <label>Fault</label>
         <description>A fault has occurred which caused the module to be disabled.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="MAINTENANCE">
         <label>Maintenance</label>
         <description>The module has been disabled for maintenance reasons.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="EXTERNAL">
         <label>External</label>
         <description>The module has been disabled by an external user or controller.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
       <symbol id="OTHER">
         <label>Other</label>
         <description>The module has been disabled for some other reason.</description>
-        <notes></notes>
+        <notes/>
       </symbol>
     </point>
 

--- a/smdx/smdx_00807.xml
+++ b/smdx/smdx_00807.xml
@@ -2,28 +2,28 @@
 
   <!-- 807: Flow Battery String Model -->
   <model id="807" len="58" name="flow_battery_string">
-    <block len="34">
-      <point id="Idx" offset="0" type="uint16" mandatory="true" />
-      <point id="NMod" offset="1" type="uint16" mandatory="true" />
-      <point id="NModCon" offset="2" type="uint16" mandatory="true" />
-      <point id="ModVMax" offset="3" type="uint16" sf="ModV_SF" units="V" mandatory="true" />
-      <point id="ModVMaxMod" offset="4" type="uint16" />
-      <point id="ModVMin" offset="5" type="uint16" sf="ModV_SF" units="V" mandatory="true" />
-      <point id="ModVMinMod" offset="6" type="uint16" />
-      <point id="ModVAvg" offset="7" type="uint16" sf="ModV_SF" units="V" mandatory="true" />
-      <point id="CellVMax" offset="8" type="uint16" sf="CellV_SF" units="V" mandatory="false" />
-      <point id="CellVMaxMod" offset="9" type="uint16" />
-      <point id="CellVMaxStk" offset="10" type="uint16" />
-      <point id="CellVMin" offset="11" type="uint16" sf="CellV_SF" units="V" mandatory="false" />
-      <point id="CellVMinMod" offset="12" type="uint16" />
-      <point id="CellVMinStk" offset="13" type="uint16" />
-      <point id="CellVAvg" offset="14" type="uint16" sf="CellV_SF" units="V" mandatory="false" />
-      <point id="TmpMax" offset="15" type="int16" sf="Tmp_SF" units="C" mandatory="true" />
-      <point id="TmpMaxMod" offset="16" type="uint16" />
-      <point id="TmpMin" offset="17" type="int16" sf="Tmp_SF" units="C" mandatory="true" />
-      <point id="TmpMinMod" offset="18" type="uint16" />
-      <point id="TmpAvg" offset="19" type="int16" sf="Tmp_SF" units="C" mandatory="true" />
-      <point id="Evt1" offset="20" type="bitfield32" mandatory="true" >
+    <block len="34" type="fixed">
+      <point id="Idx" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="NMod" offset="1" type="uint16" len="1" mandatory="true" />
+      <point id="NModCon" offset="2" type="uint16" len="1" mandatory="true" />
+      <point id="ModVMax" offset="3" type="uint16" len="1" sf="ModV_SF" units="V" mandatory="true" />
+      <point id="ModVMaxMod" offset="4" type="uint16" len="1" />
+      <point id="ModVMin" offset="5" type="uint16" len="1" sf="ModV_SF" units="V" mandatory="true" />
+      <point id="ModVMinMod" offset="6" type="uint16" len="1" />
+      <point id="ModVAvg" offset="7" type="uint16" len="1" sf="ModV_SF" units="V" mandatory="true" />
+      <point id="CellVMax" offset="8" type="uint16" len="1" sf="CellV_SF" units="V" />
+      <point id="CellVMaxMod" offset="9" type="uint16" len="1" />
+      <point id="CellVMaxStk" offset="10" type="uint16" len="1" />
+      <point id="CellVMin" offset="11" type="uint16" len="1" sf="CellV_SF" units="V" />
+      <point id="CellVMinMod" offset="12" type="uint16" len="1" />
+      <point id="CellVMinStk" offset="13" type="uint16" len="1" />
+      <point id="CellVAvg" offset="14" type="uint16" len="1" sf="CellV_SF" units="V" />
+      <point id="TmpMax" offset="15" type="int16" len="1" sf="Tmp_SF" units="C" mandatory="true" />
+      <point id="TmpMaxMod" offset="16" type="uint16" len="1" />
+      <point id="TmpMin" offset="17" type="int16" len="1" sf="Tmp_SF" units="C" mandatory="true" />
+      <point id="TmpMinMod" offset="18" type="uint16" len="1" />
+      <point id="TmpAvg" offset="19" type="int16" len="1" sf="Tmp_SF" units="C" mandatory="true" />
+      <point id="Evt1" offset="20" type="bitfield32" len="2" mandatory="true" >
         <symbol id="COMMUNICATION_ERROR">0</symbol>
         <symbol id="OVER_TEMP_ALARM">1</symbol>
         <symbol id="OVER_TEMP_WARNING">2</symbol>
@@ -55,7 +55,7 @@
         <symbol id="CONFIGURATION_ALARM">28</symbol>
         <symbol id="CONFIGURATION_WARNING">29</symbol>
       </point>
-      <point id="Evt2" offset="22" type="bitfield32" mandatory="true">
+      <point id="Evt2" offset="22" type="bitfield32" len="2" mandatory="true" >
         <symbol id="LEAK_ALARM">0</symbol>
         <symbol id="PUMP_ALARM">1</symbol>
         <symbol id="HIGH_PRESSURE_ALARM">2</symbol>
@@ -63,33 +63,33 @@
         <symbol id="LOW_FLOW_ALARM">4</symbol>
         <symbol id="LOW_FLOW_WARNING">5</symbol>
       </point>
-      <point id="EvtVnd1" offset="24" type="bitfield32" mandatory="true" />
-      <point id="EvtVnd2" offset="26" type="bitfield32" mandatory="true" />
-      <point id="ModV_SF" offset="28" type="sunssf" mandatory="true" />
-      <point id="CellV_SF" offset="29" type="sunssf" mandatory="true" />
-      <point id="Tmp_SF" offset="30" type="sunssf" mandatory="true" />
-      <point id="SoC_SF" offset="31" type="sunssf" mandatory="true" />
-      <point id="OCV_SF" offset="32" type="sunssf" mandatory="true" />
-      <point id="Pad1" offset="33" type="pad" mandatory="true" />
+      <point id="EvtVnd1" offset="24" type="bitfield32" len="2" mandatory="true" />
+      <point id="EvtVnd2" offset="26" type="bitfield32" len="2" mandatory="true" />
+      <point id="ModV_SF" offset="28" type="sunssf" len="1" mandatory="true" />
+      <point id="CellV_SF" offset="29" type="sunssf" len="1" mandatory="true" />
+      <point id="Tmp_SF" offset="30" type="sunssf" len="1" mandatory="true" />
+      <point id="SoC_SF" offset="31" type="sunssf" len="1" mandatory="true" />
+      <point id="OCV_SF" offset="32" type="sunssf" len="1" mandatory="true" />
+      <point id="Pad1" offset="33" type="pad" len="1" mandatory="true" />
     </block>
-    <block type="repeating" len="24" name="module">
-      <point id="ModIdx" offset="0" type="uint16" mandatory="true" />
-      <point id="ModNStk" offset="1" type="uint16" units="" mandatory="true" />
-      <point id="ModSt" offset="2" type="bitfield32" mandatory="true">
+    <block len="24" type="repeating" name="module">
+      <point id="ModIdx" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="ModNStk" offset="1" type="uint16" len="1" mandatory="true" />
+      <point id="ModSt" offset="2" type="bitfield32" len="2" mandatory="true" >
         <symbol id="MODULE_ENABLED">0</symbol>
         <symbol id="CONTACTOR_STATUS">1</symbol>
       </point>
-      <point id="ModSoC" offset="4" type="uint16" sf="SoC_SF" units="%" mandatory="true" />
-      <point id="ModOCV" offset="5" type="uint16" sf="OCV_SF" units="V" mandatory="true" />
-      <point id="ModV" offset="6" type="uint16" sf="ModV_SF" units="V" mandatory="true" />
-      <point id="ModCellVMax" offset="7" type="uint16" sf="CellV_SF" units="V" mandatory="false" />
-      <point id="ModCellVMaxCell" offset="8" type="uint16" units="" />
-      <point id="ModCellVMin" offset="9" type="uint16" sf="CellV_SF" units="V" mandatory="false" />
-      <point id="ModCellVMinCell" offset="10" type="uint16" units="" />
-      <point id="ModCellVAvg" offset="11" type="uint16" sf="CellV_SF" units="V" mandatory="false" />
-      <point id="ModAnoTmp" offset="12" type="uint16" sf="Tmp_SF" units="C" />
-      <point id="ModCatTmp" offset="13" type="uint16" sf="Tmp_SF" units="C" />
-      <point id="ModConSt" offset="14" type="bitfield32" units="" >
+      <point id="ModSoC" offset="4" type="uint16" len="1" sf="SoC_SF" units="%" mandatory="true" />
+      <point id="ModOCV" offset="5" type="uint16" len="1" sf="OCV_SF" units="V" mandatory="true" />
+      <point id="ModV" offset="6" type="uint16" len="1" sf="ModV_SF" units="V" mandatory="true" />
+      <point id="ModCellVMax" offset="7" type="uint16" len="1" sf="CellV_SF" units="V" />
+      <point id="ModCellVMaxCell" offset="8" type="uint16" len="1" />
+      <point id="ModCellVMin" offset="9" type="uint16" len="1" sf="CellV_SF" units="V" />
+      <point id="ModCellVMinCell" offset="10" type="uint16" len="1" />
+      <point id="ModCellVAvg" offset="11" type="uint16" len="1" sf="CellV_SF" units="V" />
+      <point id="ModAnoTmp" offset="12" type="uint16" len="1" sf="Tmp_SF" units="C" />
+      <point id="ModCatTmp" offset="13" type="uint16" len="1" sf="Tmp_SF" units="C" />
+      <point id="ModConSt" offset="14" type="bitfield32" len="2" >
         <symbol id="CONTACTOR_0">0</symbol>
         <symbol id="CONTACTOR_1">1</symbol>
         <symbol id="CONTACTOR_2">2</symbol>
@@ -122,7 +122,7 @@
         <symbol id="CONTACTOR_29">29</symbol>
         <symbol id="CONTACTOR_30">30</symbol>
       </point>
-      <point id="ModEvt1" offset="16" type="bitfield32" mandatory="true" >
+      <point id="ModEvt1" offset="16" type="bitfield32" len="2" mandatory="true" >
         <symbol id="COMMUNICATION_ERROR">0</symbol>
         <symbol id="OVER_TEMP_ALARM">1</symbol>
         <symbol id="OVER_TEMP_WARNING">2</symbol>
@@ -154,7 +154,7 @@
         <symbol id="MODULE_CONFIGURATION_ALARM">28</symbol>
         <symbol id="MODULE_CONFIGURATION_WARNING">29</symbol>
       </point>
-      <point id="ModEvt2" offset="18" type="bitfield32" mandatory="true" >
+      <point id="ModEvt2" offset="18" type="bitfield32" len="2" mandatory="true" >
         <symbol id="LEAK_ALARM">0</symbol>
         <symbol id="PUMP_ALARM">1</symbol>
         <symbol id="HIGH_PRESSURE_ALARM">2</symbol>
@@ -162,7 +162,7 @@
         <symbol id="LOW_FLOW_ALARM">4</symbol>
         <symbol id="LOW_FLOW_WARNING">5</symbol>
       </point>
-      <point id="ModConFail" offset="20" type="enum16" mandatory="false" >
+      <point id="ModConFail" offset="20" type="enum16" len="1" >
         <symbol id="NO_FAILURE">0</symbol>
         <symbol id="BUTTON_PUSHED">1</symbol>
         <symbol id="MODULE_GROUND_FAULT">2</symbol>
@@ -173,15 +173,15 @@
         <symbol id="PRECHARGE_FAILURE">7</symbol>
         <symbol id="MODULE_FAULT">8</symbol>
       </point>
-      <point id="ModSetEna" offset="21" access="rw" type="enum16" >
+      <point id="ModSetEna" offset="21" type="enum16" len="1" access="rw" >
         <symbol id="ENABLE_MODULE">1</symbol>
         <symbol id="DISABLE_MODULE">2</symbol>
       </point>
-      <point id="ModSetCon" offset="22" access="rw" type="enum16">
+      <point id="ModSetCon" offset="22" type="enum16" len="1" access="rw" >
         <symbol id="CONNECT_MODULE">1</symbol>
         <symbol id="DISCONNECT_MODULE">2</symbol>
       </point>
-      <point id="ModDisRsn" offset="23" type="enum16" mandatory="false">
+      <point id="ModDisRsn" offset="23" type="enum16" len="1" >
         <symbol id="NONE">0</symbol>
         <symbol id="FAULT">1</symbol>
         <symbol id="MAINTENANCE">2</symbol>
@@ -520,7 +520,7 @@
       <label>Pad</label>
       <description>Pad register.</description>
       <notes> </notes>
-    </point>    
+    </point>
 
     <!-- Repeating Block Strings -->
 
@@ -1058,7 +1058,7 @@
         <description>The module has been disabled for some other reason.</description>
         <notes></notes>
       </symbol>
-    </point>    
+    </point>
 
    </strings>
 </sunSpecModels>

--- a/smdx/smdx_00808.xml
+++ b/smdx/smdx_00808.xml
@@ -12,18 +12,18 @@
   <strings id="808" locale="en">
     <model>
       <label>Flow Battery Module Model</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="ModuleTBD">
       <label>Module Points To Be Determined</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="StackTBD">
       <label>Stack Points To Be Determined</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
 
    </strings>

--- a/smdx/smdx_00808.xml
+++ b/smdx/smdx_00808.xml
@@ -2,11 +2,11 @@
 
   <!-- 808: Flow Battery Module Model -->
   <model id="808" len="2" name="flow_battery_module">
-    <block len="1">
-      <point id="ModuleTBD" offset="0" type="uint16" mandatory="true" />
+    <block len="1" type="fixed">
+      <point id="ModuleTBD" offset="0" type="uint16" len="1" mandatory="true" />
     </block>
-    <block type="repeating" len="1" name="stack">
-      <point id="StackTBD" offset="0" type="uint16" mandatory="true" />
+    <block len="1" type="repeating" name="stack">
+      <point id="StackTBD" offset="0" type="uint16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="808" locale="en">

--- a/smdx/smdx_00809.xml
+++ b/smdx/smdx_00809.xml
@@ -12,18 +12,18 @@
   <strings id="809" locale="en">
     <model>
       <label>Flow Battery Stack Model</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="StackTBD">
       <label>Stack Points To Be Determined</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CellTBD">
       <label>Cell Points To Be Determined</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
 
    </strings>

--- a/smdx/smdx_00809.xml
+++ b/smdx/smdx_00809.xml
@@ -2,11 +2,11 @@
 
   <!-- 809: Flow Battery Stack Model -->
   <model id="809" len="2" name="flow_battery_stack">
-    <block len="1">
-      <point id="StackTBD" offset="0" type="uint16" mandatory="true" />
+    <block len="1" type="fixed">
+      <point id="StackTBD" offset="0" type="uint16" len="1" mandatory="true" />
     </block>
-    <block type="repeating" len="1" name="cell">
-      <point id="CellTBD" offset="0" type="uint16" mandatory="true" />
+    <block len="1" type="repeating" name="cell">
+      <point id="CellTBD" offset="0" type="uint16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="809" locale="en">

--- a/smdx/smdx_63001.xml
+++ b/smdx/smdx_63001.xml
@@ -1,79 +1,79 @@
 <sunSpecModels v="1">
-  <!-- 1: common -->
+  <!-- 63001: SunSpec Test Model 1 -->
   <model id="63001" len="152">
-    <block len="134">
-      <point id="sunssf_1"      offset="0"    type="sunssf" />
-      <point id="sunssf_2"      offset="1"    type="sunssf" />
-      <point id="sunssf_3"      offset="2"    type="sunssf" />
-      <point id="sunssf_4"      offset="3"    type="sunssf" />
-      <point id="int16_1"       offset="4"    type="int16"   sf="sunssf_1" />
-      <point id="int16_2"       offset="5"    type="int16"   sf="sunssf_2" />
-      <point id="int16_3"       offset="6"    type="int16"   sf="sunssf_3" />
-      <point id="int16_4"       offset="7"    type="int16"   sf="sunssf_4"  access="rw"/>
-      <point id="int16_5"       offset="8"    type="int16" />
-      <point id="int16_u"       offset="9"    type="int16" />
-      <point id="uint16_1"      offset="10"   type="uint16"  sf="sunssf_1" />
-      <point id="uint16_2"      offset="11"   type="uint16"  sf="sunssf_2" />
-      <point id="uint16_3"      offset="12"   type="uint16"  sf="sunssf_3" />
-      <point id="uint16_4"      offset="13"   type="uint16"  sf="sunssf_4"  access="rw"/>
-      <point id="uint16_5"      offset="14"   type="uint16" />
-      <point id="uint16_u"      offset="15"   type="uint16" />
-      <point id="acc16"         offset="16"   type="acc16" />
-      <point id="acc16_u"       offset="17"   type="acc16" />
-      <point id="enum16"        offset="18"   type="enum16" />
-      <point id="enum16_u"      offset="19"   type="enum16" />
-      <point id="bitfield16"    offset="20"   type="bitfield16" />
-      <point id="bitfield16_u"  offset="21"   type="bitfield16" />
-      <point id="int32_1"       offset="22"   type="int32"   sf="sunssf_5" />
-      <point id="int32_2"       offset="24"   type="int32"   sf="sunssf_6" />
-      <point id="int32_3"       offset="26"   type="int32"   sf="sunssf_7"  access="rw"/>
-      <point id="int32_4"       offset="28"   type="int32" />
-      <point id="int32_5"       offset="30"   type="int32" />
-      <point id="int32_u"       offset="32"   type="int32" />
-      <point id="uint32_1"      offset="34"   type="uint32"  sf="sunssf_5" />
-      <point id="uint32_2"      offset="36"   type="uint32"  sf="sunssf_6" />
-      <point id="uint32_3"      offset="38"   type="uint32"  sf="sunssf_7"  access="rw"/>
-      <point id="uint32_4"      offset="40"   type="uint32"  sf="1" />
-      <point id="uint32_5"      offset="42"   type="uint32" />
-      <point id="uint32_u"      offset="44"   type="uint32" />
-      <point id="acc32"         offset="46"   type="acc32" />
-      <point id="acc32_u"       offset="48"   type="acc32" />
-      <point id="enum32"        offset="50"   type="enum32" />
-      <point id="enum32_u"      offset="52"   type="enum32" />
-      <point id="bitfield32"    offset="54"   type="bitfield32" />
-      <point id="bitfield32_u"  offset="56"   type="bitfield32" />
-      <point id="ipaddr"        offset="58"   type="ipaddr"  access="rw"/>
-      <point id="ipaddr_u"      offset="60"   type="ipaddr" />
-      <point id="int64"         offset="62"   type="int64"  access="rw"/>
-      <point id="int64_u"       offset="66"   type="int64" />
-      <point id="acc64"         offset="70"   type="acc64" />
-      <point id="acc64_u"       offset="74"   type="acc64" />
-      <point id="ipv6addr"      offset="78"   type="ipv6addr" />
-      <point id="ipv6addr_u"    offset="86"   type="ipv6addr" />
-      <point id="float32"       offset="94"   type="float32"  access="rw"/>
-      <point id="float32_u"     offset="96"   type="float32" />
-      <point id="string"        offset="98"   type="string"  len="16"  access="rw"/>
-      <point id="string_u"      offset="114"  type="string"  len="16"/>
-      <point id="sunssf_5"      offset="130"  type="sunssf" />
-      <point id="sunssf_6"      offset="131"  type="sunssf" />
-      <point id="sunssf_7"      offset="132"  type="sunssf" />
-      <point id="pad_1"         offset="133"  type="pad" />
+    <block len="134" type="fixed">
+      <point id="sunssf_1"        offset="0"    type="sunssf"       len="1" />
+      <point id="sunssf_2"        offset="1"    type="sunssf"       len="1" />
+      <point id="sunssf_3"        offset="2"    type="sunssf"       len="1" />
+      <point id="sunssf_4"        offset="3"    type="sunssf"       len="1" />
+      <point id="int16_1"         offset="4"    type="int16"        len="1" sf="sunssf_1" />
+      <point id="int16_2"         offset="5"    type="int16"        len="1" sf="sunssf_2" />
+      <point id="int16_3"         offset="6"    type="int16"        len="1" sf="sunssf_3" />
+      <point id="int16_4"         offset="7"    type="int16"        len="1" sf="sunssf_4" access="rw" />
+      <point id="int16_5"         offset="8"    type="int16"        len="1" />
+      <point id="int16_u"         offset="9"    type="int16"        len="1" />
+      <point id="uint16_1"        offset="10"   type="uint16"       len="1" sf="sunssf_1" />
+      <point id="uint16_2"        offset="11"   type="uint16"       len="1" sf="sunssf_2" />
+      <point id="uint16_3"        offset="12"   type="uint16"       len="1" sf="sunssf_3" />
+      <point id="uint16_4"        offset="13"   type="uint16"       len="1" sf="sunssf_4" access="rw" />
+      <point id="uint16_5"        offset="14"   type="uint16"       len="1" />
+      <point id="uint16_u"        offset="15"   type="uint16"       len="1" />
+      <point id="acc16"           offset="16"   type="acc16"        len="1" />
+      <point id="acc16_u"         offset="17"   type="acc16"        len="1" />
+      <point id="enum16"          offset="18"   type="enum16"       len="1" />
+      <point id="enum16_u"        offset="19"   type="enum16"       len="1" />
+      <point id="bitfield16"      offset="20"   type="bitfield16"   len="1" />
+      <point id="bitfield16_u"    offset="21"   type="bitfield16"   len="1" />
+      <point id="int32_1"         offset="22"   type="int32"        len="2" sf="sunssf_5" />
+      <point id="int32_2"         offset="24"   type="int32"        len="2" sf="sunssf_6" />
+      <point id="int32_3"         offset="26"   type="int32"        len="2" sf="sunssf_7" access="rw" />
+      <point id="int32_4"         offset="28"   type="int32"        len="2" />
+      <point id="int32_5"         offset="30"   type="int32"        len="2" />
+      <point id="int32_u"         offset="32"   type="int32"        len="2" />
+      <point id="uint32_1"        offset="34"   type="uint32"       len="2" sf="sunssf_5" />
+      <point id="uint32_2"        offset="36"   type="uint32"       len="2" sf="sunssf_6" />
+      <point id="uint32_3"        offset="38"   type="uint32"       len="2" sf="sunssf_7" access="rw" />
+      <point id="uint32_4"        offset="40"   type="uint32"       len="2" sf="1" />
+      <point id="uint32_5"        offset="42"   type="uint32"       len="2" />
+      <point id="uint32_u"        offset="44"   type="uint32"       len="2" />
+      <point id="acc32"           offset="46"   type="acc32"        len="2" />
+      <point id="acc32_u"         offset="48"   type="acc32"        len="2" />
+      <point id="enum32"          offset="50"   type="enum32"       len="2" />
+      <point id="enum32_u"        offset="52"   type="enum32"       len="2" />
+      <point id="bitfield32"      offset="54"   type="bitfield32"   len="2" />
+      <point id="bitfield32_u"    offset="56"   type="bitfield32"   len="2" />
+      <point id="ipaddr"          offset="58"   type="ipaddr"       len="2" access="rw" />
+      <point id="ipaddr_u"        offset="60"   type="ipaddr"       len="2" />
+      <point id="int64"           offset="62"   type="int64"        len="4" access="rw" />
+      <point id="int64_u"         offset="66"   type="int64"        len="4" />
+      <point id="acc64"           offset="70"   type="acc64"        len="4" />
+      <point id="acc64_u"         offset="74"   type="acc64"        len="4" />
+      <point id="ipv6addr"        offset="78"   type="ipv6addr"     len="8" />
+      <point id="ipv6addr_u"      offset="86"   type="ipv6addr"     len="8" />
+      <point id="float32"         offset="94"   type="float32"      len="2" access="rw" />
+      <point id="float32_u"       offset="96"   type="float32"      len="2" />
+      <point id="string"          offset="98"   type="string"       len="16" access="rw" />
+      <point id="string_u"        offset="114"  type="string"       len="16" />
+      <point id="sunssf_5"        offset="130"  type="sunssf"       len="1" />
+      <point id="sunssf_6"        offset="131"  type="sunssf"       len="1" />
+      <point id="sunssf_7"        offset="132"  type="sunssf"       len="1" />
+      <point id="pad_1"           offset="133"  type="pad"          len="1" />
     </block>
-    <block type="repeating" len="18">
-      <point id="sunssf_8"      offset="0"    type="sunssf" />
-      <point id="int16_11"      offset="1"    type="int16"   sf="sunssf_8"  access="rw"/>
-      <point id="int16_12"      offset="2"    type="int16"   sf="sunssf_9" />
-      <point id="int16_u"       offset="3"    type="int16" />
-      <point id="uint16_11"     offset="4"    type="uint16"  sf="sunssf_8"  access="rw"/>
-      <point id="uint16_12"     offset="5"    type="uint16"  sf="sunssf_9" />
-      <point id="uint16_13"     offset="6"    type="uint16" />
-      <point id="uint16_u"      offset="7"    type="uint16" />
-      <point id="int32"         offset="8"    type="int32"   sf="sunssf_1"  access="rw"/>
-      <point id="int32_u"       offset="10"   type="int32" />
-      <point id="uint32"        offset="12"   type="uint32"  sf="sunssf_9"  access="rw"/>
-      <point id="uint32_u"      offset="14"   type="uint32" />
-      <point id="sunssf_9"      offset="16"   type="sunssf" />
-      <point id="pad_2"         offset="17"   type="pad" />
+    <block len="18" type="repeating">
+      <point id="sunssf_8"        offset="0"    type="sunssf"       len="1" />
+      <point id="int16_11"        offset="1"    type="int16"        len="1" sf="sunssf_8" access="rw" />
+      <point id="int16_12"        offset="2"    type="int16"        len="1" sf="sunssf_9" />
+      <point id="int16_u"         offset="3"    type="int16"        len="1" />
+      <point id="uint16_11"       offset="4"    type="uint16"       len="1" sf="sunssf_8" access="rw" />
+      <point id="uint16_12"       offset="5"    type="uint16"       len="1" sf="sunssf_9" />
+      <point id="uint16_13"       offset="6"    type="uint16"       len="1" />
+      <point id="uint16_u"        offset="7"    type="uint16"       len="1" />
+      <point id="int32"           offset="8"    type="int32"        len="2" sf="sunssf_1" access="rw" />
+      <point id="int32_u"         offset="10"   type="int32"        len="2" />
+      <point id="uint32"          offset="12"   type="uint32"       len="2" sf="sunssf_9" access="rw" />
+      <point id="uint32_u"        offset="14"   type="uint32"       len="2" />
+      <point id="sunssf_9"        offset="16"   type="sunssf"       len="1" />
+      <point id="pad_2"           offset="17"   type="pad"          len="1" />
     </block>
   </model>
   <strings id="63001" locale="en">

--- a/smdx/smdx_63002.xml
+++ b/smdx/smdx_63002.xml
@@ -1,11 +1,11 @@
 <sunSpecModels v="1">
-  <!-- 1: common -->
+  <!-- 63002: SunSpec Test Model 2 -->
   <model id="63002" len="4">
-    <block type="repeating" len="4">
-      <point id="sunssf_1"      offset="0"    type="sunssf" />
-      <point id="int16_1"       offset="1"    type="int16"   sf="sunssf_1"  access="rw"/>
-      <point id="int16_2"       offset="2"    type="int16"   sf="sunssf_2" />
-      <point id="sunssf_2"      offset="3"    type="sunssf" />
+    <block len="4" type="repeating">
+      <point id="sunssf_1"    offset="0" type="sunssf"  len="1" />
+      <point id="int16_1"     offset="1" type="int16"   len="1" sf="sunssf_1" access="rw" />
+      <point id="int16_2"     offset="2" type="int16"   len="1" sf="sunssf_2" />
+      <point id="sunssf_2"    offset="3" type="sunssf"  len="1" />
     </block>
   </model>
   <strings id="63002" locale="en">

--- a/smdx/smdx_64001.xml
+++ b/smdx/smdx_64001.xml
@@ -43,178 +43,178 @@
   <strings id="64001" locale="en">
     <model>
       <label>Veris Status and Configuration</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="Cmd">
       <label>Command Code</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="HWRev">
       <label>Hardware Revision</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="RSFWRev">
       <label>RS FW Revision</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="OSFWRev">
       <label>OS FW Revision</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="ProdRev">
       <label>Product Revision</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Boots">
       <label>Boot Count</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Switch">
       <label>DIP Switches</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Sensors">
       <label>Num Detected Sensors</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Talking">
       <label>Num Communicating Sensors</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Status">
       <label>System Status</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Config">
       <label>System Configuration</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="LEDblink">
       <label>LED Blink Threshold</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="LEDon">
       <label>LED On Threshold</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Loc">
       <label>Location String</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S1ID">
       <label>Sensor 1 Unit ID</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S1Addr">
       <label>Sensor 1 Address</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S1OSVer">
       <label>Sensor 1 OS Version</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S1Ver">
       <label>Sensor 1 Product Version</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S1Serial">
       <label>Sensor 1 Serial Num</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S2ID">
       <label>Sensor 2 Unit ID</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S2Addr">
       <label>Sensor 2 Address</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S2OSVer">
       <label>Sensor 2 OS Version</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S2Ver">
       <label>Sensor 2 Product Version</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S2Serial">
       <label>Sensor 2 Serial Num</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S3ID">
       <label>Sensor 3 Unit ID</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S3Addr">
       <label>Sensor 3 Address</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S3OSVer">
       <label>Sensor 3 OS Version</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S3Ver">
       <label>Sensor 3 Product Version</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S3Serial">
       <label>Sensor 3 Serial Num</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S4ID">
       <label>Sensor 4 Unit ID</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S4Addr">
       <label>Sensor 4 Address</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S4OSVer">
       <label>Sensor 4 OS Version</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S4Ver">
       <label>Sensor 4 Product Version</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="S4Serial">
       <label>Sensor 4 Serial Num</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_64001.xml
+++ b/smdx/smdx_64001.xml
@@ -2,40 +2,40 @@
 
   <!-- 64001: Veris Status and Configuration -->
   <model id="64001" len="71">
-    <block len="71">
-      <point id="Cmd" offset="0" type="enum16" access="rw" />
-      <point id="HWRev" offset="1" type="uint16" />
-      <point id="RSFWRev" offset="2" type="uint16" />
-      <point id="OSFWRev" offset="3" type="uint16" />
+    <block len="71" type="fixed">
+      <point id="Cmd" offset="0" type="enum16" len="1" access="rw" />
+      <point id="HWRev" offset="1" type="uint16" len="1" />
+      <point id="RSFWRev" offset="2" type="uint16" len="1" />
+      <point id="OSFWRev" offset="3" type="uint16" len="1" />
       <point id="ProdRev" offset="4" type="string" len="2" />
-      <point id="Boots" offset="6" type="uint16" />
-      <point id="Switch" offset="7" type="bitfield16" />
-      <point id="Sensors" offset="8" type="uint16" />
-      <point id="Talking" offset="9" type="uint16" />
-      <point id="Status" offset="10" type="bitfield16" />
-      <point id="Config" offset="11" type="bitfield16" />
-      <point id="LEDblink" offset="12" type="uint16" units="Pct" />
-      <point id="LEDon" offset="13" type="uint16" units="Pct" />
-      <point id="Reserved" offset="14" type="uint16" />
+      <point id="Boots" offset="6" type="uint16" len="1" />
+      <point id="Switch" offset="7" type="bitfield16" len="1" />
+      <point id="Sensors" offset="8" type="uint16" len="1" />
+      <point id="Talking" offset="9" type="uint16" len="1" />
+      <point id="Status" offset="10" type="bitfield16" len="1" />
+      <point id="Config" offset="11" type="bitfield16" len="1" />
+      <point id="LEDblink" offset="12" type="uint16" len="1" units="Pct" />
+      <point id="LEDon" offset="13" type="uint16" len="1" units="Pct" />
+      <point id="Reserved" offset="14" type="uint16" len="1" />
       <point id="Loc" offset="15" type="string" len="16" />
-      <point id="S1ID" offset="31" type="enum16" />
-      <point id="S1Addr" offset="32" type="uint16" />
-      <point id="S1OSVer" offset="33" type="uint16" />
+      <point id="S1ID" offset="31" type="enum16" len="1" />
+      <point id="S1Addr" offset="32" type="uint16" len="1" />
+      <point id="S1OSVer" offset="33" type="uint16" len="1" />
       <point id="S1Ver" offset="34" type="string" len="2" />
       <point id="S1Serial" offset="36" type="string" len="5" />
-      <point id="S2ID" offset="41" type="enum16" />
-      <point id="S2Addr" offset="42" type="uint16" />
-      <point id="S2OSVer" offset="43" type="uint16" />
+      <point id="S2ID" offset="41" type="enum16" len="1" />
+      <point id="S2Addr" offset="42" type="uint16" len="1" />
+      <point id="S2OSVer" offset="43" type="uint16" len="1" />
       <point id="S2Ver" offset="44" type="string" len="2" />
       <point id="S2Serial" offset="46" type="string" len="5" />
-      <point id="S3ID" offset="51" type="enum16" />
-      <point id="S3Addr" offset="52" type="uint16" />
-      <point id="S3OSVer" offset="53" type="uint16" />
+      <point id="S3ID" offset="51" type="enum16" len="1" />
+      <point id="S3Addr" offset="52" type="uint16" len="1" />
+      <point id="S3OSVer" offset="53" type="uint16" len="1" />
       <point id="S3Ver" offset="54" type="string" len="2" />
       <point id="S3Serial" offset="56" type="string" len="5" />
-      <point id="S4ID" offset="61" type="enum16" />
-      <point id="S4Addr" offset="62" type="uint16" />
-      <point id="S4OSVer" offset="63" type="uint16" />
+      <point id="S4ID" offset="61" type="enum16" len="1" />
+      <point id="S4Addr" offset="62" type="uint16" len="1" />
+      <point id="S4OSVer" offset="63" type="uint16" len="1" />
       <point id="S4Ver" offset="64" type="string" len="2" />
       <point id="S4Serial" offset="66" type="string" len="5" />
     </block>

--- a/smdx/smdx_64020.xml
+++ b/smdx/smdx_64020.xml
@@ -2,42 +2,42 @@
 
   <!-- 64020: Mersen GreenString -->
   <model id="64020" len="46">
-    <block len="30">
-      <point id="Aux0Tmp" offset="0" type="int16" units="C" />
-      <point id="Aux1Tmp" offset="1" type="int16" units="C" />
-      <point id="Aux2Tmp" offset="2" type="int16" units="C" />
-      <point id="Aux3Tmp" offset="3" type="int16" units="C" />
-      <point id="Aux4Tmp" offset="4" type="int16" units="C" />
-      <point id="ProbeTmp" offset="6" type="int16" units="C" mandatory="true" />
-      <point id="MainTmp" offset="5" type="int16" units="C" mandatory="true" />
-      <point id="SensorV_SF" offset="7" type="sunssf" mandatory="true" />
-      <point id="SensorA_SF" offset="8" type="sunssf" mandatory="true" />
-      <point id="SensorHz_SF" offset="9" type="sunssf" mandatory="true" />
-      <point id="Sensor1Voltage" offset="10" type="int16" sf="SensorV_SF" units="V" />
-      <point id="Sensor2Voltage" offset="11" type="int16" sf="SensorV_SF" units="V" />
-      <point id="Sensor3Voltage" offset="12" type="int16" sf="SensorV_SF" units="V" />
-      <point id="Sensor4Voltage" offset="13" type="int16" sf="SensorV_SF" units="V" />
-      <point id="Sensor5Voltage" offset="14" type="int16" sf="SensorV_SF" units="V" />
-      <point id="Sensor6Voltage" offset="15" type="int16" sf="SensorV_SF" units="V" />
-      <point id="Sensor7Voltage" offset="16" type="int16" sf="SensorV_SF" units="V" />
-      <point id="Sensor1Current" offset="17" type="int16" sf="SensorA_SF" units="A" />
-      <point id="Sensor2Current" offset="18" type="int16" sf="SensorA_SF" units="A" />
-      <point id="Sensor3Current" offset="19" type="int16" sf="SensorA_SF" units="A" />
-      <point id="Sensor4Current" offset="20" type="int16" sf="SensorA_SF" units="A" />
-      <point id="Sensor5Current" offset="21" type="int16" sf="SensorA_SF" units="A" />
-      <point id="Sensor6Current" offset="22" type="int16" sf="SensorA_SF" units="A" />
-      <point id="Sensor7Current" offset="23" type="int16" sf="SensorA_SF" units="A" />
-      <point id="Sensor8" offset="24" type="uint16" sf="SensorHz_SF" units="Hz" />
-      <point id="Relay1" offset="25" type="uint16"  />
-      <point id="Relay2" offset="26" type="uint16"  />
-      <point id="Relay3" offset="27" type="uint16"  />
-      <point id="ResetAccumulators" offset="28" type="uint16"  />
-      <point id="Reset" offset="29" type="uint16"  />
+    <block len="30" type="fixed">
+      <point id="Aux0Tmp" offset="0" type="int16" len="1" units="C" />
+      <point id="Aux1Tmp" offset="1" type="int16" len="1" units="C" />
+      <point id="Aux2Tmp" offset="2" type="int16" len="1" units="C" />
+      <point id="Aux3Tmp" offset="3" type="int16" len="1" units="C" />
+      <point id="Aux4Tmp" offset="4" type="int16" len="1" units="C" />
+      <point id="MainTmp" offset="5" type="int16" len="1" units="C" mandatory="true" />
+      <point id="ProbeTmp" offset="6" type="int16" len="1" units="C" mandatory="true" />
+      <point id="SensorV_SF" offset="7" type="sunssf" len="1" mandatory="true" />
+      <point id="SensorA_SF" offset="8" type="sunssf" len="1" mandatory="true" />
+      <point id="SensorHz_SF" offset="9" type="sunssf" len="1" mandatory="true" />
+      <point id="Sensor1Voltage" offset="10" type="int16" len="1" sf="SensorV_SF" units="V" />
+      <point id="Sensor2Voltage" offset="11" type="int16" len="1" sf="SensorV_SF" units="V" />
+      <point id="Sensor3Voltage" offset="12" type="int16" len="1" sf="SensorV_SF" units="V" />
+      <point id="Sensor4Voltage" offset="13" type="int16" len="1" sf="SensorV_SF" units="V" />
+      <point id="Sensor5Voltage" offset="14" type="int16" len="1" sf="SensorV_SF" units="V" />
+      <point id="Sensor6Voltage" offset="15" type="int16" len="1" sf="SensorV_SF" units="V" />
+      <point id="Sensor7Voltage" offset="16" type="int16" len="1" sf="SensorV_SF" units="V" />
+      <point id="Sensor1Current" offset="17" type="int16" len="1" sf="SensorA_SF" units="A" />
+      <point id="Sensor2Current" offset="18" type="int16" len="1" sf="SensorA_SF" units="A" />
+      <point id="Sensor3Current" offset="19" type="int16" len="1" sf="SensorA_SF" units="A" />
+      <point id="Sensor4Current" offset="20" type="int16" len="1" sf="SensorA_SF" units="A" />
+      <point id="Sensor5Current" offset="21" type="int16" len="1" sf="SensorA_SF" units="A" />
+      <point id="Sensor6Current" offset="22" type="int16" len="1" sf="SensorA_SF" units="A" />
+      <point id="Sensor7Current" offset="23" type="int16" len="1" sf="SensorA_SF" units="A" />
+      <point id="Sensor8" offset="24" type="uint16" len="1" sf="SensorHz_SF" units="Hz" />
+      <point id="Relay1" offset="25" type="uint16" len="1" />
+      <point id="Relay2" offset="26" type="uint16" len="1" />
+      <point id="Relay3" offset="27" type="uint16" len="1" />
+      <point id="ResetAccumulators" offset="28" type="uint16" len="1" />
+      <point id="Reset" offset="29" type="uint16" len="1" />
     </block>
-    <block type="repeating" len="16">
+    <block len="16" type="repeating">
       <point id="SerialNumber" offset="0" type="string" len="9" mandatory="true" />
       <point id="Firmware" offset="9" type="string" len="6" mandatory="true" />
-      <point id="Hardware" offset="15" type="uint16" mandatory="true" />
+      <point id="Hardware" offset="15" type="uint16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="64020" locale="en">
@@ -75,12 +75,12 @@
       <label>Probe Temperature</label>
       <description></description>
       <notes></notes>
-    </point>    
+    </point>
     <point id="MainTmp">
       <label>Main Temperature</label>
       <description></description>
       <notes></notes>
-    </point>    
+    </point>
     <point id="SensorV_SF">
       <label>Voltage scale factor for the sensors</label>
       <description></description>

--- a/smdx/smdx_64020.xml
+++ b/smdx/smdx_64020.xml
@@ -43,173 +43,173 @@
   <strings id="64020" locale="en">
     <model>
       <label>Mersen GreenString</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="Aux0Tmp">
       <label>Aux 0 temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Aux1Tmp">
       <label>Aux 1 temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Aux2Tmp">
       <label>Aux 2 temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Aux3Tmp">
       <label>Aux 3 temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Aux4Tmp">
       <label>Aux 4 temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="ProbeTmp">
       <label>Probe Temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="MainTmp">
       <label>Main Temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="SensorV_SF">
       <label>Voltage scale factor for the sensors</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="SensorA_SF">
       <label>Current scale factor for the sensors</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="SensorHz_SF">
       <label>Frequency scale factor for the sensors</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Sensor1Voltage">
       <label>Sensor1 Voltage</label>
       <description>scale of 0-10V</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor2Voltage">
       <label>Sensor2 Voltage</label>
       <description>scale of 0-10V</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor3Voltage">
       <label>Sensor3 Voltage</label>
       <description>scale of 0-10V</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor4Voltage">
       <label>Sensor4 Voltage</label>
       <description>scale of 0-10V</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor5Voltage">
       <label>Sensor5 Voltage</label>
       <description>scale of 0-10V</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor6Voltage">
       <label>Sensor6 Voltage</label>
       <description>scale of 0-10V</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor7Voltage">
       <label>Sensor7 Voltage</label>
       <description>scale of 0-10V</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor1Current">
       <label>Sensor1 Current</label>
       <description>scale of 4-20mA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor2Current">
       <label>Sensor2 Current</label>
       <description>in 4-20mA or 4-20mA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor3Current">
       <label>Sensor3 Current</label>
       <description>in 4-20mA or 4-20mA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor4Current">
       <label>Sensor4 Current</label>
       <description>in 4-20mA or 4-20mA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor5Current">
       <label>Sensor5 Current</label>
       <description>in 4-20mA or 4-20mA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor6Current">
       <label>Sensor6 Current</label>
       <description>in 4-20mA or 4-20mA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor7Current">
       <label>Sensor7 Current</label>
       <description>in 4-20mA or 4-20mA</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Sensor8">
       <label>Sensor8 frequency</label>
       <description>frequency in Hz</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Relay1">
       <label>Relay 1 state</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Relay2">
       <label>Relay 2 state</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Relay3">
       <label>Relay 3 state</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="ResetAccumulators">
       <label>Reset the accumulators</label>
       <description>always 0 in reading, used the code 0xC0DA during the writing for resetting them</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="Reset">
       <label>Reset the system</label>
       <description>always 0 in reading, used the code 0xC0DA during the writing for resetting the system</description>
-      <notes></notes>
+      <notes/>
     </point>
     <point id="SerialNumber">
       <label>Serial number</label>
       <description>strings of 16 characters</description>
-      <notes></notes>
+      <notes/>
     </point>
      <point id="Firmware">
       <label>Firmware version</label>
       <description>string of 11 characters</description>
-      <notes></notes>
+      <notes/>
     </point>
      <point id="Hardware">
       <label>Hardware version</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_64101.xml
+++ b/smdx/smdx_64101.xml
@@ -2,14 +2,14 @@
 
   <!-- 64101: eltek -->
   <model id="64101" len="7">
-    <block len="7">
-      <point id="Eltek_Country_Code" offset="0" type="uint16" />
-      <point id="Eltek_Feeding_Phase" offset="1" type="uint16" />
-      <point id="Eltek_APD_Method" offset="2" type="uint16" />
-      <point id="Eltek_APD_Power_Ref" offset="3" type="uint16" />
-      <point id="Eltek_RPS_Method" offset="4" type="uint16" />
-      <point id="Eltek_RPS_Q_Ref" offset="5" type="uint16" />
-      <point id="Eltek_RPS_CosPhi_Ref" offset="6" type="int16" />
+    <block len="7" type="fixed">
+      <point id="Eltek_Country_Code" offset="0" type="uint16" len="1" />
+      <point id="Eltek_Feeding_Phase" offset="1" type="uint16" len="1" />
+      <point id="Eltek_APD_Method" offset="2" type="uint16" len="1" />
+      <point id="Eltek_APD_Power_Ref" offset="3" type="uint16" len="1" />
+      <point id="Eltek_RPS_Method" offset="4" type="uint16" len="1" />
+      <point id="Eltek_RPS_Q_Ref" offset="5" type="uint16" len="1" />
+      <point id="Eltek_RPS_CosPhi_Ref" offset="6" type="int16" len="1" />
     </block>
   </model>
   <strings id="64101" locale="en">

--- a/smdx/smdx_64101.xml
+++ b/smdx/smdx_64101.xml
@@ -15,8 +15,8 @@
   <strings id="64101" locale="en">
     <model>
       <label>Eltek Inverter Extension</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_64110.xml
+++ b/smdx/smdx_64110.xml
@@ -68,283 +68,283 @@
   <strings id="64110" locale="en">
     <model>
       <label>OutBack AXS device</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="MajorFWRev">
       <label>AXS Major Firmware Number</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="MidFWRev">
       <label>AXS Mid Firmware Number</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="MinorFWRev">
       <label>AXS Minor Firmware Number</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="EncrypKey">
       <label>Encryption Key</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="MAC_Address">
       <label>MAC Address</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="WritePassword">
       <label>Write Password</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="EnableDHCP">
       <label>Enable DHCP</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TCPIP_address">
       <label>TCPIP Address</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Gateway_address">
       <label>TCPIP Gateway</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TCPIP_Netmask">
       <label>TCPIP Netmask</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="DNS1_address">
       <label>TCPIP DNS1</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="DNS2_address">
       <label>TCPIP DNS2</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Modbus_port">
       <label>ModBus Port</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="SMTP_server_nm">
       <label>SMTP Server Name</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="SMTP_account_nm">
       <label>SMTP Account Name</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="SMTP_enable_SSL">
       <label>Enable SMTP SSL</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="ASX_DISABLED">
         <label>Disabled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="ASX_ENABLED">
         <label>Enabled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="SMTP_password">
       <label>SMTP Password</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="SMTP_user_nm">
       <label>SMTP User Name</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Stat_email_int">
       <label>Status Email Interval</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Stat_start_HR">
       <label>Status Email Start Hour</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Stat_email_sub">
       <label>Status Email Subject</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Stat_email_addr1">
       <label>Status Email to Address 1</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Stat_email_addr2">
       <label>Status Email to Address 2</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Alarm_email_en">
       <label>Enable Alarm Email</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="ASX_DISABLED">
         <label>Disabled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="ASX_ENABLED">
         <label>Enabled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="Alarm_email_sub">
       <label>Alarm Email Subject</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Alarm_email_addr1">
       <label>Alarm Email to Address 1</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Alarm_email_addr2">
       <label>Alarm Email to Address 2</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="FTP_password">
       <label>FTP Password</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TELNET_password">
       <label>Telnet Password</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Log_write_int">
       <label>SD-Card Datalog Write Interval</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Log_retain">
       <label>SD-Card Datalog Retain</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Log_mode">
       <label>SD-Card Datalog Mode</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="LOG_DISABLED">
         <label>Disabled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="LOG_EXCEL">
         <label>Excel</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="LOG_COMPACT">
         <label>Compact</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="NTP_server_nm">
       <label>NTP Timer Server Name</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="NTP_enable">
       <label>Enable Network Time</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="ASX_DISABLED">
         <label>Disabled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="ASX_ENABLED">
         <label>Enabled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="TimeZone">
       <label>Time Zone</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Date_year">
       <label>Year</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Date_month">
       <label>Month</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Date_Day">
       <label>Day</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Time_hour">
       <label>Hour</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Time_minute">
       <label>Minute</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Time_second">
       <label>Second</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Battery_temp">
       <label>Battery Temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="Ambient_temp">
       <label>Ambient Temperature</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="AXS_Error">
       <label>AXS Error</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="AXS_Status">
       <label>AXS Status</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="AXS_Spare">
       <label>Spare</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_64110.xml
+++ b/smdx/smdx_64110.xml
@@ -2,34 +2,34 @@
 
   <!-- 64110: OutBack AXS device -->
   <model id="64110" len="282">
-    <block len="282">
-      <point id="MajorFWRev" offset="0" type="uint16" mandatory="true" />
-      <point id="MidFWRev" offset="1" type="uint16" mandatory="true" />
-      <point id="MinorFWRev" offset="2" type="uint16" mandatory="true" />
-      <point id="EncrypKey" offset="3" type="uint16" mandatory="true" />
+    <block len="282" type="fixed">
+      <point id="MajorFWRev" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="MidFWRev" offset="1" type="uint16" len="1" mandatory="true" />
+      <point id="MinorFWRev" offset="2" type="uint16" len="1" mandatory="true" />
+      <point id="EncrypKey" offset="3" type="uint16" len="1" mandatory="true" />
       <point id="MAC_Address" offset="4" type="string" len="7" mandatory="true" />
       <point id="WritePassword" offset="11" type="string" len="8" mandatory="true" />
-      <point id="EnableDHCP" offset="19" type="enum16" mandatory="true" />
-      <point id="TCPIP_address" offset="20" type="ipaddr" mandatory="true" />
-      <point id="Gateway_address" offset="22" type="ipaddr" mandatory="true" />
-      <point id="TCPIP_Netmask" offset="24" type="ipaddr" mandatory="true" />
-      <point id="DNS1_address" offset="26" type="ipaddr" mandatory="true" />
-      <point id="DNS2_address" offset="28" type="ipaddr" mandatory="true" />
-      <point id="Modbus_port" offset="30" type="uint16" mandatory="true" />
+      <point id="EnableDHCP" offset="19" type="enum16" len="1" mandatory="true" />
+      <point id="TCPIP_address" offset="20" type="ipaddr" len="2" mandatory="true" />
+      <point id="Gateway_address" offset="22" type="ipaddr" len="2" mandatory="true" />
+      <point id="TCPIP_Netmask" offset="24" type="ipaddr" len="2" mandatory="true" />
+      <point id="DNS1_address" offset="26" type="ipaddr" len="2" mandatory="true" />
+      <point id="DNS2_address" offset="28" type="ipaddr" len="2" mandatory="true" />
+      <point id="Modbus_port" offset="30" type="uint16" len="1" mandatory="true" />
       <point id="SMTP_server_nm" offset="31" type="string" len="20" mandatory="true" />
       <point id="SMTP_account_nm" offset="51" type="string" len="16" mandatory="true" />
-      <point id="SMTP_enable_SSL" offset="67" type="enum16" mandatory="true" >
+      <point id="SMTP_enable_SSL" offset="67" type="enum16" len="1" mandatory="true" >
         <symbol id="ASX_DISABLED">0</symbol>
         <symbol id="ASX_ENABLED">1</symbol>
       </point>
       <point id="SMTP_password" offset="68" type="string" len="8" mandatory="true" />
       <point id="SMTP_user_nm" offset="76" type="string" len="20" mandatory="true" />
-      <point id="Stat_email_int" offset="96" type="uint16" mandatory="true" />
-      <point id="Stat_start_HR" offset="97" type="uint16" mandatory="true" />
+      <point id="Stat_email_int" offset="96" type="uint16" len="1" mandatory="true" />
+      <point id="Stat_start_HR" offset="97" type="uint16" len="1" mandatory="true" />
       <point id="Stat_email_sub" offset="98" type="string" len="25" mandatory="true" />
       <point id="Stat_email_addr1" offset="123" type="string" len="20" mandatory="true" />
       <point id="Stat_email_addr2" offset="143" type="string" len="20" mandatory="true" />
-      <point id="Alarm_email_en" offset="163" type="enum16" mandatory="true" >
+      <point id="Alarm_email_en" offset="163" type="enum16" len="1" mandatory="true" >
         <symbol id="ASX_DISABLED">0</symbol>
         <symbol id="ASX_ENABLED">1</symbol>
       </point>
@@ -38,31 +38,31 @@
       <point id="Alarm_email_addr2" offset="209" type="string" len="20" mandatory="true" />
       <point id="FTP_password" offset="229" type="string" len="8" mandatory="true" />
       <point id="TELNET_password" offset="237" type="string" len="8" mandatory="true" />
-      <point id="Log_write_int" offset="245" type="uint16" units="Tms" mandatory="true" />
-      <point id="Log_retain" offset="246" type="uint16" units="Tmd" mandatory="true" />
-      <point id="Log_mode" offset="247" type="enum16" mandatory="true" >
+      <point id="Log_write_int" offset="245" type="uint16" len="1" units="Tms" mandatory="true" />
+      <point id="Log_retain" offset="246" type="uint16" len="1" units="Tmd" mandatory="true" />
+      <point id="Log_mode" offset="247" type="enum16" len="1" mandatory="true" >
         <symbol id="LOG_DISABLED">0</symbol>
         <symbol id="LOG_EXCEL">1</symbol>
         <symbol id="LOG_COMPACT">2</symbol>
       </point>
       <point id="NTP_server_nm" offset="248" type="string" len="20" mandatory="true" />
-      <point id="NTP_enable" offset="268" type="enum16" mandatory="true" >
+      <point id="NTP_enable" offset="268" type="enum16" len="1" mandatory="true" >
         <symbol id="ASX_DISABLED">0</symbol>
         <symbol id="ASX_ENABLED">1</symbol>
       </point>
-      <point id="TimeZone" offset="269" type="int16" units="Tmh" mandatory="true" />
-      <point id="Date_year" offset="270" type="uint16" mandatory="true" />
-      <point id="Date_month" offset="271" type="uint16" mandatory="true" />
-      <point id="Date_Day" offset="272" type="uint16" mandatory="true" />
-      <point id="Time_hour" offset="273" type="uint16" mandatory="true" />
-      <point id="Time_minute" offset="274" type="uint16" mandatory="true" />
-      <point id="Time_second" offset="275" type="uint16" mandatory="true" />
-      <point id="Battery_temp" offset="276" type="int16" sf="Temp_SF" units="C" mandatory="true" />
-      <point id="Ambient_temp" offset="277" type="int16" sf="Temp_SF" units="C" mandatory="true" />
-      <point id="Temp_SF" offset="278" type="sunssf" mandatory="true" />
-      <point id="AXS_Error" offset="279" type="bitfield16" mandatory="true" />
-      <point id="AXS_Status" offset="280" type="bitfield16" mandatory="true" />
-      <point id="AXS_Spare" offset="281" type="uint16" mandatory="true" />
+      <point id="TimeZone" offset="269" type="int16" len="1" units="Tmh" mandatory="true" />
+      <point id="Date_year" offset="270" type="uint16" len="1" mandatory="true" />
+      <point id="Date_month" offset="271" type="uint16" len="1" mandatory="true" />
+      <point id="Date_Day" offset="272" type="uint16" len="1" mandatory="true" />
+      <point id="Time_hour" offset="273" type="uint16" len="1" mandatory="true" />
+      <point id="Time_minute" offset="274" type="uint16" len="1" mandatory="true" />
+      <point id="Time_second" offset="275" type="uint16" len="1" mandatory="true" />
+      <point id="Battery_temp" offset="276" type="int16" len="1" sf="Temp_SF" units="C" mandatory="true" />
+      <point id="Ambient_temp" offset="277" type="int16" len="1" sf="Temp_SF" units="C" mandatory="true" />
+      <point id="Temp_SF" offset="278" type="sunssf" len="1" mandatory="true" />
+      <point id="AXS_Error" offset="279" type="bitfield16" len="1" mandatory="true" />
+      <point id="AXS_Status" offset="280" type="bitfield16" len="1" mandatory="true" />
+      <point id="AXS_Spare" offset="281" type="uint16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="64110" locale="en">

--- a/smdx/smdx_64111.xml
+++ b/smdx/smdx_64111.xml
@@ -37,123 +37,123 @@
   <strings id="64111" locale="en">
     <model>
       <label>Basic Charge Controller</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="Port">
       <label>Port Number</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="BattV">
       <label>Battery Voltage</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="ArrayV">
       <label>Array Voltage</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="OutputA">
       <label>Output Current</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="InputA">
       <label>Array Current</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="ChargerSt">
       <label>Operating State</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="Off">
         <label>Off</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Float">
         <label>Float Charging</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Bulk">
         <label>Bulk Charging</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Absorb">
         <label>Absorb Charging</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="EQ">
         <label>Equalize Charging</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="OutputW">
       <label>Output Wattage</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TodayMinBatV">
       <label>Today's Minimum Battery Voltage</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TodayMaxBatV">
       <label>Today's Maximum Battery Voltage</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="VOCV">
       <label>VOC</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TodayMaxVOC">
       <label>Today's Maximum VOC</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TodaykWhOutput">
       <label>Today's kWh</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="TodayAHOutput">
       <label>Today's AH</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="LifeTimeKWHOut">
       <label>Lifetime kWh</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="LifeTimeAHOut">
       <label>Lifetime kAH</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="LifeTimeMaxOut">
       <label>Lifetime Maximum Output Wattage</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="LifeTimeMaxBatt">
       <label>Lifetime Maximum Battery Voltage</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="LifeTimeMaxVOC">
       <label>Lifetime Maximum VOC Voltage</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>

--- a/smdx/smdx_64111.xml
+++ b/smdx/smdx_64111.xml
@@ -2,36 +2,36 @@
 
   <!-- 64111: Charge Controller -->
   <model id="64111" len="23">
-    <block len="23">
-      <point id="Port" offset="0" type="uint16" mandatory="true" />
-      <point id="V_SF" offset="1" type="sunssf" mandatory="true" />
-      <point id="A_SF" offset="2" type="sunssf" mandatory="true" />
-      <point id="P_SF" offset="3" type="sunssf" mandatory="true" />
-      <point id="AH_SF" offset="4" type="sunssf" mandatory="true" />
-      <point id="KWH_SF" offset="5" type="sunssf" mandatory="true" />
-      <point id="BattV" offset="6" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="ArrayV" offset="7" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="OutputA" offset="8" type="uint16" sf="A_SF" units="A" mandatory="true" />
-      <point id="InputA" offset="9" type="uint16" sf="P_SF" units="A" mandatory="true" />
-      <point id="ChargerSt" offset="10" type="enum16" mandatory="true" >
+    <block len="23" type="fixed">
+      <point id="Port" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="V_SF" offset="1" type="sunssf" len="1" mandatory="true" />
+      <point id="A_SF" offset="2" type="sunssf" len="1" mandatory="true" />
+      <point id="P_SF" offset="3" type="sunssf" len="1" mandatory="true" />
+      <point id="AH_SF" offset="4" type="sunssf" len="1" mandatory="true" />
+      <point id="KWH_SF" offset="5" type="sunssf" len="1" mandatory="true" />
+      <point id="BattV" offset="6" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="ArrayV" offset="7" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="OutputA" offset="8" type="uint16" len="1" sf="A_SF" units="A" mandatory="true" />
+      <point id="InputA" offset="9" type="uint16" len="1" sf="P_SF" units="A" mandatory="true" />
+      <point id="ChargerSt" offset="10" type="enum16" len="1" mandatory="true" >
         <symbol id="Off">0</symbol>
         <symbol id="Float">1</symbol>
         <symbol id="Bulk">2</symbol>
         <symbol id="Absorb">3</symbol>
         <symbol id="EQ">4</symbol>
       </point>
-      <point id="OutputW" offset="11" type="uint16" sf="P_SF" units="W" mandatory="true" />
-      <point id="TodayMinBatV" offset="12" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="TodayMaxBatV" offset="13" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="VOCV" offset="14" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="TodayMaxVOC" offset="15" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="TodaykWhOutput" offset="16" type="uint16" sf="KWH_SF" units="kWh" mandatory="true" />
-      <point id="TodayAHOutput" offset="17" type="uint16" sf="AH_SF" units="AH" mandatory="true" />
-      <point id="LifeTimeKWHOut" offset="18" type="uint16" sf="P_SF" units="kWh" mandatory="true" />
-      <point id="LifeTimeAHOut" offset="19" type="uint16" sf="KWH_SF" units="kAH" mandatory="true" />
-      <point id="LifeTimeMaxOut" offset="20" type="uint16" sf="P_SF" units="W" mandatory="true" />
-      <point id="LifeTimeMaxBatt" offset="21" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="LifeTimeMaxVOC" offset="22" type="uint16" sf="V_SF" units="V" mandatory="true" />
+      <point id="OutputW" offset="11" type="uint16" len="1" sf="P_SF" units="W" mandatory="true" />
+      <point id="TodayMinBatV" offset="12" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="TodayMaxBatV" offset="13" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="VOCV" offset="14" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="TodayMaxVOC" offset="15" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="TodaykWhOutput" offset="16" type="uint16" len="1" sf="KWH_SF" units="kWh" mandatory="true" />
+      <point id="TodayAHOutput" offset="17" type="uint16" len="1" sf="AH_SF" units="AH" mandatory="true" />
+      <point id="LifeTimeKWHOut" offset="18" type="uint16" len="1" sf="P_SF" units="kWh" mandatory="true" />
+      <point id="LifeTimeAHOut" offset="19" type="uint16" len="1" sf="KWH_SF" units="kAH" mandatory="true" />
+      <point id="LifeTimeMaxOut" offset="20" type="uint16" len="1" sf="P_SF" units="W" mandatory="true" />
+      <point id="LifeTimeMaxBatt" offset="21" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="LifeTimeMaxVOC" offset="22" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
     </block>
   </model>
   <strings id="64111" locale="en">

--- a/smdx/smdx_64112.xml
+++ b/smdx/smdx_64112.xml
@@ -2,59 +2,59 @@
 
   <!-- 64112: OutBack FM Charge Controller -->
   <model id="64112" len="64">
-    <block len="64">
-      <point id="Port" offset="0" type="uint16" mandatory="true" />
-      <point id="V_SF" offset="1" type="sunssf" mandatory="true" />
-      <point id="C_SF" offset="2" type="sunssf" mandatory="true" />
-      <point id="H_SF" offset="3" type="sunssf" mandatory="true" />
-      <point id="P_SF" offset="4" type="sunssf" mandatory="true" />
-      <point id="AH_SF" offset="5" type="sunssf" mandatory="true" />
-      <point id="KWH_SF" offset="6" type="sunssf" mandatory="true" />
-      <point id="CC_Config_fault" offset="7" type="bitfield16" mandatory="true" />
-      <point id="CC_Config_absorb_V" offset="8" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_absorb_Hr" offset="9" type="uint16" sf="H_SF" units="Tmh" mandatory="true" />
-      <point id="CC_Config_absorb_End_A" offset="10" type="uint16" sf="V_SF" units="A" mandatory="true" />
-      <point id="CC_Config_rebulk_V" offset="11" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_float_V" offset="12" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_max_Chg_A" offset="13" type="uint16" sf="V_SF" units="A" mandatory="true" />
-      <point id="CC_Config_equalize_V" offset="14" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_equalize_Hr" offset="15" type="uint16" units="Tmh" mandatory="true" />
-      <point id="CC_Config_auto_equalize" offset="16" type="uint16" units="Tmd" mandatory="true" />
-      <point id="CC_Config_MPPT_mode" offset="17" type="enum16" mandatory="true" >
+    <block len="64" type="fixed">
+      <point id="Port" offset="0" type="uint16" len="1" mandatory="true" />
+      <point id="V_SF" offset="1" type="sunssf" len="1" mandatory="true" />
+      <point id="C_SF" offset="2" type="sunssf" len="1" mandatory="true" />
+      <point id="H_SF" offset="3" type="sunssf" len="1" mandatory="true" />
+      <point id="P_SF" offset="4" type="sunssf" len="1" mandatory="true" />
+      <point id="AH_SF" offset="5" type="sunssf" len="1" mandatory="true" />
+      <point id="KWH_SF" offset="6" type="sunssf" len="1" mandatory="true" />
+      <point id="CC_Config_fault" offset="7" type="bitfield16" len="1" mandatory="true" />
+      <point id="CC_Config_absorb_V" offset="8" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_absorb_Hr" offset="9" type="uint16" len="1" sf="H_SF" units="Tmh" mandatory="true" />
+      <point id="CC_Config_absorb_End_A" offset="10" type="uint16" len="1" sf="V_SF" units="A" mandatory="true" />
+      <point id="CC_Config_rebulk_V" offset="11" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_float_V" offset="12" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_max_Chg_A" offset="13" type="uint16" len="1" sf="V_SF" units="A" mandatory="true" />
+      <point id="CC_Config_equalize_V" offset="14" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_equalize_Hr" offset="15" type="uint16" len="1" units="Tmh" mandatory="true" />
+      <point id="CC_Config_auto_equalize" offset="16" type="uint16" len="1" units="Tmd" mandatory="true" />
+      <point id="CC_Config_MPPT_mode" offset="17" type="enum16" len="1" mandatory="true" >
         <symbol id="Auto">0</symbol>
         <symbol id="U_Pick">1</symbol>
         <symbol id="Wind">2</symbol>
       </point>
-      <point id="CC_Config_sweep_width" offset="18" type="enum16" mandatory="true" >
+      <point id="CC_Config_sweep_width" offset="18" type="enum16" len="1" mandatory="true" >
         <symbol id="Half">0</symbol>
         <symbol id="Full">1</symbol>
       </point>
-      <point id="CC_Config_sweep_max" offset="19" type="enum16" mandatory="true" >
+      <point id="CC_Config_sweep_max" offset="19" type="enum16" len="1" mandatory="true" >
         <symbol id="Eighty_Percent">0</symbol>
         <symbol id="Eighty_Five_Percent">1</symbol>
         <symbol id="Ninty_Percent">2</symbol>
         <symbol id="Ninty_Nine_Percent">3</symbol>
       </point>
-      <point id="CC_Config_U_Pick_Duty_cyc" offset="20" type="uint16" sf="V_SF" units="Pct" mandatory="true" />
-      <point id="CC_Config_grid_tie" offset="21" type="enum16" mandatory="true" >
+      <point id="CC_Config_U_Pick_Duty_cyc" offset="20" type="uint16" len="1" sf="V_SF" units="Pct" mandatory="true" />
+      <point id="CC_Config_grid_tie" offset="21" type="enum16" len="1" mandatory="true" >
         <symbol id="Disabled">0</symbol>
         <symbol id="Enabled">1</symbol>
       </point>
-      <point id="CC_Config_temp_comp" offset="22" type="enum16" mandatory="true" >
+      <point id="CC_Config_temp_comp" offset="22" type="enum16" len="1" mandatory="true" >
         <symbol id="Wide">0</symbol>
         <symbol id="Limited">1</symbol>
       </point>
-      <point id="CC_Config_temp_comp_llimt" offset="23" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_temp_comp_hlimt" offset="24" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_auto_restart" offset="25" type="enum16" mandatory="true" >
+      <point id="CC_Config_temp_comp_llimt" offset="23" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_temp_comp_hlimt" offset="24" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_auto_restart" offset="25" type="enum16" len="1" mandatory="true" >
         <symbol id="Off">0</symbol>
         <symbol id="Every_90_Minutes">1</symbol>
         <symbol id="Every_90_Minutes_if_Absorb_or_Float">2</symbol>
       </point>
-      <point id="CC_Config_wakeup_VOC" offset="26" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_snooze_mode_A" offset="27" type="uint16" sf="V_SF" units="A" mandatory="true" />
-      <point id="CC_Config_wakeup_interval" offset="28" type="uint16" units="Tms" mandatory="true" />
-      <point id="CC_Config_AUX_mode" offset="29" type="enum16" mandatory="true" >
+      <point id="CC_Config_wakeup_VOC" offset="26" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_snooze_mode_A" offset="27" type="uint16" len="1" sf="V_SF" units="A" mandatory="true" />
+      <point id="CC_Config_wakeup_interval" offset="28" type="uint16" len="1" units="Tms" mandatory="true" />
+      <point id="CC_Config_AUX_mode" offset="29" type="enum16" len="1" mandatory="true" >
         <symbol id="Float">0</symbol>
         <symbol id="Diversion_Relay">1</symbol>
         <symbol id="Diversion_Solid_St">2</symbol>
@@ -65,50 +65,50 @@
         <symbol id="Error_Output">7</symbol>
         <symbol id="Night_Light">8</symbol>
       </point>
-      <point id="CC_Config_AUX_control" offset="30" type="enum16" mandatory="true" >
+      <point id="CC_Config_AUX_control" offset="30" type="enum16" len="1" mandatory="true" >
         <symbol id="Off">0</symbol>
         <symbol id="Auto">1</symbol>
         <symbol id="On">2</symbol>
       </point>
-      <point id="CC_Config_AUX_state" offset="31" type="enum16" mandatory="true" >
+      <point id="CC_Config_AUX_state" offset="31" type="enum16" len="1" mandatory="true" >
         <symbol id="Disabled">0</symbol>
         <symbol id="Enabled">1</symbol>
       </point>
-      <point id="CC_Config_AUX_polarity" offset="32" type="enum16" mandatory="true" >
+      <point id="CC_Config_AUX_polarity" offset="32" type="enum16" len="1" mandatory="true" >
         <symbol id="Low">0</symbol>
         <symbol id="High">1</symbol>
       </point>
-      <point id="CC_Config_AUX_L_Batt_disc" offset="33" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_AUX_L_Batt_rcon" offset="34" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_AUX_L_Batt_dly" offset="35" type="uint16" units="Tms" mandatory="true" />
-      <point id="CC_Config_AUX_Vent_fan_V" offset="36" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_AUX_PV_triggerV" offset="37" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_AUX_PV_trg_h_tm" offset="38" type="uint16" units="Tms" mandatory="true" />
-      <point id="CC_Config_AUX_Nlite_ThrsV" offset="39" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_AUX_Nlite_On_tm" offset="40" type="uint16" sf="H_SF" units="Tmh" mandatory="true" />
-      <point id="CC_Config_AUX_Nlite_On_hist" offset="41" type="uint16" units="Tms" mandatory="true" />
-      <point id="CC_Config_AUX_Nlite_Off_hist" offset="42" type="uint16" units="Tms" mandatory="true" />
-      <point id="CC_Config_AUX_Error_batt_V" offset="43" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_AUX_Divert_h_time" offset="44" type="uint16" sf="V_SF" units="Tms" mandatory="true" />
-      <point id="CC_Config_AUX_Divert_dly_time" offset="45" type="uint16" units="Tms" mandatory="true" />
-      <point id="CC_Config_AUX_Divert_Rel_V" offset="46" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_AUX_Divert_Hyst_V" offset="47" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_MajorFWRev" offset="48" type="uint16" mandatory="true" />
-      <point id="CC_Config_MidFWRev" offset="49" type="uint16" mandatory="true" />
-      <point id="CC_Config_MinorFWRev" offset="50" type="uint16" mandatory="true" />
-      <point id="CC_Config_DataLog_Day_offset" offset="51" type="uint16" units="Tmd" mandatory="true" />
-      <point id="CC_Config_DataLog_Cur_Day_off" offset="52" type="uint16" units="Tmd" mandatory="true" />
-      <point id="CC_Config_DataLog_Daily_AH" offset="53" type="uint16" units="Ah" mandatory="true" />
-      <point id="CC_Config_DataLog_Daily_KWH" offset="54" type="uint16" sf="KWH_SF" units="kWh" mandatory="true" />
-      <point id="CC_Config_DataLog_Max_Out_A" offset="55" type="uint16" sf="V_SF" units="A" mandatory="true" />
-      <point id="CC_Config_DataLog_Max_Out_W" offset="56" type="uint16" sf="V_SF" units="W" mandatory="true" />
-      <point id="CC_Config_DataLog_Absorb_T" offset="57" type="uint16" units="Tms" mandatory="true" />
-      <point id="CC_Config_DataLog_Float_T" offset="58" type="uint16" units="Tms" mandatory="true" />
-      <point id="CC_Config_DataLog_Min_Batt_V" offset="59" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_DataLog_Max_Batt_V" offset="60" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_DataLog_Max_Input_V" offset="61" type="uint16" sf="V_SF" units="V" mandatory="true" />
-      <point id="CC_Config_DataLog_Clear" offset="62" type="uint16" mandatory="true" />
-      <point id="CC_Config_DataLog_Clr_Comp" offset="63" type="uint16" mandatory="true" />
+      <point id="CC_Config_AUX_L_Batt_disc" offset="33" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_AUX_L_Batt_rcon" offset="34" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_AUX_L_Batt_dly" offset="35" type="uint16" len="1" units="Tms" mandatory="true" />
+      <point id="CC_Config_AUX_Vent_fan_V" offset="36" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_AUX_PV_triggerV" offset="37" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_AUX_PV_trg_h_tm" offset="38" type="uint16" len="1" units="Tms" mandatory="true" />
+      <point id="CC_Config_AUX_Nlite_ThrsV" offset="39" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_AUX_Nlite_On_tm" offset="40" type="uint16" len="1" sf="H_SF" units="Tmh" mandatory="true" />
+      <point id="CC_Config_AUX_Nlite_On_hist" offset="41" type="uint16" len="1" units="Tms" mandatory="true" />
+      <point id="CC_Config_AUX_Nlite_Off_hist" offset="42" type="uint16" len="1" units="Tms" mandatory="true" />
+      <point id="CC_Config_AUX_Error_batt_V" offset="43" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_AUX_Divert_h_time" offset="44" type="uint16" len="1" sf="V_SF" units="Tms" mandatory="true" />
+      <point id="CC_Config_AUX_Divert_dly_time" offset="45" type="uint16" len="1" units="Tms" mandatory="true" />
+      <point id="CC_Config_AUX_Divert_Rel_V" offset="46" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_AUX_Divert_Hyst_V" offset="47" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_MajorFWRev" offset="48" type="uint16" len="1" mandatory="true" />
+      <point id="CC_Config_MidFWRev" offset="49" type="uint16" len="1" mandatory="true" />
+      <point id="CC_Config_MinorFWRev" offset="50" type="uint16" len="1" mandatory="true" />
+      <point id="CC_Config_DataLog_Day_offset" offset="51" type="uint16" len="1" units="Tmd" mandatory="true" />
+      <point id="CC_Config_DataLog_Cur_Day_off" offset="52" type="uint16" len="1" units="Tmd" mandatory="true" />
+      <point id="CC_Config_DataLog_Daily_AH" offset="53" type="uint16" len="1" units="Ah" mandatory="true" />
+      <point id="CC_Config_DataLog_Daily_KWH" offset="54" type="uint16" len="1" sf="KWH_SF" units="kWh" mandatory="true" />
+      <point id="CC_Config_DataLog_Max_Out_A" offset="55" type="uint16" len="1" sf="V_SF" units="A" mandatory="true" />
+      <point id="CC_Config_DataLog_Max_Out_W" offset="56" type="uint16" len="1" sf="V_SF" units="W" mandatory="true" />
+      <point id="CC_Config_DataLog_Absorb_T" offset="57" type="uint16" len="1" units="Tms" mandatory="true" />
+      <point id="CC_Config_DataLog_Float_T" offset="58" type="uint16" len="1" units="Tms" mandatory="true" />
+      <point id="CC_Config_DataLog_Min_Batt_V" offset="59" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_DataLog_Max_Batt_V" offset="60" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_DataLog_Max_Input_V" offset="61" type="uint16" len="1" sf="V_SF" units="V" mandatory="true" />
+      <point id="CC_Config_DataLog_Clear" offset="62" type="uint16" len="1" mandatory="true" />
+      <point id="CC_Config_DataLog_Clr_Comp" offset="63" type="uint16" len="1" mandatory="true" />
     </block>
   </model>
   <strings id="64112" locale="en">

--- a/smdx/smdx_64112.xml
+++ b/smdx/smdx_64112.xml
@@ -114,458 +114,458 @@
   <strings id="64112" locale="en">
     <model>
       <label>OutBack FM Charge Controller</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </model>
     <point id="Port">
       <label>Port Number</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_fault">
       <label>Faults</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_absorb_V">
       <label>Absorb</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_absorb_Hr">
       <label>Absorb Time</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_absorb_End_A">
       <label>Absorb End</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_rebulk_V">
       <label>Rebulk</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_float_V">
       <label>Float</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_max_Chg_A">
       <label>Maximum Charge</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_equalize_V">
       <label>Equalize</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_equalize_Hr">
       <label>Equalize Time</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_auto_equalize">
       <label>Auto Equalize Interval</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_MPPT_mode">
       <label>MPPT mode</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="Auto">
         <label>Auto</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="U_Pick">
         <label>U-Pick</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Wind">
         <label>Wind</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="CC_Config_sweep_width">
       <label>Sweep Width</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="Half">
         <label>Half</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Full">
         <label>Full</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="CC_Config_sweep_max">
       <label>Sweep Maximum</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="Eighty_Percent">
         <label>80 %</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Eighty_Five_Percent">
         <label>85 %</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Ninty_Percent">
         <label>90 %</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Ninty_Nine_Percent">
         <label>99 %</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="CC_Config_U_Pick_Duty_cyc">
       <label>U-Pick PWM Duty Cycle</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_grid_tie">
       <label>Grid Tie Mode</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="Disabled">
         <label>Grid Tie Mode Disabled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Enabled">
         <label>Grid Tie Mode Enabled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="CC_Config_temp_comp">
       <label>Temp Comp Mode</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="Wide">
         <label>Wide</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Limited">
         <label>Limited</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="CC_Config_temp_comp_llimt">
       <label>Temp Comp Lower Limit</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_temp_comp_hlimt">
       <label>Temp Comp Upper Limit</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_auto_restart">
       <label>Auto Restart Mode</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="Off">
         <label>Off</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Every_90_Minutes">
         <label>Every 90 Minutes</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Every_90_Minutes_if_Absorb_or_Float">
         <label>Every 90 Minutes if Absorb or Float</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="CC_Config_wakeup_VOC">
       <label>Wakeup VOC Change</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_snooze_mode_A">
       <label>Snooze Mode</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_wakeup_interval">
       <label>Wakeup Interval</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_mode">
       <label>AUX Output Mode</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="Float">
         <label>Float</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Diversion_Relay">
         <label>Diversion: Relay</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Diversion_Solid_St">
         <label>Diversion: Solid St</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Low_Batt_Disconnect">
         <label>Low Batt Disconnect</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Remote">
         <label>Remote</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Vent_Fan">
         <label>Vent Fan</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="PV_Trigger">
         <label>PV Trigger</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Error_Output">
         <label>Alarm Output</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Night_Light">
         <label>Night Light</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="CC_Config_AUX_control">
       <label>AUX Output Control</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="Off">
         <label>Off</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Auto">
         <label>Auto</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="On">
         <label>On</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="CC_Config_AUX_state">
       <label>AUX Output State</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="Disabled">
         <label>Disabled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="Enabled">
         <label>Enabled</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="CC_Config_AUX_polarity">
       <label>AUX Output Polarity</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
       <symbol id="Low">
         <label>Low</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
       <symbol id="High">
         <label>High</label>
-        <description></description>
-        <notes></notes>
+        <description/>
+        <notes/>
       </symbol>
     </point>
     <point id="CC_Config_AUX_L_Batt_disc">
       <label>AUX Low Battery Disconnect</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_L_Batt_rcon">
       <label>AUX Low Battery Reconnect</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_L_Batt_dly">
       <label>AUX Low Battery Disconnect Delay</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_Vent_fan_V">
       <label>AUX Vent Fan</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_PV_triggerV">
       <label>AUX PV Trigger</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_PV_trg_h_tm">
       <label>AUX PV Trigger Hold Time</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_Nlite_ThrsV">
       <label>AUX Night Light Threshold</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_Nlite_On_tm">
       <label>AUX Night Light On Time</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_Nlite_On_hist">
       <label>AUX Night Light On Hysteresis</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_Nlite_Off_hist">
       <label>AUX Night Light Off Hysteresis</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_Error_batt_V">
       <label>AUX Error Output Low Battery</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_Divert_h_time">
       <label>AUX Divert Hold Time</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_Divert_dly_time">
       <label>AUX Divert Delay Time</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_Divert_Rel_V">
       <label>AUX Divert Relative</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_AUX_Divert_Hyst_V">
       <label>AUX Divert Hysteresis</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_MajorFWRev">
       <label>FM CC Major Firmware Number</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_MidFWRev">
       <label>FM CC Mid Firmware Number</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_MinorFWRev">
       <label>FM CC Minor Firmware Number</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Day_offset">
       <label>Set Data Log Day Offset</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Cur_Day_off">
       <label>Current Data Log Day Offset</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Daily_AH">
       <label>Data Log Daily (Ah)</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Daily_KWH">
       <label>Data Log Daily (kWh)</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Max_Out_A">
       <label>Data Log Daily Maximum Output (A)</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Max_Out_W">
       <label>Data Log Daily Maximum Output (W)</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Absorb_T">
       <label>Data Log Daily Absorb Time</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Float_T">
       <label>Data Log Daily Float Time</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Min_Batt_V">
       <label>Data Log Daily Minimum Battery</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Max_Batt_V">
       <label>Data Log Daily Maximum Battery</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Max_Input_V">
       <label>Data Log Daily Maximum Input</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Clear">
       <label>Data Log Clear</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
     <point id="CC_Config_DataLog_Clr_Comp">
       <label>Data Log Clear Complement</label>
-      <description></description>
-      <notes></notes>
+      <description/>
+      <notes/>
     </point>
   </strings>
 </sunSpecModels>


### PR DESCRIPTION
This touches only the XML form of the specification and is intended to resolve unclear parts and fix bad xml:
- All points have an explicit len indicating how many modbus registers must be read.
- Trivial attributes values that are the same as the default specified in the schema have been removed (like access="r" and mandatory="false")
- The attribute  units="" is meaningless and removed
- All blocks have an explict type (fixed/repeating)
- Because I used custom software to do this cleanup all attributes are in the same order everywhere. In fact: I parsed the json and generated the xml from that and then manually cherry picked and verified the changes I'm proposing here.
