### PR TITLE
Fix count attribute discrepancy with sunspec specification.

### DIFF
--- a/json/model_126.json
+++ b/json/model_126.json
@@ -3,7 +3,7 @@
         "desc": "Static Volt-VAR Arrays ",
         "groups": [
             {
-                "count": 0,
+                "count": "NPt",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_129.json
+++ b/json/model_129.json
@@ -3,7 +3,7 @@
         "desc": "LVRT Must Disconnect",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_130.json
+++ b/json/model_130.json
@@ -3,7 +3,7 @@
         "desc": "HVRT Must Disconnect",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_131.json
+++ b/json/model_131.json
@@ -3,7 +3,7 @@
         "desc": "Watt-Power Factor ",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_132.json
+++ b/json/model_132.json
@@ -3,7 +3,7 @@
         "desc": "Volt-Watt ",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_133.json
+++ b/json/model_133.json
@@ -3,7 +3,7 @@
         "desc": "Basic Scheduling ",
         "groups": [
             {
-                "count": 0,
+                "count": "NSchd",
                 "name": "repeating",
                 "points": [
                     {

--- a/json/model_134.json
+++ b/json/model_134.json
@@ -3,7 +3,7 @@
         "desc": "Curve-Based Frequency-Watt ",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_135.json
+++ b/json/model_135.json
@@ -3,7 +3,7 @@
         "desc": "Low Frequency Ride-through",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_136.json
+++ b/json/model_136.json
@@ -3,7 +3,7 @@
         "desc": "High Frequency Ride-through",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_137.json
+++ b/json/model_137.json
@@ -3,7 +3,7 @@
         "desc": "LVRT must remain connected",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_138.json
+++ b/json/model_138.json
@@ -3,7 +3,7 @@
         "desc": "HVRT must remain connected",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_139.json
+++ b/json/model_139.json
@@ -3,7 +3,7 @@
         "desc": "LVRT extended curve",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_140.json
+++ b/json/model_140.json
@@ -3,7 +3,7 @@
         "desc": "HVRT extended curve",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_141.json
+++ b/json/model_141.json
@@ -3,7 +3,7 @@
         "desc": "LFRT must remain connected",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_142.json
+++ b/json/model_142.json
@@ -3,7 +3,7 @@
         "desc": "HFRT must remain connected",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_143.json
+++ b/json/model_143.json
@@ -3,7 +3,7 @@
         "desc": "LFRT extended curve",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_144.json
+++ b/json/model_144.json
@@ -3,7 +3,7 @@
         "desc": "HFRT extended curve",
         "groups": [
             {
-                "count": 0,
+                "count": "NCrv",
                 "name": "curve",
                 "points": [
                     {

--- a/json/model_160.json
+++ b/json/model_160.json
@@ -2,7 +2,7 @@
     "group": {
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "module",
                 "points": [
                     {
@@ -365,7 +365,7 @@
                 "label": "Number of Modules",
                 "name": "N",
                 "size": 1,
-                "type": "count"
+                "type": "uint16"
             },
             {
                 "label": "Timestamp Period",

--- a/json/model_220.json
+++ b/json/model_220.json
@@ -3,7 +3,7 @@
         "desc": "Include this model for secure metering",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "repeating",
                 "points": [
                     {

--- a/json/model_3.json
+++ b/json/model_3.json
@@ -3,7 +3,7 @@
         "desc": "Request a digital signature over a specified set of data registers",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "repeating",
                 "points": [
                     {

--- a/json/model_4.json
+++ b/json/model_4.json
@@ -3,7 +3,7 @@
         "desc": "Compute a digital signature over a specified set of data registers",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "repeating",
                 "points": [
                     {

--- a/json/model_401.json
+++ b/json/model_401.json
@@ -5,7 +5,7 @@
         "name": "string_combiner_current",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "string",
                 "points": [
                     {
@@ -187,7 +187,7 @@
                 "mandatory": "M",
                 "name": "N",
                 "size": 1,
-                "type": "count"
+                "type": "uint16"
             },
             {
                 "desc": "Bitmask value.  Events",

--- a/json/model_402.json
+++ b/json/model_402.json
@@ -5,7 +5,7 @@
         "name": "string_combiner_advanced",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "string",
                 "points": [
                     {
@@ -238,7 +238,7 @@
                 "label": "N",
                 "name": "N",
                 "size": 1,
-                "type": "count"
+                "type": "uint16"
             },
             {
                 "desc": "Bitmask value.  Events",

--- a/json/model_403.json
+++ b/json/model_403.json
@@ -5,7 +5,7 @@
         "name": "string_combiner_current_input",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "string",
                 "points": [
                     {
@@ -187,7 +187,7 @@
                 "mandatory": "M",
                 "name": "N",
                 "size": 1,
-                "type": "count"
+                "type": "uint16"
             },
             {
                 "desc": "Bitmask value.  Events",

--- a/json/model_404.json
+++ b/json/model_404.json
@@ -5,7 +5,7 @@
         "name": "string_combiner_advanced_inputs",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "string",
                 "points": [
                     {
@@ -241,7 +241,7 @@
                 "mandatory": "M",
                 "name": "N",
                 "size": 1,
-                "type": "count"
+                "type": "uint16"
             },
             {
                 "desc": "Bitmask value.  Events",

--- a/json/model_5.json
+++ b/json/model_5.json
@@ -3,7 +3,7 @@
         "desc": "Include a digital signature along with the control data",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "repeating",
                 "points": [
                     {

--- a/json/model_6.json
+++ b/json/model_6.json
@@ -3,7 +3,7 @@
         "desc": "Include a digital signature along with the control data",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "repeating",
                 "points": [
                     {

--- a/json/model_601.json
+++ b/json/model_601.json
@@ -3,7 +3,7 @@
         "desc": "Monitors and controls multiple trackers",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "tracker",
                 "points": [
                     {

--- a/json/model_7.json
+++ b/json/model_7.json
@@ -3,7 +3,7 @@
         "desc": "Include a digital signature over the response",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "repeating",
                 "points": [
                     {

--- a/json/model_8.json
+++ b/json/model_8.json
@@ -3,7 +3,7 @@
         "desc": "Security model for PKI",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "repeating",
                 "points": [
                     {

--- a/json/model_805.json
+++ b/json/model_805.json
@@ -2,7 +2,7 @@
     "group": {
         "groups": [
             {
-                "count": 0,
+                "count": "NCell",
                 "name": "lithium-ion-module-cell",
                 "points": [
                     {

--- a/json/model_806.json
+++ b/json/model_806.json
@@ -2,7 +2,7 @@
     "group": {
         "groups": [
             {
-                "count": 0,
+                "count": "BatTBD",
                 "name": "battery_string",
                 "points": [
                     {

--- a/json/model_807.json
+++ b/json/model_807.json
@@ -2,7 +2,7 @@
     "group": {
         "groups": [
             {
-                "count": 0,
+                "count": "NMod",
                 "name": "module",
                 "points": [
                     {

--- a/json/model_808.json
+++ b/json/model_808.json
@@ -2,7 +2,7 @@
     "group": {
         "groups": [
             {
-                "count": 0,
+                "count": "ModuleTBD",
                 "name": "stack",
                 "points": [
                     {

--- a/json/model_809.json
+++ b/json/model_809.json
@@ -2,7 +2,7 @@
     "group": {
         "groups": [
             {
-                "count": 0,
+                "count": "StackTBD",
                 "name": "cell",
                 "points": [
                     {

--- a/json/model_9.json
+++ b/json/model_9.json
@@ -3,7 +3,7 @@
         "desc": "Security model for PKI",
         "groups": [
             {
-                "count": 0,
+                "count": "N",
                 "name": "repeating",
                 "points": [
                     {


### PR DESCRIPTION
Changed the value of count attribute from 0 to the point name that holds the variable count for variable type group.
Changed the type of point that hold count from type count to uint16.

According to SunSpec Device Information Model Specification, SunSpec Specification:
The count MAY be specified as a constant value in the model definition, or by another point in
the model that contains the count.