### PR TITLE
Add notes from SMDX files to JSON models

### DIFF
--- a/json/model_101.json
+++ b/json/model_101.json
@@ -41,7 +41,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "desc": "Phase B Current",

--- a/json/model_102.json
+++ b/json/model_102.json
@@ -31,7 +31,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "A"
+                "units": "A",
+                "notes": "Sum of active phases"
             },
             {
                 "desc": "Phase A Current",
@@ -41,7 +42,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "desc": "Phase B Current",
@@ -51,7 +53,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "desc": "Phase C Current",

--- a/json/model_103.json
+++ b/json/model_103.json
@@ -31,7 +31,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "A"
+                "units": "A",
+                "notes": "Sum of active phases"
             },
             {
                 "desc": "Phase A Current",
@@ -41,7 +42,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "desc": "Phase B Current",
@@ -51,7 +53,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "desc": "Phase C Current",
@@ -61,7 +64,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "mandatory": "M",

--- a/json/model_111.json
+++ b/json/model_111.json
@@ -39,7 +39,8 @@
                 "name": "AphA",
                 "size": 2,
                 "type": "float32",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "desc": "Phase B Current",

--- a/json/model_112.json
+++ b/json/model_112.json
@@ -39,7 +39,8 @@
                 "name": "AphA",
                 "size": 2,
                 "type": "float32",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "desc": "Phase B Current",
@@ -48,7 +49,8 @@
                 "name": "AphB",
                 "size": 2,
                 "type": "float32",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "desc": "Phase C Current",

--- a/json/model_113.json
+++ b/json/model_113.json
@@ -30,7 +30,8 @@
                 "name": "A",
                 "size": 2,
                 "type": "float32",
-                "units": "A"
+                "units": "A",
+                "notes": "Sum of active phases"
             },
             {
                 "desc": "Phase A Current",
@@ -39,7 +40,8 @@
                 "name": "AphA",
                 "size": 2,
                 "type": "float32",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "desc": "Phase B Current",
@@ -48,7 +50,8 @@
                 "name": "AphB",
                 "size": 2,
                 "type": "float32",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "desc": "Phase C Current",
@@ -57,7 +60,8 @@
                 "name": "AphC",
                 "size": 2,
                 "type": "float32",
-                "units": "A"
+                "units": "A",
+                "notes": "Connected Phase"
             },
             {
                 "desc": "Phase Voltage AB",

--- a/json/model_120.json
+++ b/json/model_120.json
@@ -133,7 +133,8 @@
                 "sf": "ARtg_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "A"
+                "units": "A",
+                "notes": "Sum of all connected phases.  Current rating under nominal voltage under nominal power factor."
             },
             {
                 "desc": "Scale factor",
@@ -151,7 +152,8 @@
                 "sf": "PFRtg_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "cos()"
+                "units": "cos()",
+                "notes": "EEI sign convention."
             },
             {
                 "desc": "Minimum power factor capability of the inverter in quadrant 2.",
@@ -161,7 +163,8 @@
                 "sf": "PFRtg_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "cos()"
+                "units": "cos()",
+                "notes": "EEI sign convention."
             },
             {
                 "desc": "Minimum power factor capability of the inverter in quadrant 3.",
@@ -171,7 +174,8 @@
                 "sf": "PFRtg_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "cos()"
+                "units": "cos()",
+                "notes": "EEI sign convention."
             },
             {
                 "desc": "Minimum power factor capability of the inverter in quadrant 4.",
@@ -181,7 +185,8 @@
                 "sf": "PFRtg_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "cos()"
+                "units": "cos()",
+                "notes": "EEI sign convention."
             },
             {
                 "desc": "Scale factor",
@@ -263,7 +268,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.14.3.2, Ref 4: 17"
     },
     "id": 120
 }

--- a/json/model_121.json
+++ b/json/model_121.json
@@ -144,7 +144,8 @@
                 "sf": "PFMin_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "cos()"
+                "units": "cos()",
+                "notes": "EEI sign convention."
             },
             {
                 "access": "RW",
@@ -154,7 +155,8 @@
                 "sf": "PFMin_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "cos()"
+                "units": "cos()",
+                "notes": "EEI sign convention."
             },
             {
                 "access": "RW",
@@ -164,7 +166,8 @@
                 "sf": "PFMin_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "cos()"
+                "units": "cos()",
+                "notes": "EEI sign convention."
             },
             {
                 "access": "RW",
@@ -174,7 +177,8 @@
                 "sf": "PFMin_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "cos()"
+                "units": "cos()",
+                "notes": "EEI sign convention."
             },
             {
                 "access": "RW",
@@ -328,7 +332,8 @@
                 "type": "sunssf"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.4.2.1, Ref 4: 17"
     },
     "id": 121
 }

--- a/json/model_122.json
+++ b/json/model_122.json
@@ -220,7 +220,8 @@
                         "value": 10
                     }
                 ],
-                "type": "bitfield32"
+                "type": "bitfield32",
+                "notes": "Bits shall be automatically cleared on read."
             },
             {
                 "desc": "Bit Mask indicating which inverter controls are currently active.",
@@ -344,7 +345,8 @@
                 "type": "sunssf"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.14.3.2, Ref 4: 17"
     },
     "id": 122
 }

--- a/json/model_123.json
+++ b/json/model_123.json
@@ -300,7 +300,8 @@
                 "type": "sunssf"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.7.1.2, 8.7.2.2, 8.7.3.2"
     },
     "id": 123
 }

--- a/json/model_124.json
+++ b/json/model_124.json
@@ -281,7 +281,8 @@
                 "type": "sunssf"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.7.4.2"
     },
     "id": 124
 }

--- a/json/model_125.json
+++ b/json/model_125.json
@@ -119,7 +119,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.7.5.1; Ref 4: 6"
     },
     "id": 125
 }

--- a/json/model_126.json
+++ b/json/model_126.json
@@ -590,7 +590,8 @@
                 "type": "sunssf"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.8.1.2"
     },
     "id": 126
 }

--- a/json/model_127.json
+++ b/json/model_127.json
@@ -123,7 +123,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.9.1.2, 8.9.4.2"
     },
     "id": 127
 }

--- a/json/model_128.json
+++ b/json/model_128.json
@@ -167,7 +167,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.10.1.2; Ref 4: 12"
     },
     "id": 128
 }

--- a/json/model_129.json
+++ b/json/model_129.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -558,7 +561,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 129
 }

--- a/json/model_130.json
+++ b/json/model_130.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for HVRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for HVRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for HVRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -558,7 +561,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 130
 }

--- a/json/model_131.json
+++ b/json/model_131.json
@@ -594,7 +594,8 @@
                 "type": "sunssf"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.11.1.2"
     },
     "id": 131
 }

--- a/json/model_132.json
+++ b/json/model_132.json
@@ -608,7 +608,8 @@
                 "type": "sunssf"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.12.1.2"
     },
     "id": 132
 }

--- a/json/model_133.json
+++ b/json/model_133.json
@@ -609,7 +609,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 2: 2.2.8"
     },
     "id": 133
 }

--- a/json/model_134.json
+++ b/json/model_134.json
@@ -641,7 +641,8 @@
                 "units": "SF"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 3: 8.9.1.2, 8.9.4.2"
     },
     "id": 134
 }

--- a/json/model_135.json
+++ b/json/model_135.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -558,7 +561,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 135
 }

--- a/json/model_136.json
+++ b/json/model_136.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for HFRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for HFRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for HFRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -558,7 +561,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 136
 }

--- a/json/model_137.json
+++ b/json/model_137.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -558,7 +561,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 137
 }

--- a/json/model_138.json
+++ b/json/model_138.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for HVRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for HVRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for HVRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -558,7 +561,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 138
 }

--- a/json/model_139.json
+++ b/json/model_139.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -565,7 +568,8 @@
                 "type": "enum16"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 139
 }

--- a/json/model_140.json
+++ b/json/model_140.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LVRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -565,7 +568,8 @@
                 "type": "enum16"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 140
 }

--- a/json/model_141.json
+++ b/json/model_141.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -558,7 +561,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 141
 }

--- a/json/model_142.json
+++ b/json/model_142.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -558,7 +561,8 @@
                 "type": "pad"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 142
 }

--- a/json/model_143.json
+++ b/json/model_143.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -565,7 +568,8 @@
                 "type": "enum16"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 143
 }

--- a/json/model_144.json
+++ b/json/model_144.json
@@ -500,7 +500,8 @@
                 "name": "WinTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "access": "RW",
@@ -509,7 +510,8 @@
                 "name": "RvrtTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "access": "RW",
@@ -518,7 +520,8 @@
                 "name": "RmpTms",
                 "size": 1,
                 "type": "uint16",
-                "units": "Secs"
+                "units": "Secs",
+                "notes": "Setting is ignored for LFRT controls."
             },
             {
                 "desc": "Number of curves supported (recommend 4).",
@@ -565,7 +568,8 @@
                 "type": "enum16"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Ref 4: 11"
     },
     "id": 144
 }

--- a/json/model_201.json
+++ b/json/model_201.json
@@ -75,7 +75,8 @@
                 "sf": "V_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "V"
+                "units": "V",
+                "notes": "Conditional AN connection"
             },
             {
                 "desc": "Phase Voltage AN",
@@ -84,7 +85,8 @@
                 "sf": "V_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "V"
+                "units": "V",
+                "notes": "Conditional AN connection"
             },
             {
                 "desc": "Phase Voltage BN",
@@ -120,7 +122,8 @@
                 "sf": "V_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "V"
+                "units": "V",
+                "notes": "Conditional AB connection"
             },
             {
                 "desc": "Phase Voltage BC",

--- a/json/model_211.json
+++ b/json/model_211.json
@@ -607,7 +607,8 @@
                 "type": "bitfield32"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Float"
     },
     "id": 211
 }

--- a/json/model_212.json
+++ b/json/model_212.json
@@ -613,7 +613,8 @@
                 "type": "bitfield32"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Float"
     },
     "id": 212
 }

--- a/json/model_213.json
+++ b/json/model_213.json
@@ -617,7 +617,8 @@
                 "type": "bitfield32"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Float"
     },
     "id": 213
 }

--- a/json/model_214.json
+++ b/json/model_214.json
@@ -613,7 +613,8 @@
                 "type": "bitfield32"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Float"
     },
     "id": 214
 }

--- a/json/model_220.json
+++ b/json/model_220.json
@@ -376,7 +376,8 @@
                 "symbols": [
                     {
                         "name": "NONE",
-                        "value": 0
+                        "value": 0,
+                        "notes": "For test purposes only"
                     },
                     {
                         "name": "AES-GMAC-64",

--- a/json/model_220.json
+++ b/json/model_220.json
@@ -364,7 +364,8 @@
                 "mandatory": "M",
                 "name": "Seq",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Shall be advanced for each request"
             },
             {
                 "desc": "Algorithm used to compute the digital signature",
@@ -386,7 +387,8 @@
                         "value": 2
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "For future proof"
             },
             {
                 "desc": "Number of registers comprising the digital signature.",
@@ -394,7 +396,8 @@
                 "mandatory": "M",
                 "name": "N",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "The value of N must be at least 4 (64 bits)"
             }
         ],
         "type": "group"

--- a/json/model_3.json
+++ b/json/model_3.json
@@ -47,7 +47,8 @@
                 "mandatory": "M",
                 "name": "X",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "A max of 50 registers are allowed"
             },
             {
                 "access": "RW",
@@ -426,7 +427,8 @@
                 "mandatory": "M",
                 "name": "Seq",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Shall be advanced for each request"
             },
             {
                 "access": "RW",
@@ -435,7 +437,8 @@
                 "mandatory": "M",
                 "name": "Role",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "User's role id 0-5"
             },
             {
                 "desc": "Algorithm used to compute the digital signature",
@@ -457,7 +460,8 @@
                         "value": 2
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "For future proof"
             },
             {
                 "desc": "Number of registers comprising the digital signature.",
@@ -465,10 +469,12 @@
                 "mandatory": "M",
                 "name": "N",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "The value of N must be at least 4 (64 bits)"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Used in conjunction with Secure Dataset Read Response Model"
     },
     "id": 3
 }

--- a/json/model_3.json
+++ b/json/model_3.json
@@ -449,7 +449,8 @@
                 "symbols": [
                     {
                         "name": "NONE",
-                        "value": 0
+                        "value": 0,
+                        "notes": "For test purposes only"
                     },
                     {
                         "name": "AES-GMAC-64",

--- a/json/model_307.json
+++ b/json/model_307.json
@@ -102,7 +102,8 @@
                 "units": "Pct"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "This model supersedes model 301"
     },
     "id": 307
 }

--- a/json/model_4.json
+++ b/json/model_4.json
@@ -65,11 +65,13 @@
                     },
                     {
                         "name": "ACL",
-                        "value": 2
+                        "value": 2,
+                        "notes": "One or more registers were not writable by this role"
                     },
                     {
                         "name": "OFF",
-                        "value": 3
+                        "value": 3,
+                        "notes": "Offset out of range or missing from multi-register value"
                     }
                 ],
                 "type": "enum16"
@@ -424,7 +426,8 @@
                     },
                     {
                         "name": "ALM",
-                        "value": 1
+                        "value": 1,
+                        "notes": "Tampered"
                     }
                 ],
                 "type": "enum16"
@@ -438,7 +441,8 @@
                 "symbols": [
                     {
                         "name": "NONE",
-                        "value": 0
+                        "value": 0,
+                        "notes": "For test purposes only"
                     },
                     {
                         "name": "AES-GMAC-64",

--- a/json/model_4.json
+++ b/json/model_4.json
@@ -80,7 +80,8 @@
                 "mandatory": "M",
                 "name": "X",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "A max of 50 values are allocated"
             },
             {
                 "desc": "Copy of value from register Off1.",
@@ -88,7 +89,8 @@
                 "mandatory": "M",
                 "name": "Val1",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Unused values shall return 0xFFFF (unimplemented)"
             },
             {
                 "mandatory": "M",
@@ -406,7 +408,8 @@
                 "mandatory": "M",
                 "name": "Seq",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Shall be advanced for each response"
             },
             {
                 "desc": "Bitmask alarm code",
@@ -446,7 +449,8 @@
                         "value": 2
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "For future proof"
             },
             {
                 "desc": "Number of registers comprising the digital signature.",
@@ -454,7 +458,8 @@
                 "mandatory": "M",
                 "name": "N",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "The value of N must be at least 4 (64 bits)"
             }
         ],
         "type": "group"

--- a/json/model_401.json
+++ b/json/model_401.json
@@ -319,7 +319,8 @@
                 "units": "C"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "This model is SUPERSEDED by model 403"
     },
     "id": 401
 }

--- a/json/model_402.json
+++ b/json/model_402.json
@@ -397,7 +397,8 @@
                 "units": "Wh"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "This model is SUPERSEDED by model 404"
     },
     "id": 402
 }

--- a/json/model_403.json
+++ b/json/model_403.json
@@ -331,7 +331,8 @@
                 "type": "sunssf"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "This model supersedes model 401"
     },
     "id": 403
 }

--- a/json/model_404.json
+++ b/json/model_404.json
@@ -429,7 +429,8 @@
                 "type": "sunssf"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "This model supersedes model 402"
     },
     "id": 404
 }

--- a/json/model_5.json
+++ b/json/model_5.json
@@ -663,7 +663,8 @@
                 "symbols": [
                     {
                         "name": "NONE",
-                        "value": 0
+                        "value": 0,
+                        "notes": "For test purposes only"
                     },
                     {
                         "name": "AES-GMAC-64",

--- a/json/model_5.json
+++ b/json/model_5.json
@@ -48,7 +48,8 @@
                 "mandatory": "M",
                 "name": "X",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "A max of 50 (offset, value) pairs are allocated"
             },
             {
                 "access": "RW",
@@ -639,7 +640,8 @@
                 "mandatory": "M",
                 "name": "Seq",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Shall be advanced for each request"
             },
             {
                 "access": "RW",
@@ -648,7 +650,8 @@
                 "mandatory": "M",
                 "name": "Role",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Each controller is assigned a key index that maps to their access control role"
             },
             {
                 "access": "RW",
@@ -671,7 +674,8 @@
                         "value": 2
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "For future proof"
             },
             {
                 "access": "RW",
@@ -680,7 +684,8 @@
                 "mandatory": "M",
                 "name": "N",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "The value of N must be at least 4 (64 bits)"
             }
         ],
         "type": "group"

--- a/json/model_501.json
+++ b/json/model_501.json
@@ -286,7 +286,8 @@
                 "units": "W"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Float"
     },
     "id": 501
 }

--- a/json/model_502.json
+++ b/json/model_502.json
@@ -318,7 +318,8 @@
                 "units": "W"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Integer"
     },
     "id": 502
 }

--- a/json/model_6.json
+++ b/json/model_6.json
@@ -678,7 +678,8 @@
                 "symbols": [
                     {
                         "name": "NONE",
-                        "value": 0
+                        "value": 0,
+                        "notes": "For test purposes only"
                     },
                     {
                         "name": "AES-GMAC-64",

--- a/json/model_6.json
+++ b/json/model_6.json
@@ -48,7 +48,8 @@
                 "mandatory": "M",
                 "name": "X",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "A max of 50 (offset, value) pairs are allocated"
             },
             {
                 "access": "RW",
@@ -57,7 +58,8 @@
                 "mandatory": "M",
                 "name": "Off",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "X values to follow"
             },
             {
                 "access": "RW",
@@ -646,7 +648,8 @@
                 "mandatory": "M",
                 "name": "Seq",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Shall be advanced for each request"
             },
             {
                 "access": "RW",
@@ -655,7 +658,8 @@
                 "mandatory": "M",
                 "name": "Role",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Each controller is assigned a key index that maps to their access control role"
             },
             {
                 "access": "RW",
@@ -685,7 +689,8 @@
                         "value": 2
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "For future proof"
             },
             {
                 "access": "RW",
@@ -694,7 +699,8 @@
                 "mandatory": "M",
                 "name": "N",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "The value of N must be at least 4 (64 bits)"
             }
         ],
         "type": "group"

--- a/json/model_601.json
+++ b/json/model_601.json
@@ -246,7 +246,8 @@
                         "value": 2
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "The global controls all trackers"
             },
             {
                 "desc": "Global tracker alarm conditions",
@@ -267,7 +268,8 @@
                         "value": 2
                     }
                 ],
-                "type": "bitfield16"
+                "type": "bitfield16",
+                "notes": "Combined tracker alarm conditions.  See individual trackers for alarms"
             },
             {
                 "desc": "Scale Factor for targets and position measurements in degrees",
@@ -286,7 +288,8 @@
                 "type": "uint16"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Trackers may include GPS model 305 for location information"
     },
     "id": 601
 }

--- a/json/model_7.json
+++ b/json/model_7.json
@@ -62,19 +62,23 @@
                     },
                     {
                         "name": "DS",
-                        "value": 1
+                        "value": 1,
+                        "notes": "The signature was not valid"
                     },
                     {
                         "name": "ACL",
-                        "value": 2
+                        "value": 2,
+                        "notes": "One or more registers were not writable by this role"
                     },
                     {
                         "name": "OFF",
-                        "value": 3
+                        "value": 3,
+                        "notes": "Offset out of range or missing from multi-register value"
                     },
                     {
                         "name": "VAL",
-                        "value": 4
+                        "value": 4,
+                        "notes": "Value is out of acceptable range"
                     }
                 ],
                 "type": "enum16"
@@ -117,7 +121,8 @@
                     },
                     {
                         "name": "ALM",
-                        "value": 1
+                        "value": 1,
+                        "notes": "Tampered"
                     }
                 ],
                 "type": "enum16"
@@ -137,7 +142,8 @@
                 "symbols": [
                     {
                         "name": "NONE",
-                        "value": 0
+                        "value": 0,
+                        "notes": "For test purposes only"
                     },
                     {
                         "name": "AES-GMAC-64",

--- a/json/model_7.json
+++ b/json/model_7.json
@@ -101,7 +101,8 @@
                 "mandatory": "M",
                 "name": "Seq",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Shall be advanced for each response"
             },
             {
                 "desc": "Bitmask alarm code",
@@ -147,7 +148,8 @@
                         "value": 2
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "For future proof"
             },
             {
                 "access": "RW",
@@ -156,10 +158,12 @@
                 "mandatory": "M",
                 "name": "N",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "The value of N must be at least 4 (64 bits)"
             }
         ],
-        "type": "group"
+        "type": "group",
+        "notes": "Used in conjunction with a Secure Write Request"
     },
     "id": 7
 }

--- a/json/model_802.json
+++ b/json/model_802.json
@@ -192,11 +192,13 @@
                 "symbols": [
                     {
                         "name": "REMOTE",
-                        "value": 0
+                        "value": 0,
+                        "notes": "Value of 0 matches LocRemCtl in IEC 61850."
                     },
                     {
                         "name": "LOCAL",
-                        "value": 1
+                        "value": 1,
+                        "notes": "Value of 1 matches LocRemCtl in IEC 61850."
                     }
                 ],
                 "type": "enum16",
@@ -369,19 +371,23 @@
                     },
                     {
                         "name": "OVER_CHARGE_CURRENT_ALARM",
-                        "value": 5
+                        "value": 5,
+                        "notes": "See AChaMax."
                     },
                     {
                         "name": "OVER_CHARGE_CURRENT_WARNING",
-                        "value": 6
+                        "value": 6,
+                        "notes": "See AChaMax."
                     },
                     {
                         "name": "OVER_DISCHARGE_CURRENT_ALARM",
-                        "value": 7
+                        "value": 7,
+                        "notes": "See ADisChaMax."
                     },
                     {
                         "name": "OVER_DISCHARGE_CURRENT_WARNING",
-                        "value": 8
+                        "value": 8,
+                        "notes": "See ADisChaMax."
                     },
                     {
                         "name": "OVER_VOLT_ALARM",
@@ -449,15 +455,18 @@
                     },
                     {
                         "name": "OTHER_ALARM",
-                        "value": 25
+                        "value": 25,
+                        "notes": "See EvtVnd1 and EvtVnd2 for more information."
                     },
                     {
                         "name": "OTHER_WARNING",
-                        "value": 26
+                        "value": 26,
+                        "notes": "See EvtVnd1 and EvtVnd2 for more information."
                     },
                     {
                         "name": "RESERVED_1",
-                        "value": 27
+                        "value": 27,
+                        "notes": "Do not implement."
                     },
                     {
                         "name": "CONFIGURATION_ALARM",
@@ -638,11 +647,13 @@
                     },
                     {
                         "name": "START",
-                        "value": 1
+                        "value": 1,
+                        "notes": "Battery is notified of inverter state change through SetInvState."
                     },
                     {
                         "name": "STOP",
-                        "value": 2
+                        "value": 2,
+                        "notes": "Battery is notified of inverter state change through SetInvState."
                     }
                 ],
                 "type": "enum16",

--- a/json/model_802.json
+++ b/json/model_802.json
@@ -117,7 +117,8 @@
                 "sf": "SoC_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "%WHRtg"
+                "units": "%WHRtg",
+                "notes": "Measurement."
             },
             {
                 "desc": "Depth of discharge, expressed as a percentage.",
@@ -126,7 +127,8 @@
                 "sf": "DoD_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "%"
+                "units": "%",
+                "notes": "Measurement."
             },
             {
                 "desc": "Percentage of battery life remaining.",
@@ -197,7 +199,8 @@
                         "value": 1
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "Maps to DRCC.LocRemCtl in IEC 61850."
             },
             {
                 "desc": "Value is incremented every second with periodic resets to zero.",
@@ -221,7 +224,8 @@
                 "mandatory": "M",
                 "name": "AlmRst",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Battery should reset to 0 when reset is complete."
             },
             {
                 "desc": "Type of battery. Enumeration.",
@@ -279,7 +283,8 @@
                         "value": 99
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "Maps to DBAT.BatTyp in 61850."
             },
             {
                 "desc": "State of the battery bank.  Enumeration.",
@@ -317,7 +322,8 @@
                         "value": 99
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "Must be reconciled with State in IEC 61850."
             },
             {
                 "desc": "Vendor specific battery bank state.  Enumeration.",
@@ -331,7 +337,8 @@
                 "label": "Warranty Date",
                 "name": "WarrDt",
                 "size": 2,
-                "type": "uint32"
+                "type": "uint32",
+                "notes": "Number of days since 1/1/2000."
             },
             {
                 "desc": "Alarms and warnings.  Bit flags.",
@@ -469,7 +476,8 @@
                 "mandatory": "M",
                 "name": "Evt2",
                 "size": 2,
-                "type": "bitfield32"
+                "type": "bitfield32",
+                "notes": "Reserved for future use."
             },
             {
                 "desc": "Vendor defined events.",
@@ -495,7 +503,8 @@
                 "sf": "V_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Maps to ZBAT.V in IEC 61850."
             },
             {
                 "desc": "Instantaneous maximum battery voltage.",
@@ -504,7 +513,8 @@
                 "sf": "V_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "If not implemented, must implement AChaMax and ADisChaMax."
             },
             {
                 "desc": "Instantaneous minimum battery voltage.",
@@ -513,7 +523,8 @@
                 "sf": "V_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "If not implemented, must implement AChaMax and ADisChaMax."
             },
             {
                 "desc": "Maximum voltage for all cells in the bank.",
@@ -522,7 +533,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "String containing the cell with maximum voltage.",
@@ -545,7 +557,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "String containing the cell with minimum voltage.",
@@ -568,7 +581,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Calculation based on measurements."
             },
             {
                 "desc": "Total DC current flowing to/from the battery bank.",
@@ -578,7 +592,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "A"
+                "units": "A",
+                "notes": "Measurement."
             },
             {
                 "desc": "Instantaneous maximum DC charge current.",
@@ -587,7 +602,8 @@
                 "sf": "AMax_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "A"
+                "units": "A",
+                "notes": "Calculation which is always unsigned (i.e. magnitude only). If not implemented, must implement VMax and VMin."
             },
             {
                 "desc": "Instantaneous maximum DC discharge current.",
@@ -596,7 +612,8 @@
                 "sf": "AMax_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "A"
+                "units": "A",
+                "notes": "Calculation which is always unsigned (i.e. magnitude only). If not implemented, must implement VMax and VMin."
             },
             {
                 "desc": "Total power flowing to/from the battery bank.",
@@ -606,7 +623,8 @@
                 "sf": "W_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "W"
+                "units": "W",
+                "notes": "Measurement."
             },
             {
                 "desc": "Request from battery to start or stop the inverter.  Enumeration.",
@@ -627,7 +645,8 @@
                         "value": 2
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "Used in special states such as manual battery charging."
             },
             {
                 "desc": "AC Power requested by battery.",
@@ -636,7 +655,8 @@
                 "sf": "W_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "W"
+                "units": "W",
+                "notes": "Used in special states such as string balancing."
             },
             {
                 "access": "RW",
@@ -678,7 +698,8 @@
                         "value": 3
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "Information needed by battery for some operations."
             },
             {
                 "desc": "Scale factor for charge capacity.",

--- a/json/model_803.json
+++ b/json/model_803.json
@@ -606,7 +606,8 @@
                 "name": "ModTmpMax",
                 "sf": "ModTmp_SF",
                 "size": 1,
-                "type": "int16"
+                "type": "int16",
+                "notes": "Measurement."
             },
             {
                 "desc": "String containing the module with maximum temperature.",
@@ -630,7 +631,8 @@
                 "sf": "ModTmp_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "C"
+                "units": "C",
+                "notes": "Measurement."
             },
             {
                 "desc": "String containing the module with minimum temperature.",
@@ -651,7 +653,8 @@
                 "label": "Average Module Temperature",
                 "name": "ModTmpAvg",
                 "size": 1,
-                "type": "int16"
+                "type": "int16",
+                "notes": "Calculation based on measurements."
             },
             {
                 "desc": "Maximum string voltage for all strings in the bank.",
@@ -660,7 +663,8 @@
                 "sf": "V_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "String with maximum voltage.",
@@ -676,7 +680,8 @@
                 "sf": "V_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "String with minimum voltage.",
@@ -692,7 +697,8 @@
                 "sf": "V_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Calculation based on measurements."
             },
             {
                 "desc": "Maximum current of any string in the bank.",
@@ -701,7 +707,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "A"
+                "units": "A",
+                "notes": "Measurement."
             },
             {
                 "desc": "String with the maximum current.",
@@ -717,7 +724,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "A"
+                "units": "A",
+                "notes": "Measurement."
             },
             {
                 "desc": "String with the minimum current.",
@@ -733,7 +741,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "A"
+                "units": "A",
+                "notes": "Calculation based on measurements."
             },
             {
                 "desc": "Total number of cells that are currently being balanced.",

--- a/json/model_804.json
+++ b/json/model_804.json
@@ -201,7 +201,8 @@
                     },
                     {
                         "name": "CONTACTOR_STATUS",
-                        "value": 1
+                        "value": 1,
+                        "notes": "If string has multiple contactors, indicates that all contactors are closed."
                     }
                 ],
                 "type": "bitfield32"
@@ -245,7 +246,8 @@
                     },
                     {
                         "name": "STRING_FAULT",
-                        "value": 8
+                        "value": 8,
+                        "notes": "See Evt1 for more information."
                     }
                 ],
                 "type": "enum16"
@@ -582,19 +584,23 @@
                     },
                     {
                         "name": "OVER_CHARGE_CURRENT_ALARM",
-                        "value": 5
+                        "value": 5,
+                        "notes": "See AChaMax in model S 802."
                     },
                     {
                         "name": "OVER_CHARGE_CURRENT_WARNING",
-                        "value": 6
+                        "value": 6,
+                        "notes": "See AChaMax in model S 802."
                     },
                     {
                         "name": "OVER_DISCHARGE_CURRENT_ALARM",
-                        "value": 7
+                        "value": 7,
+                        "notes": "See ADisChaMax in model S 802."
                     },
                     {
                         "name": "OVER_DISCHARGE_CURRENT_WARNING",
-                        "value": 8
+                        "value": 8,
+                        "notes": "See ADisChaMax in model S 802."
                     },
                     {
                         "name": "OVER_VOLT_ALARM",
@@ -658,19 +664,23 @@
                     },
                     {
                         "name": "RESERVED_1",
-                        "value": 24
+                        "value": 24,
+                        "notes": "Do not implement."
                     },
                     {
                         "name": "OTHER_ALARM",
-                        "value": 25
+                        "value": 25,
+                        "notes": "See EvtVnd1 and EvtVnd2 for more information."
                     },
                     {
                         "name": "OTHER_WARNING",
-                        "value": 26
+                        "value": 26,
+                        "notes": "See EvtVnd1 and EvtVnd2 for more information."
                     },
                     {
                         "name": "RESERVED_2",
-                        "value": 27
+                        "value": 27,
+                        "notes": "Do not implement."
                     },
                     {
                         "name": "CONFIGURATION_ALARM",

--- a/json/model_804.json
+++ b/json/model_804.json
@@ -177,7 +177,8 @@
                 "mandatory": "M",
                 "name": "Idx",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Indices are one-based."
             },
             {
                 "desc": "Count of modules in the string.",
@@ -264,7 +265,8 @@
                 "sf": "SoC_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "%"
+                "units": "%",
+                "notes": "Measurement."
             },
             {
                 "desc": "Depth of discharge for the string, expressed as a percentage.",
@@ -273,7 +275,8 @@
                 "sf": "DoD_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "%"
+                "units": "%",
+                "notes": "Measurement."
             },
             {
                 "desc": "Number of discharge cycles executed upon the string.",
@@ -289,7 +292,8 @@
                 "sf": "SoH_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "%"
+                "units": "%",
+                "notes": "Measurement."
             },
             {
                 "desc": "String current measurement.",
@@ -299,7 +303,8 @@
                 "sf": "A_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "A"
+                "units": "A",
+                "notes": "Measurement."
             },
             {
                 "desc": "String voltage measurement.",
@@ -308,7 +313,8 @@
                 "sf": "V_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "Maximum voltage for all cells in the string.",
@@ -318,7 +324,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "Module containing the cell with maximum cell voltage.",
@@ -335,7 +342,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "Module containing the cell with minimum cell voltage.",
@@ -352,7 +360,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Calculation based on measurements."
             },
             {
                 "desc": "Maximum temperature for all modules in the string.",
@@ -362,7 +371,8 @@
                 "sf": "ModTmp_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "C"
+                "units": "C",
+                "notes": "Measurement."
             },
             {
                 "desc": "Module with the maximum temperature.",
@@ -380,7 +390,8 @@
                 "sf": "ModTmp_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "C"
+                "units": "C",
+                "notes": "Measurement."
             },
             {
                 "desc": "Module with the minimum temperature.",
@@ -398,7 +409,8 @@
                 "sf": "ModTmp_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "C"
+                "units": "C",
+                "notes": "Calculation based on measurements."
             },
             {
                 "desc": "Pad register.",
@@ -676,7 +688,8 @@
                 "label": "String Event 2",
                 "name": "Evt2",
                 "size": 2,
-                "type": "bitfield32"
+                "type": "bitfield32",
+                "notes": "Reserved for future use."
             },
             {
                 "desc": "Vendor defined events.",
@@ -716,7 +729,8 @@
                         "value": 2
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "Should reset to 0 upon completion."
             },
             {
                 "desc": "Scale factor for string state of charge.",

--- a/json/model_805.json
+++ b/json/model_805.json
@@ -70,7 +70,8 @@
                 "mandatory": "M",
                 "name": "StrIdx",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Indices are one-based."
             },
             {
                 "desc": "Index of the module within the string.",
@@ -78,7 +79,8 @@
                 "mandatory": "M",
                 "name": "ModIdx",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Indices are one-based."
             },
             {
                 "desc": "Count of all cells in the module.",
@@ -104,7 +106,8 @@
                 "sf": "DoD_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "%"
+                "units": "%",
+                "notes": "Measurement."
             },
             {
                 "desc": "Module state of health, expressed as a percentage.",
@@ -130,7 +133,8 @@
                 "sf": "V_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "Maximum voltage for all cells in the module.",
@@ -140,7 +144,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "Cell with the maximum voltage.",
@@ -157,7 +162,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "Cell with the minimum voltage.",
@@ -174,7 +180,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Calculation based on measurements."
             },
             {
                 "desc": "Maximum temperature for all cells in the module.",
@@ -184,7 +191,8 @@
                 "sf": "Tmp_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "C"
+                "units": "C",
+                "notes": "Measurement."
             },
             {
                 "desc": "Cell with the maximum cell temperature.",
@@ -201,7 +209,8 @@
                 "sf": "Tmp_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "C"
+                "units": "C",
+                "notes": "Measurement."
             },
             {
                 "desc": "Cell with the minimum cell temperature.",
@@ -218,7 +227,8 @@
                 "sf": "Tmp_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "C"
+                "units": "C",
+                "notes": "Calculation based on measurements."
             },
             {
                 "desc": "Number of cells currently being balanced in the module.",

--- a/json/model_807.json
+++ b/json/model_807.json
@@ -563,7 +563,8 @@
                 "mandatory": "M",
                 "name": "Idx",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Indices are one-based."
             },
             {
                 "desc": "Number of modules in this string.",
@@ -589,7 +590,8 @@
                 "sf": "ModV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "Module with the maximum voltage.",
@@ -606,7 +608,8 @@
                 "sf": "ModV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "Module with the minimum voltage.",
@@ -623,7 +626,8 @@
                 "sf": "ModV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Calculation based on measurements."
             },
             {
                 "desc": "Maximum voltage for all cells in the string.",
@@ -632,7 +636,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "Module containing the cell with the maximum voltage.",
@@ -655,7 +660,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Measurement."
             },
             {
                 "desc": "Module containing the cell with the minimum voltage.",
@@ -678,7 +684,8 @@
                 "sf": "CellV_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "V"
+                "units": "V",
+                "notes": "Calculation based on measurements."
             },
             {
                 "desc": "Maximum electrolyte temperature for all modules in the string.",
@@ -688,7 +695,8 @@
                 "sf": "Tmp_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "C"
+                "units": "C",
+                "notes": "Measurement."
             },
             {
                 "desc": "Module with the maximum temperature.",
@@ -705,7 +713,8 @@
                 "sf": "Tmp_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "C"
+                "units": "C",
+                "notes": "Measurement."
             },
             {
                 "desc": "Module with the minimum temperature.",
@@ -722,7 +731,8 @@
                 "sf": "Tmp_SF",
                 "size": 1,
                 "type": "int16",
-                "units": "C"
+                "units": "C",
+                "notes": "Calculation based on measurements."
             },
             {
                 "desc": "Alarms, warnings and status values.  Bit flags.",

--- a/json/model_807.json
+++ b/json/model_807.json
@@ -763,19 +763,23 @@
                     },
                     {
                         "name": "OVER_CHARGE_CURRENT_ALARM",
-                        "value": 5
+                        "value": 5,
+                        "notes": "See AChaMax in model S 802."
                     },
                     {
                         "name": "OVER_CHARGE_CURRENT_WARNING",
-                        "value": 6
+                        "value": 6,
+                        "notes": "See AChaMax in model S 802."
                     },
                     {
                         "name": "OVER_DISCHARGE_CURRENT_ALARM",
-                        "value": 7
+                        "value": 7,
+                        "notes": "See ADisChaMax in model S 802."
                     },
                     {
                         "name": "OVER_DISCHARGE_CURRENT_WARNING",
-                        "value": 8
+                        "value": 8,
+                        "notes": "See ADisChaMax in model S 802."
                     },
                     {
                         "name": "OVER_VOLT_ALARM",
@@ -815,11 +819,13 @@
                     },
                     {
                         "name": "RESERVED_1",
-                        "value": 18
+                        "value": 18,
+                        "notes": "Do not implement."
                     },
                     {
                         "name": "RESERVED_2",
-                        "value": 19
+                        "value": 19,
+                        "notes": "Do not implement."
                     },
                     {
                         "name": "CONTACTOR_ERROR",
@@ -839,15 +845,18 @@
                     },
                     {
                         "name": "RESERVED_3",
-                        "value": 24
+                        "value": 24,
+                        "notes": "Do not implement."
                     },
                     {
                         "name": "OTHER_ALARM",
-                        "value": 25
+                        "value": 25,
+                        "notes": "See EvtVnd1 and EvtVnd2 for more information."
                     },
                     {
                         "name": "OTHER_WARNING",
-                        "value": 26
+                        "value": 26,
+                        "notes": "See EvtVnd1 and EvtVnd2 for more information."
                     },
                     {
                         "name": "FIRE_ALARM",

--- a/json/model_9.json
+++ b/json/model_9.json
@@ -738,7 +738,8 @@
                 "symbols": [
                     {
                         "name": "NONE",
-                        "value": 0
+                        "value": 0,
+                        "notes": "For test purposes only"
                     },
                     {
                         "name": "AES-GMAC-64",

--- a/json/model_9.json
+++ b/json/model_9.json
@@ -118,7 +118,8 @@
                 "mandatory": "M",
                 "name": "TotLn",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "In registers, zero padded."
             },
             {
                 "access": "RW",
@@ -127,7 +128,8 @@
                 "mandatory": "M",
                 "name": "FrgLn",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Maximum fragment length is 80 registers"
             },
             {
                 "access": "RW",
@@ -704,7 +706,8 @@
                 "mandatory": "M",
                 "name": "Seq",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Shall be advanced for each request"
             },
             {
                 "access": "RW",
@@ -722,7 +725,8 @@
                 "mandatory": "M",
                 "name": "Role",
                 "size": 1,
-                "type": "uint16"
+                "type": "uint16",
+                "notes": "Each controller is assigned a key index that maps to their access control role"
             },
             {
                 "access": "RW",
@@ -745,7 +749,8 @@
                         "value": 2
                     }
                 ],
-                "type": "enum16"
+                "type": "enum16",
+                "notes": "For future proof"
             },
             {
                 "access": "RW",


### PR DESCRIPTION
The JSON models were missing the notes from the SMDX files. I do consider those very useful as they explain some of the rather cryptic abbreviations.

I quickly hacked together a Python script to copy the missing notes from the SMDX files to the JSON files:

---

```python
#!/bin/python3
import json
from os import listdir
from xml.etree import ElementTree as ET

for fn in listdir('smdx'):
    if not (fn.startswith('smdx_') and fn.endswith('.xml')):
        continue
    model_id = int(fn[5:-4], base=10)
    dom = ET.parse(f'smdx/{fn}').getroot()
    strings = dom.find('strings')
    # model notes
    model_string = strings.find('model')
    model_notes = model_string.findtext('notes')
    if model_notes:
        model_notes = model_notes.strip()
    # point notes
    points_notes = {}
    symbols_notes = {}
    for point in strings.findall('point'):
        point_id = point.get('id')
        point_notes = point.findtext('notes')
        if point_notes:
            point_notes = point_notes.strip()
        if point_notes:
            points_notes[point_id] = point_notes
        for symbol in point.findall('symbol'):
            symbol_id = symbol.get('id')
            symbol_notes = symbol.findtext('notes')
            if symbol_notes:
                symbol_notes = symbol_notes.strip()
            if symbol_notes:
                symbols_notes[(point_id, symbol_id)] = symbol_notes
    if not (model_notes or points_notes):
        continue
    with open(f'json/model_{model_id}.json') as fh:
        jsondoc = json.load(fh)
    if not jsondoc['group'].get('notes', '') and model_notes:
        jsondoc['group']['notes'] = model_notes
    for point in jsondoc['group']['points']:
        point_name = point['name']
        point_notes = points_notes.get(point_name, '')
        if not point.get('notes', '') and point_notes:
            point['notes'] = point_notes
        for symbol in point.get('symbols', []):
            symbol_name = symbol['name']
            symbol_notes = symbols_notes.get((point_name, symbol_name), '')
            if not symbol.get('notes', '') and symbol_notes:
                symbol['notes'] = symbol_notes
    with open(f'json/model_{model_id}.json', 'w') as fh:
        json.dump(jsondoc, fh, indent=4)
```

Licensed under either of

- Apache License, Version 2.0 ([LICENSE-APACHE](https://github.com/bikeshedder/sunspec/blob/main/LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
- MIT license ([LICENSE-MIT](https://github.com/bikeshedder/sunspec/blob/main/LICENSE-MIT) or http://opensource.org/licenses/MIT)

at your option.