### PR TITLE
Add static to model 715 ID and length

### DIFF
--- a/json/model_715.json
+++ b/json/model_715.json
@@ -10,6 +10,7 @@
                 "mandatory": "M",
                 "name": "ID",
                 "size": 1,
+                "static": "S",
                 "type": "uint16",
                 "value": 715
             },
@@ -19,6 +20,7 @@
                 "mandatory": "M",
                 "name": "L",
                 "size": 1,
+                "static": "S",
                 "type": "uint16",
                 "value": 7
             },


### PR DESCRIPTION
This model is the only one that is missing this field for these two common points to all models.