### PR TITLE
Remove length values from models 7XX

### DIFF
--- a/json/model_701.json
+++ b/json/model_701.json
@@ -21,8 +21,7 @@
                 "name": "L",
                 "size": 1,
                 "static": "S",
-                "type": "uint16",
-                "value": 153
+                "type": "uint16"
             },
             {
                 "comments": [

--- a/json/model_702.json
+++ b/json/model_702.json
@@ -21,8 +21,7 @@
                 "name": "L",
                 "size": 1,
                 "static": "S",
-                "type": "uint16",
-                "value": 50
+                "type": "uint16"
             },
             {
                 "comments": [

--- a/json/model_703.json
+++ b/json/model_703.json
@@ -21,8 +21,7 @@
                 "name": "L",
                 "size": 1,
                 "static": "S",
-                "type": "uint16",
-                "value": 17
+                "type": "uint16"
             },
             {
                 "access": "RW",

--- a/json/model_704.json
+++ b/json/model_704.json
@@ -182,8 +182,7 @@
                 "name": "L",
                 "size": 1,
                 "static": "S",
-                "type": "uint16",
-                "value": 65
+                "type": "uint16"
             },
             {
                 "access": "RW",

--- a/json/model_713.json
+++ b/json/model_713.json
@@ -21,8 +21,7 @@
                 "name": "L",
                 "size": 1,
                 "static": "S",
-                "type": "uint16",
-                "value": 7
+                "type": "uint16"
             },
             {
                 "desc": "Energy rating of the DER storage.",

--- a/json/model_715.json
+++ b/json/model_715.json
@@ -19,8 +19,7 @@
                 "mandatory": "M",
                 "name": "L",
                 "size": 1,
-                "type": "uint16",
-                "value": 7
+                "type": "uint16"
             },
             {
                 "comments": [


### PR DESCRIPTION
6 models belonging to the 7XX group have their length values set in the specification, which is not the case for the other 100 models. Keeping this value here is prone to error if these models were to be modified as it is easy to forget to update these values accordingly.