### PR TITLE
model 803 repeated string group count should be top level NStr

### DIFF
--- a/json/model_803.json
+++ b/json/model_803.json
@@ -2,7 +2,7 @@
     "group": {
         "groups": [
             {
-                "count": 0,
+                "count": "NStr",
                 "name": "string",
                 "points": [
                     {


### PR DESCRIPTION
Model 803 has a repeated group named `string`, which currently has its `count` attribute incorrectly set to `0` within the json specification file.

According to the [device information model specification](https://sunspec.org/wp-content/uploads/2022/05/SunSpec-Device-Information-Model-Specificiation-V1-1-final.pdf), such `count` attribute should be (section 4.1.2):

>  defined as a constant in the point group definition or be specified as the value of another point in the model definition. If the point group count is specified in another point, that point MUST be defined in the top-level point group of the model before the point group definition.

As far as I understand, the current `0` value works with `pysunspec2` because of a feature [deducing the number of repetitions in the group based on the group length and the parent group lenght](https://github.com/sunspec/pysunspec2/blob/dfe99cad9030c48080d633ad5163ea736a4fd20d/sunspec2/device.py#L539).

In the case of model 803, the `strings` group will be repeated once per spring, s.t. `count` should be `NStr`: [the number of string in the bank](https://github.com/sunspec/models/blob/master/json/model_803.json#L587).

This PR fixes the model 803 json specification specification, in a similar way as is done in other models (e.g. [model 705](https://github.com/sunspec/models/blob/master/json/model_705.json#L9))