### PR TITLE
Clean descriptions

### DIFF
--- a/json/model_10.json
+++ b/json/model_10.json
@@ -54,7 +54,7 @@
                 "type": "uint16"
             },
             {
-                "desc": "Enumerated value.  Type of physical media",
+                "desc": "Type of physical media",
                 "label": "Physical Access Type",
                 "name": "Typ",
                 "size": 1,

--- a/json/model_101.json
+++ b/json/model_101.json
@@ -305,7 +305,7 @@
                 "type": "sunssf"
             },
             {
-                "desc": "Enumerated value.  Operating state",
+                "desc": "Operating state",
                 "label": "Operating State",
                 "mandatory": "M",
                 "name": "St",
@@ -354,7 +354,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Bitmask value. Event fields",
+                "desc": "Event fields",
                 "label": "Event1",
                 "mandatory": "M",
                 "name": "Evt1",

--- a/json/model_102.json
+++ b/json/model_102.json
@@ -309,7 +309,7 @@
                 "type": "sunssf"
             },
             {
-                "desc": "Enumerated value.  Operating state",
+                "desc": "Operating state",
                 "label": "Operating State",
                 "mandatory": "M",
                 "name": "St",
@@ -358,7 +358,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Bitmask value. Event fields",
+                "desc": "Event fields",
                 "label": "Event1",
                 "mandatory": "M",
                 "name": "Evt1",

--- a/json/model_103.json
+++ b/json/model_103.json
@@ -312,7 +312,7 @@
                 "type": "sunssf"
             },
             {
-                "desc": "Enumerated value.  Operating state",
+                "desc": "Operating state",
                 "label": "Operating State",
                 "mandatory": "M",
                 "name": "St",
@@ -361,7 +361,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Bitmask value. Event fields",
+                "desc": "Event fields",
                 "label": "Event1",
                 "mandatory": "M",
                 "name": "Evt1",

--- a/json/model_11.json
+++ b/json/model_11.json
@@ -33,7 +33,7 @@
                 "units": "Mbps"
             },
             {
-                "desc": "Bitmask values Interface flags.",
+                "desc": "Interface flags.",
                 "label": "Interface Status Flags",
                 "mandatory": "M",
                 "name": "CfgSt",
@@ -71,7 +71,7 @@
                 "type": "bitfield16"
             },
             {
-                "desc": "Enumerated value. State information for this interface",
+                "desc": "State information for this interface",
                 "label": "Link State",
                 "mandatory": "M",
                 "name": "St",

--- a/json/model_111.json
+++ b/json/model_111.json
@@ -216,7 +216,7 @@
                 "units": "C"
             },
             {
-                "desc": "Enumerated value.  Operating state",
+                "desc": "Operating state",
                 "label": "Operating State",
                 "mandatory": "M",
                 "name": "St",
@@ -265,7 +265,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Bitmask value. Event fields",
+                "desc": "Event fields",
                 "label": "Event1",
                 "mandatory": "M",
                 "name": "Evt1",

--- a/json/model_112.json
+++ b/json/model_112.json
@@ -219,7 +219,7 @@
                 "units": "C"
             },
             {
-                "desc": "Enumerated value.  Operating state",
+                "desc": "Operating state",
                 "label": "Operating State",
                 "mandatory": "M",
                 "name": "St",
@@ -268,7 +268,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Bitmask value. Event fields",
+                "desc": "Event fields",
                 "label": "Event1",
                 "mandatory": "M",
                 "name": "Evt1",

--- a/json/model_113.json
+++ b/json/model_113.json
@@ -223,7 +223,7 @@
                 "units": "C"
             },
             {
-                "desc": "Enumerated value.  Operating state",
+                "desc": "Operating state",
                 "label": "Operating State",
                 "mandatory": "M",
                 "name": "St",
@@ -272,7 +272,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Bitmask value. Event fields",
+                "desc": "Event fields",
                 "label": "Event1",
                 "mandatory": "M",
                 "name": "Evt1",

--- a/json/model_12.json
+++ b/json/model_12.json
@@ -32,7 +32,7 @@
                 "type": "string"
             },
             {
-                "desc": "Enumerated value.  Configuration status",
+                "desc": "Configuration status",
                 "label": "Config Status",
                 "mandatory": "M",
                 "name": "CfgSt",
@@ -54,7 +54,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Bitmask value.  A configuration change is pending",
+                "desc": "A configuration change is pending",
                 "label": "Change Status",
                 "mandatory": "M",
                 "name": "ChgSt",
@@ -68,7 +68,7 @@
                 "type": "bitfield16"
             },
             {
-                "desc": "Bitmask value. Identify capable sources of configuration",
+                "desc": "Identify capable sources of configuration",
                 "label": "Config Capability",
                 "mandatory": "M",
                 "name": "Cap",
@@ -111,7 +111,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enumerated value.  Configuration method used.",
+                "desc": "Configuration method used.",
                 "label": "IPv4 Config",
                 "mandatory": "M",
                 "name": "Cfg",

--- a/json/model_120.json
+++ b/json/model_120.json
@@ -213,7 +213,7 @@
                 "type": "sunssf"
             },
             {
-                "desc": "The usable capacity of the battery.  Maximum charge minus minimum charge from a technology capability perspective (Amp-hour capacity rating).",
+                "desc": "The usable capacity of the battery. Maximum charge minus minimum charge from a technology capability perspective (Amp-hour capacity rating).",
                 "label": "AhrRtg",
                 "name": "AhrRtg",
                 "sf": "AhrRtg_SF",

--- a/json/model_121.json
+++ b/json/model_121.json
@@ -47,7 +47,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Offset  from PCC to inverter.",
+                "desc": "Offset from PCC to inverter.",
                 "label": "VRefOfs",
                 "mandatory": "M",
                 "name": "VRefOfs",

--- a/json/model_122.json
+++ b/json/model_122.json
@@ -126,7 +126,7 @@
                 "units": "varh"
             },
             {
-                "desc": "AC lifetime negative energy output  in quadrant 3.",
+                "desc": "AC lifetime negative energy output in quadrant 3.",
                 "label": "ActVArhQ3",
                 "name": "ActVArhQ3",
                 "size": 4,
@@ -134,7 +134,7 @@
                 "units": "varh"
             },
             {
-                "desc": "AC lifetime reactive energy output  in quadrant 4.",
+                "desc": "AC lifetime reactive energy output in quadrant 4.",
                 "label": "ActVArhQ4",
                 "name": "ActVArhQ4",
                 "size": 4,

--- a/json/model_122.json
+++ b/json/model_122.json
@@ -24,7 +24,7 @@
                 "type": "uint16"
             },
             {
-                "desc": "PV inverter present/available status. Enumerated value.",
+                "desc": "PV inverter present/available status.",
                 "label": "PVConn",
                 "mandatory": "M",
                 "name": "PVConn",
@@ -50,7 +50,7 @@
                 "type": "bitfield16"
             },
             {
-                "desc": "Storage inverter present/available status. Enumerated value.",
+                "desc": "Storage inverter present/available status.",
                 "label": "StorConn",
                 "mandatory": "M",
                 "name": "StorConn",
@@ -76,8 +76,8 @@
                 "type": "bitfield16"
             },
             {
-                "desc": "ECP connection status: disconnected=0  connected=1.",
                 "label": "ECPConn",
+                "desc": "ECP connection status: disconnected=0 connected=1.",
                 "mandatory": "M",
                 "name": "ECPConn",
                 "size": 1,
@@ -174,7 +174,7 @@
                 "type": "sunssf"
             },
             {
-                "desc": "Bit Mask indicating setpoint limit(s) reached.",
+                "desc": "Setpoint limit(s) reached.",
                 "label": "StSetLimMsk",
                 "name": "StSetLimMsk",
                 "size": 2,
@@ -228,8 +228,8 @@
                 "detail": "Bits shall be automatically cleared on read."
             },
             {
-                "desc": "Bit Mask indicating which inverter controls are currently active.",
                 "label": "StActCtl",
+                "desc": "Which inverter controls are currently active.",
                 "name": "StActCtl",
                 "size": 2,
                 "symbols": [
@@ -308,7 +308,7 @@
                 "units": "Secs"
             },
             {
-                "desc": "Bit Mask indicating active ride-through status.",
+                "desc": "Active ride-through status.",
                 "label": "RtSt",
                 "name": "RtSt",
                 "size": 1,

--- a/json/model_123.json
+++ b/json/model_123.json
@@ -43,7 +43,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enumerated valued.  Connection control.",
+                "desc": "Connection control.",
                 "label": "Conn",
                 "mandatory": "M",
                 "name": "Conn",
@@ -100,7 +100,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enumerated valued.  Throttle enable/disable control.",
+                "desc": "Throttle enable/disable control.",
                 "label": "WMaxLim_Ena",
                 "mandatory": "M",
                 "name": "WMaxLim_Ena",
@@ -157,7 +157,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enumerated valued.  Fixed power factor enable/disable control.",
+                "desc": "Fixed power factor enable/disable control.",
                 "label": "OutPFSet_Ena",
                 "mandatory": "M",
                 "name": "OutPFSet_Ena",
@@ -233,7 +233,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enumerated value. VAR percent limit mode.",
+                "desc": "VAR percent limit mode.",
                 "label": "VArPct_Mod",
                 "name": "VArPct_Mod",
                 "size": 1,
@@ -259,7 +259,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enumerated valued.  Percent limit VAr enable/disable control.",
+                "desc": "Percent limit VAr enable/disable control.",
                 "label": "VArPct_Ena",
                 "mandatory": "M",
                 "name": "VArPct_Ena",

--- a/json/model_124.json
+++ b/json/model_124.json
@@ -58,7 +58,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Activate hold/discharge/charge storage control mode. Bitfield value.",
+                "desc": "Activate hold/discharge/charge storage control mode.",
                 "label": "StorCtl_Mod",
                 "mandatory": "M",
                 "name": "StorCtl_Mod",
@@ -123,7 +123,7 @@
                 "units": "V"
             },
             {
-                "desc": "Charge status of storage device. Enumerated value.",
+                "desc": "Charge status of storage device.",
                 "label": "ChaSt",
                 "name": "ChaSt",
                 "size": 1,

--- a/json/model_126.json
+++ b/json/model_126.json
@@ -577,7 +577,7 @@
                 "type": "sunssf"
             },
             {
-                "desc": "scale factor for dependent variable.",
+                "desc": "Scale factor for dependent variable.",
                 "label": "DeptRef_SF",
                 "mandatory": "M",
                 "name": "DeptRef_SF",

--- a/json/model_128.json
+++ b/json/model_128.json
@@ -55,7 +55,7 @@
             },
             {
                 "access": "RW",
-                "desc": "The gradient used to increase inductive dynamic current.  A value of 0 indicates no additional reactive current support.",
+                "desc": "The gradient used to increase inductive dynamic current. A value of 0 indicates no additional reactive current support.",
                 "label": "ArGraSwell",
                 "mandatory": "M",
                 "name": "ArGraSwell",

--- a/json/model_129.json
+++ b/json/model_129.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "LVRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "LVRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_13.json
+++ b/json/model_13.json
@@ -32,7 +32,7 @@
                 "type": "string"
             },
             {
-                "desc": "Enumerated value.  Configuration status",
+                "desc": "Configuration status",
                 "label": "Config Status",
                 "mandatory": "M",
                 "name": "CfgSt",
@@ -54,7 +54,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Bitmask value.  A configuration change is pending",
+                "desc": "A configuration change is pending",
                 "label": "Change Status",
                 "mandatory": "M",
                 "name": "ChgSt",
@@ -68,7 +68,7 @@
                 "type": "bitfield16"
             },
             {
-                "desc": "Bitmask value. Identify capable sources of configuration",
+                "desc": "Identify capable sources of configuration",
                 "label": "Config Capability",
                 "mandatory": "M",
                 "name": "Cap",
@@ -111,7 +111,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enumerated value.  Configuration method used.",
+                "desc": "Configuration method used.",
                 "label": "IPv6 Config",
                 "mandatory": "M",
                 "name": "Cfg",
@@ -138,7 +138,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Bitmask value.  Configure use of services",
+                "desc": "Configure use of services",
                 "label": "Control",
                 "mandatory": "M",
                 "name": "Ctl",

--- a/json/model_130.json
+++ b/json/model_130.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "HVRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "HVRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_131.json
+++ b/json/model_131.json
@@ -455,7 +455,7 @@
                         "units": "% PF/min"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",

--- a/json/model_132.json
+++ b/json/model_132.json
@@ -474,7 +474,7 @@
                         "units": "% WMax/min"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",

--- a/json/model_132.json
+++ b/json/model_132.json
@@ -17,7 +17,7 @@
                     },
                     {
                         "access": "RW",
-                        "desc": "Defines the meaning of the Watts DeptRef.  1=% WMax 2=% WAvail",
+                        "desc": "Defines the meaning of the Watts DeptRef. 1=% WMax 2=% WAvail",
                         "label": "DeptRef",
                         "mandatory": "M",
                         "name": "DeptRef",

--- a/json/model_133.json
+++ b/json/model_133.json
@@ -79,7 +79,7 @@
                     },
                     {
                         "access": "RW",
-                        "desc": "The meaning of the X-values in the array. ",
+                        "desc": "The meaning of the X-values in the array.",
                         "label": "XTyp",
                         "mandatory": "M",
                         "name": "XTyp",

--- a/json/model_134.json
+++ b/json/model_134.json
@@ -456,7 +456,7 @@
                     },
                     {
                         "access": "RW",
-                        "desc": "The maximum rate at which the power may be increased after releasing the frozen value of snap shot function. ",
+                        "desc": "The maximum rate at which the power may be increased after releasing the frozen value of snap shot function.",
                         "label": "RmpRsUp",
                         "name": "RmpRsUp",
                         "sf": "RmpIncDec_SF",

--- a/json/model_134.json
+++ b/json/model_134.json
@@ -504,7 +504,7 @@
                         "units": "Hz"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",

--- a/json/model_135.json
+++ b/json/model_135.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "LHzRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "LHzRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_136.json
+++ b/json/model_136.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "HFRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "HFRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_137.json
+++ b/json/model_137.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "LVRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "LVRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_138.json
+++ b/json/model_138.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "HVRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "HVRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_139.json
+++ b/json/model_139.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "LVRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "LVRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_14.json
+++ b/json/model_14.json
@@ -33,7 +33,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Bitmask value.  Proxy configuration capabilities",
+                "desc": "Proxy configuration capabilities",
                 "label": "Capabilities",
                 "mandatory": "M",
                 "name": "Cap",
@@ -56,7 +56,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enumerated value.  Set proxy address type",
+                "desc": "Set proxy address type",
                 "label": "Config",
                 "mandatory": "M",
                 "name": "Cfg",
@@ -65,7 +65,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enumerate value.  Proxy server type",
+                "desc": "Enumerate value. Proxy server type",
                 "label": "Type",
                 "mandatory": "M",
                 "name": "Typ",

--- a/json/model_140.json
+++ b/json/model_140.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "LVRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "LVRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_141.json
+++ b/json/model_141.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "LHzRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "LHzRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_142.json
+++ b/json/model_142.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "LHzRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "LHzRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_143.json
+++ b/json/model_143.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "LHzRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "LHzRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_144.json
+++ b/json/model_144.json
@@ -426,7 +426,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Enumerated value indicates if curve is read-only or can be modified.",
+                        "desc": "Curve is read-only or can be modified.",
                         "label": "ReadOnly",
                         "mandatory": "M",
                         "name": "ReadOnly",
@@ -480,7 +480,7 @@
             },
             {
                 "access": "RW",
-                "desc": "LHzRT control mode. Enable active curve.  Bitfield value.",
+                "desc": "LHzRT control mode. Enable active curve.",
                 "label": "ModEna",
                 "mandatory": "M",
                 "name": "ModEna",

--- a/json/model_16.json
+++ b/json/model_16.json
@@ -25,7 +25,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Interface name.  (8 chars)",
+                "desc": "Interface name. (8 chars)",
                 "label": "Name",
                 "name": "Nam",
                 "size": 4,

--- a/json/model_16.json
+++ b/json/model_16.json
@@ -32,7 +32,7 @@
                 "type": "string"
             },
             {
-                "desc": "Enumerated value.  Force IPv4 configuration method",
+                "desc": "Force IPv4 configuration method",
                 "label": "Config",
                 "mandatory": "M",
                 "name": "Cfg",
@@ -51,7 +51,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Bitmask value Configure use of services",
+                "desc": "Configure use of services",
                 "label": "Control",
                 "mandatory": "M",
                 "name": "Ctl",
@@ -119,7 +119,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Bitmask value.  Link control flags",
+                "desc": "Link control flags",
                 "label": "Link Control",
                 "name": "LnkCtl",
                 "size": 1,

--- a/json/model_17.json
+++ b/json/model_17.json
@@ -52,7 +52,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Bitmask value.  Parity setting",
+                "desc": "Parity setting",
                 "label": "Parity",
                 "mandatory": "M",
                 "name": "Pty",
@@ -75,7 +75,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enumerated value.  Duplex mode",
+                "desc": "Duplex mode",
                 "label": "Duplex",
                 "name": "Dup",
                 "size": 1,
@@ -114,7 +114,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Enumerated value.  Interface type",
+                "desc": "Interface type",
                 "label": "Interface Type",
                 "name": "Typ",
                 "size": 1,
@@ -135,7 +135,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Enumerated value. Serial protocol selection",
+                "desc": "Serial protocol selection",
                 "label": "Protocol",
                 "name": "Pcol",
                 "size": 1,

--- a/json/model_19.json
+++ b/json/model_19.json
@@ -52,7 +52,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Bitmask value.  Parity setting",
+                "desc": "Parity setting",
                 "label": "Parity",
                 "mandatory": "M",
                 "name": "Pty",
@@ -75,7 +75,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enumerated value.  Duplex mode",
+                "desc": "Duplex mode",
                 "label": "Duplex",
                 "name": "Dup",
                 "size": 1,
@@ -114,7 +114,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Enumerated value.  Authentication method",
+                "desc": "Authentication method",
                 "label": "Authentication",
                 "name": "Auth",
                 "size": 1,

--- a/json/model_2.json
+++ b/json/model_2.json
@@ -40,7 +40,7 @@
                 "type": "uint16"
             },
             {
-                "desc": "Update Number.  Incrementing number each time the mapping is changed.  If the number is not changed from the last reading the direct access to a specific offset will result in reading the same logical model as before.  Otherwise the entire model must be read to refresh the changes",
+                "desc": "Update Number. Incrementing number each time the mapping is changed. If the number is not changed from the last reading the direct access to a specific offset will result in reading the same logical model as before. Otherwise the entire model must be read to refresh the changes",
                 "label": "UN",
                 "mandatory": "M",
                 "name": "UN",

--- a/json/model_306.json
+++ b/json/model_306.json
@@ -40,7 +40,7 @@
                 "units": "W/m2"
             },
             {
-                "desc": "Voltage  measurement at reference point",
+                "desc": "Voltage measurement at reference point",
                 "label": "Voltage",
                 "name": "V",
                 "size": 1,

--- a/json/model_307.json
+++ b/json/model_307.json
@@ -74,7 +74,7 @@
                 "units": "mm"
             },
             {
-                "desc": "\u00a0Precipitation Type (WMO 4680 SYNOP code reference)",
+                "desc": "Precipitation Type (WMO 4680 SYNOP code reference)",
                 "label": "Precipitation Type",
                 "name": "PPT",
                 "size": 1,

--- a/json/model_401.json
+++ b/json/model_401.json
@@ -190,7 +190,7 @@
                 "type": "count"
             },
             {
-                "desc": "Bitmask value.  Events",
+                "desc": "Events",
                 "label": "Event",
                 "mandatory": "M",
                 "name": "Evt",
@@ -276,7 +276,7 @@
                 "type": "bitfield32"
             },
             {
-                "desc": "Bitmask value.  Vendor defined events",
+                "desc": "Vendor defined events",
                 "label": "Vendor Event",
                 "name": "EvtVnd",
                 "size": 2,

--- a/json/model_402.json
+++ b/json/model_402.json
@@ -103,7 +103,7 @@
                         "type": "bitfield32"
                     },
                     {
-                        "desc": "Bitmask value.  Vendor defined events",
+                        "desc": "Vendor defined events",
                         "label": "Vendor Event",
                         "name": "EvtVnd",
                         "size": 2,
@@ -241,7 +241,7 @@
                 "type": "count"
             },
             {
-                "desc": "Bitmask value.  Events",
+                "desc": "Events",
                 "label": "Event",
                 "mandatory": "M",
                 "name": "Evt",
@@ -327,7 +327,7 @@
                 "type": "bitfield32"
             },
             {
-                "desc": "Bitmask value.  Vendor defined events",
+                "desc": "Vendor defined events",
                 "label": "Vendor Event",
                 "name": "EvtVnd",
                 "size": 2,

--- a/json/model_403.json
+++ b/json/model_403.json
@@ -190,7 +190,7 @@
                 "type": "count"
             },
             {
-                "desc": "Bitmask value.  Events",
+                "desc": "Events",
                 "label": "Event",
                 "mandatory": "M",
                 "name": "Evt",
@@ -276,7 +276,7 @@
                 "type": "bitfield32"
             },
             {
-                "desc": "Bitmask value.  Vendor defined events",
+                "desc": "Vendor defined events",
                 "label": "Vendor Event",
                 "name": "EvtVnd",
                 "size": 2,

--- a/json/model_404.json
+++ b/json/model_404.json
@@ -244,7 +244,7 @@
                 "type": "count"
             },
             {
-                "desc": "Bitmask value.  Events",
+                "desc": "Events",
                 "label": "Event",
                 "mandatory": "M",
                 "name": "Evt",
@@ -330,7 +330,7 @@
                 "type": "bitfield32"
             },
             {
-                "desc": "Bitmask value.  Vendor defined events",
+                "desc": "Vendor defined events",
                 "label": "Vendor Event",
                 "name": "EvtVnd",
                 "size": 2,

--- a/json/model_501.json
+++ b/json/model_501.json
@@ -24,7 +24,7 @@
                 "type": "uint16"
             },
             {
-                "desc": "Enumerated value.  Module Status Code",
+                "desc": "Module Status Code",
                 "label": "Status",
                 "mandatory": "M",
                 "name": "Stat",
@@ -81,7 +81,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Bitmask value.  Module Event Flags",
+                "desc": "Module Event Flags",
                 "label": "Events",
                 "mandatory": "M",
                 "name": "Evt",

--- a/json/model_502.json
+++ b/json/model_502.json
@@ -48,7 +48,7 @@
                 "type": "sunssf"
             },
             {
-                "desc": "Enumerated value.  Module Status Code",
+                "desc": "Module Status Code",
                 "label": "Status",
                 "mandatory": "M",
                 "name": "Stat",
@@ -105,7 +105,7 @@
                 "type": "enum16"
             },
             {
-                "desc": "Bitmask value.  Module Event Flags",
+                "desc": "Module Event Flags",
                 "label": "Events",
                 "mandatory": "M",
                 "name": "Evt",

--- a/json/model_601.json
+++ b/json/model_601.json
@@ -14,7 +14,7 @@
                         "type": "string"
                     },
                     {
-                        "desc": "Auto target elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type",
+                        "desc": "Auto target elevation in degrees from horizontal. Unimplemented for single axis azimuth tracker type",
                         "label": "Target Elevation",
                         "name": "ElTrgt",
                         "sf": "Dgr_SF",
@@ -23,7 +23,7 @@
                         "units": "Degrees"
                     },
                     {
-                        "desc": "Auto target azimuth  in degrees from true north towards east.  Unimplemented for single axis horizontal tracker type",
+                        "desc": "Auto target azimuth in degrees from true north towards east. Unimplemented for single axis horizontal tracker type",
                         "label": "Target Azimuth",
                         "name": "AzTrgt",
                         "sf": "Dgr_SF",
@@ -32,7 +32,7 @@
                         "units": "Degrees"
                     },
                     {
-                        "desc": "Actual elevation position  in degrees from horizontal.  Unimplemented for single axis azimuth tracker type",
+                        "desc": "Actual elevation position in degrees from horizontal. Unimplemented for single axis azimuth tracker type",
                         "label": "Elevation",
                         "name": "ElPos",
                         "sf": "Dgr_SF",
@@ -41,7 +41,7 @@
                         "units": "Degrees"
                     },
                     {
-                        "desc": "Actual azimuth position  in degrees from true north towards east.  Unimplemented for single axis horizontal tracker type",
+                        "desc": "Actual azimuth position in degrees from true north towards east. Unimplemented for single axis horizontal tracker type",
                         "label": "Azimuth",
                         "name": "AzPos",
                         "sf": "Dgr_SF",
@@ -51,7 +51,7 @@
                     },
                     {
                         "access": "RW",
-                        "desc": "Manual override target position of elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type",
+                        "desc": "Manual override target position of elevation in degrees from horizontal. Unimplemented for single axis azimuth tracker type",
                         "label": "Manual Elevation",
                         "name": "ElCtl",
                         "sf": "Dgr_SF",
@@ -61,7 +61,7 @@
                     },
                     {
                         "access": "RW",
-                        "desc": "Manual override target position of azimuth in degrees from true north towards east.  Unimplemented for single axis azimuth tracker type",
+                        "desc": "Manual override target position of azimuth in degrees from true north towards east. Unimplemented for single axis azimuth tracker type",
                         "label": "Manual Azimuth",
                         "name": "AzCtl",
                         "sf": "Dgr_SF",
@@ -71,7 +71,7 @@
                     },
                     {
                         "access": "RW",
-                        "desc": "Control register. Normal operation is automatic.  Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete.",
+                        "desc": "Control register. Normal operation is automatic. Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete.",
                         "label": "Mode",
                         "name": "Ctl",
                         "size": 1,
@@ -208,7 +208,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Global manual override target position of elevation in degrees from horizontal.  Unimplemented for single axis azimuth tracker type",
+                "desc": "Global manual override target position of elevation in degrees from horizontal. Unimplemented for single axis azimuth tracker type",
                 "label": "Manual Elevation",
                 "name": "GlblElCtl",
                 "sf": "Dgr_SF",
@@ -218,7 +218,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Global manual override target position of azimuth in degrees from true north towards east.  Unimplemented for single axis azimuth tracker type",
+                "desc": "Global manual override target position of azimuth in degrees from true north towards east. Unimplemented for single axis azimuth tracker type",
                 "label": "Manual Azimuth",
                 "name": "GlblAzCtl",
                 "sf": "Dgr_SF",
@@ -228,7 +228,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Global Control register operates on all trackers. Normal operation is automatic.  Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete.",
+                "desc": "Global Control register operates on all trackers. Normal operation is automatic. Operator can override the position by setting the ElCtl, AzCtl and enabling Manual operation. Entering calibration mode will revert to automatic operation after calibration is complete.",
                 "label": "Global Mode",
                 "name": "GlblCtl",
                 "size": 1,
@@ -280,7 +280,7 @@
                 "type": "sunssf"
             },
             {
-                "desc": "Number of trackers being controlled.  Size of repeating block.",
+                "desc": "Number of trackers being controlled. Size of repeating block.",
                 "label": "Trackers",
                 "mandatory": "M",
                 "name": "N",

--- a/json/model_701.json
+++ b/json/model_701.json
@@ -88,7 +88,7 @@
                 "comments": [
                     "Inverter State"
                 ],
-                "desc": "Enumerated value.  Inverter state.",
+                "desc": "Inverter state.",
                 "label": "Inverter State",
                 "name": "InvSt",
                 "size": 1,

--- a/json/model_705.json
+++ b/json/model_705.json
@@ -356,7 +356,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Reversion time in seconds.  0 = No reversion time.",
+                "desc": "Reversion time in seconds. 0 = No reversion time.",
                 "label": "Reversion Timeout",
                 "name": "RvrtTms",
                 "size": 2,

--- a/json/model_706.json
+++ b/json/model_706.json
@@ -253,7 +253,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Reversion time in seconds.  0 = No reversion time.",
+                "desc": "Reversion time in seconds. 0 = No reversion time.",
                 "label": "Reversion Timeout",
                 "name": "RvrtTms",
                 "size": 2,

--- a/json/model_711.json
+++ b/json/model_711.json
@@ -230,7 +230,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Reversion time in seconds.  0 = No reversion time.",
+                "desc": "Reversion time in seconds. 0 = No reversion time.",
                 "label": "Reversion Timeout",
                 "name": "RvrtTms",
                 "size": 2,

--- a/json/model_712.json
+++ b/json/model_712.json
@@ -277,7 +277,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Reversion time in seconds.  0 = No reversion time.",
+                "desc": "Reversion time in seconds. 0 = No reversion time.",
                 "label": "Reversion Timeout",
                 "name": "RvrtTms",
                 "size": 2,

--- a/json/model_715.json
+++ b/json/model_715.json
@@ -72,7 +72,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Commands to PCS. Enumerated value.",
+                "desc": "Commands to PCS.",
                 "label": "Set Operation",
                 "name": "OpCtl",
                 "size": 1,

--- a/json/model_802.json
+++ b/json/model_802.json
@@ -289,7 +289,7 @@
                 "detail": "Maps to DBAT.BatTyp in 61850."
             },
             {
-                "desc": "State of the battery bank.  Enumeration.",
+                "desc": "State of the battery bank. Enumeration.",
                 "label": "State of the Battery Bank",
                 "mandatory": "M",
                 "name": "State",
@@ -328,7 +328,7 @@
                 "detail": "Must be reconciled with State in IEC 61850."
             },
             {
-                "desc": "Vendor specific battery bank state.  Enumeration.",
+                "desc": "Vendor specific battery bank state. Enumeration.",
                 "label": "Vendor Battery Bank State",
                 "name": "StateVnd",
                 "size": 1,
@@ -343,7 +343,7 @@
                 "detail": "Number of days since 1/1/2000."
             },
             {
-                "desc": "Alarms and warnings.  Bit flags.",
+                "desc": "Alarms and warnings.",
                 "label": "Battery Event 1 Bitfield",
                 "mandatory": "M",
                 "name": "Evt1",
@@ -480,7 +480,7 @@
                 "type": "bitfield32"
             },
             {
-                "desc": "Alarms and warnings.  Bit flags.",
+                "desc": "Alarms and warnings.",
                 "label": "Battery Event 2 Bitfield",
                 "mandatory": "M",
                 "name": "Evt2",
@@ -636,7 +636,7 @@
                 "detail": "DC Measurement."
             },
             {
-                "desc": "Request from battery to start or stop the inverter.  Enumeration.",
+                "desc": "Request from battery to start or stop the inverter. Enumeration.",
                 "label": "Inverter State Request",
                 "name": "ReqInvState",
                 "size": 1,
@@ -671,7 +671,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Instruct the battery bank to perform an operation such as connecting.  Enumeration.",
+                "desc": "Instruct the battery bank to perform an operation such as connecting. Enumeration.",
                 "label": "Set Operation",
                 "mandatory": "M",
                 "name": "SetOp",

--- a/json/model_802.json
+++ b/json/model_802.json
@@ -63,7 +63,7 @@
                 "units": "W"
             },
             {
-                "desc": "Self discharge rate.  Percentage of capacity (WHRtg) discharged per day.",
+                "desc": "Self discharge rate. Percentage of capacity (WHRtg) discharged per day.",
                 "label": "Self Discharge Rate",
                 "name": "DisChaRte",
                 "sf": "DisChaRte_SF",
@@ -221,7 +221,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Used to reset any latched alarms.  1 = Reset.",
+                "desc": "Used to reset any latched alarms. 1 = Reset.",
                 "label": "Alarm Reset",
                 "mandatory": "M",
                 "name": "AlmRst",

--- a/json/model_803.json
+++ b/json/model_803.json
@@ -355,7 +355,7 @@
                         "type": "bitfield32"
                     },
                     {
-                        "desc": "Alarms, warnings and status values.  Bit flags.",
+                        "desc": "Alarms, warnings and status values.",
                         "label": "String Event 1",
                         "mandatory": "M",
                         "name": "StrEvt1",
@@ -485,7 +485,7 @@
                         "type": "bitfield32"
                     },
                     {
-                        "desc": "Alarms, warnings and status values.  Bit flags.",
+                        "desc": "Alarms, warnings and status values.",
                         "label": "String Event 2",
                         "name": "StrEvt2",
                         "size": 2,

--- a/json/model_804.json
+++ b/json/model_804.json
@@ -554,7 +554,7 @@
                 "type": "bitfield32"
             },
             {
-                "desc": "Alarms, warnings and status values.  Bit flags.",
+                "desc": "Alarms, warnings and status values.",
                 "label": "String Event 1",
                 "mandatory": "M",
                 "name": "Evt1",
@@ -692,7 +692,7 @@
                 "type": "bitfield32"
             },
             {
-                "desc": "Alarms, warnings and status values.  Bit flags.",
+                "desc": "Alarms, warnings and status values.",
                 "label": "String Event 2",
                 "name": "Evt2",
                 "size": 2,

--- a/json/model_804.json
+++ b/json/model_804.json
@@ -715,7 +715,7 @@
             },
             {
                 "access": "RW",
-                "desc": "Enables and disables the string.  Should reset to 0 upon completion.",
+                "desc": "Enables and disables the string. Should reset to 0 upon completion.",
                 "label": "Enable/Disable String",
                 "name": "SetEna",
                 "size": 1,

--- a/json/model_807.json
+++ b/json/model_807.json
@@ -259,7 +259,7 @@
                         "type": "bitfield32"
                     },
                     {
-                        "desc": "Alarms, warnings and status values.  Bit flags.",
+                        "desc": "Alarms, warnings and status values.",
                         "label": "Module Event 1",
                         "mandatory": "M",
                         "name": "ModEvt1",
@@ -389,7 +389,7 @@
                         "type": "bitfield32"
                     },
                     {
-                        "desc": "Alarms, warnings and status values.  Bit flags.",
+                        "desc": "Alarms, warnings and status values.",
                         "label": "Module Event 2",
                         "mandatory": "M",
                         "name": "ModEvt2",
@@ -735,7 +735,7 @@
                 "detail": "Calculation based on measurements."
             },
             {
-                "desc": "Alarms, warnings and status values.  Bit flags.",
+                "desc": "Alarms, warnings and status values.",
                 "label": "String Event 1",
                 "mandatory": "M",
                 "name": "Evt1",
@@ -874,7 +874,7 @@
                 "type": "bitfield32"
             },
             {
-                "desc": "Alarms, warnings and status values.  Bit flags.",
+                "desc": "Alarms, warnings and status values.",
                 "label": "String Event 2",
                 "mandatory": "M",
                 "name": "Evt2",


### PR DESCRIPTION
My effort to cleanup the descriptions and make them consistent.
- Remove references to the type it is.
- Remove stray spaces.
- Make all descriptions look more similar by always letting them end with a period.