### PR TITLE
Model 122: correct WAval units from var to W

### DIFF
--- a/json/model_122.json
+++ b/json/model_122.json
@@ -164,7 +164,7 @@
                 "sf": "WAval_SF",
                 "size": 1,
                 "type": "uint16",
-                "units": "var"
+                "units": "W"
             },
             {
                 "desc": "Scale factor for available Watts.",

--- a/smdx/smdx_00122.xml
+++ b/smdx/smdx_00122.xml
@@ -25,7 +25,7 @@
       <point id="ActVArhQ4" offset="23" type="acc64" len="4" units="varh" />
       <point id="VArAval" offset="27" type="int16" len="1" sf="VArAval_SF" units="var" />
       <point id="VArAval_SF" offset="28" type="sunssf" len="1" />
-      <point id="WAval" offset="29" type="uint16" len="1" sf="WAval_SF" units="var" />
+      <point id="WAval" offset="29" type="uint16" len="1" sf="WAval_SF" units="W" />
       <point id="WAval_SF" offset="30" type="sunssf" len="1" />
       <point id="StSetLimMsk" offset="31" type="bitfield32" len="2" >
         <symbol id="WMax">0</symbol>


### PR DESCRIPTION
`WAval` in model 122 declares reactive-power units while describing itself as real power.

```json
{
  "desc": "Amount of Watts available.",
  "name": "WAval",
  "sf": "WAval_SF",
  "type": "uint16",
  "units": "var"
}
```

Its scale factor is likewise described as `"Scale factor for available Watts."`, so the point's own metadata is internally inconsistent.

The value appears to have been carried over from `VArAval`, which immediately precedes it in the model and is correctly `var`:

| point | desc | units |
|---|---|---|
| `VArAval` | Amount of VARs available without impacting watts output. | `var` |
| `WAval` | Amount of Watts available. | `var` |

`W` is the units string already used for watt-valued points elsewhere in the model set — `WRtg`, `MaxChaRte` and `MaxDisChaRte` in model 120, among others.

## Change

Both representations carry the same value, so both are corrected:

- `json/model_122.json`
- `smdx/smdx_00122.xml`

Two lines total. `json/model_122.json` validates against `json/schema.json`, and the SMDX file still parses.

`models_workbook.xlsx` is left untouched, since `utils/json_to_xslx.py` suggests it is generated from `json/` — worth regenerating if that is part of the release process.

## Why it matters

Tooling that derives register maps from these definitions propagates the units verbatim, so any consumer reading `WAval` sees real power labelled as reactive. It is a metadata-only defect — no register address, type, size or scale factor changes — so the correction is safe for existing implementations.
