### PR TITLE
fix(model 64410): Correct the size for DeptRef

### DIFF
--- a/json/model_64410.json
+++ b/json/model_64410.json
@@ -452,7 +452,7 @@
             "label": "Dependent References",
             "mandatory": "M",
             "name": "DeptRef",
-            "size": 1,
+            "size": 2,
             "type": "bitfield32",
             "symbols": [
               {


### PR DESCRIPTION
A fix for this bug #275 
This is the change in accordance with what the models_workbook.xlsx says about this point.