### PR TITLE
fix: Give nested groups readable names

### DIFF
--- a/json/model_705.json
+++ b/json/model_705.json
@@ -16,7 +16,7 @@
                         "count": "NPt",
                         "desc": "Stored curve points.",
                         "label": "Stored Curve Points",
-                        "name": "Pt",
+                        "name": "Point",
                         "points": [
                             {
                                 "access": "RW",
@@ -51,7 +51,7 @@
                     }
                 ],
                 "label": "Stored Curves",
-                "name": "Crv",
+                "name": "Curve",
                 "points": [
                     {
                         "access": "RW",

--- a/json/model_706.json
+++ b/json/model_706.json
@@ -16,7 +16,7 @@
                         "count": "NPt",
                         "desc": "Stored curve points.",
                         "label": "Stored Curve Points",
-                        "name": "Pt",
+                        "name": "Point",
                         "points": [
                             {
                                 "access": "RW",
@@ -51,7 +51,7 @@
                     }
                 ],
                 "label": "Stored Curves",
-                "name": "Crv",
+                "name": "Curve",
                 "points": [
                     {
                         "access": "RW",

--- a/json/model_707.json
+++ b/json/model_707.json
@@ -19,7 +19,7 @@
                                 "count": "NPt",
                                 "desc": "Must trip curve points.",
                                 "label": "Must Trip Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -77,7 +77,7 @@
                                 "count": "NPt",
                                 "desc": "May trip curve points.",
                                 "label": "May Trip Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -127,7 +127,7 @@
                                 "count": "NPt",
                                 "desc": "Momentary cessation curve points.",
                                 "label": "Mom Cessation Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -172,7 +172,7 @@
                     }
                 ],
                 "label": "Stored Curves",
-                "name": "Crv",
+                "name": "Curve",
                 "points": [
                     {
                         "desc": "Curve read-write access.",

--- a/json/model_708.json
+++ b/json/model_708.json
@@ -19,7 +19,7 @@
                                 "count": "NPt",
                                 "desc": "Must trip curve points.",
                                 "label": "Must Trip Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -77,7 +77,7 @@
                                 "count": "NPt",
                                 "desc": "May trip curve points.",
                                 "label": "May Trip Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -127,7 +127,7 @@
                                 "count": "NPt",
                                 "desc": "Momentary cessation curve points.",
                                 "label": "Mom Cessation Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -172,7 +172,7 @@
                     }
                 ],
                 "label": "Stored Curves",
-                "name": "Crv",
+                "name": "Curve",
                 "points": [
                     {
                         "desc": "Curve read-write access.",

--- a/json/model_709.json
+++ b/json/model_709.json
@@ -19,7 +19,7 @@
                                 "count": "NPt",
                                 "desc": "Must trip curve points.",
                                 "label": "Must Trip Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -77,7 +77,7 @@
                                 "count": "NPt",
                                 "desc": "May trip curve points.",
                                 "label": "May Trip Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -127,7 +127,7 @@
                                 "count": "NPt",
                                 "desc": "Momentary cessation curve points.",
                                 "label": "Mom Cessation Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -172,7 +172,7 @@
                     }
                 ],
                 "label": "Stored Curves",
-                "name": "Crv",
+                "name": "Curve",
                 "points": [
                     {
                         "desc": "Curve read-write access.",

--- a/json/model_710.json
+++ b/json/model_710.json
@@ -19,7 +19,7 @@
                                 "count": "NPt",
                                 "desc": "Must trip curve points.",
                                 "label": "Must Trip Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -77,7 +77,7 @@
                                 "count": "NPt",
                                 "desc": "May trip curve points.",
                                 "label": "May Trip Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -127,7 +127,7 @@
                                 "count": "NPt",
                                 "desc": "Momentary cessation curve points.",
                                 "label": "Mom Cessation Curve Points",
-                                "name": "Pt",
+                                "name": "Point",
                                 "points": [
                                     {
                                         "access": "RW",
@@ -172,7 +172,7 @@
                     }
                 ],
                 "label": "Stored Curves",
-                "name": "Crv",
+                "name": "Curve",
                 "points": [
                     {
                         "desc": "Curve read-write access.",

--- a/json/model_711.json
+++ b/json/model_711.json
@@ -9,7 +9,7 @@
                 "count": "NCtl",
                 "desc": "Stored control sets.",
                 "label": "Stored Controls",
-                "name": "Ctl",
+                "name": "Control",
                 "points": [
                     {
                         "access": "RW",

--- a/json/model_712.json
+++ b/json/model_712.json
@@ -16,7 +16,7 @@
                         "count": "NPt",
                         "desc": "Stored curve points.",
                         "label": "Stored Curve Points",
-                        "name": "Pt",
+                        "name": "Point",
                         "points": [
                             {
                                 "access": "RW",
@@ -51,7 +51,7 @@
                     }
                 ],
                 "label": "Stored Curves",
-                "name": "Crv",
+                "name": "Curve",
                 "points": [
                     {
                         "access": "RW",

--- a/json/model_714.json
+++ b/json/model_714.json
@@ -7,7 +7,7 @@
                     "DC Port"
                 ],
                 "count": "NPrt",
-                "name": "Prt",
+                "name": "Port",
                 "points": [
                     {
                         "desc": "Port type.",


### PR DESCRIPTION
When generating code from the SunSpec models it is very useful to have a name for the subgroups that is a bit easier to understand.